### PR TITLE
LIBFCREPO-520

### DIFF
--- a/handler/ndnp.py
+++ b/handler/ndnp.py
@@ -411,15 +411,13 @@ class Page(pcdm.Component):
     def __init__(self, issue, reel, number, title=None, frame=None):
         super(Page, self).__init__()
         self.title = title
-        if issue is not None:
-            self.issue = issue
+        self.issue = issue
+        self.number = number
+        self.ordered = True
         if reel is not None:
             self.reel = reel
-        if number is not None:
-            self.number = number
         if frame is not None:
             self.frame = frame
-        self.ordered = True
 
     def parse_ocr(self):
         # try to get an OCR file

--- a/handler/ndnp.py
+++ b/handler/ndnp.py
@@ -347,7 +347,9 @@ class Page(pcdm.Component):
     def from_mets(cls, issue_mets, div, issue):
         dmdsec = issue_mets.dmdsec(div.get('DMDID'))
         number = dmdsec.find('.//MODS:start', xmlns).text
-        reel = dmdsec.find('.//MODS:identifier[@type="reel number"]', xmlns).text
+        reel = dmdsec.find('.//MODS:identifier[@type="reel number"]', xmlns)
+        if reel is not None:
+            reel = reel.text
         frame = dmdsec.find('.//MODS:identifier[@type="reel sequence number"]', xmlns)
         if frame is not None:
             frame = frame.text

--- a/handler/ndnp.py
+++ b/handler/ndnp.py
@@ -410,11 +410,15 @@ class Page(pcdm.Component):
 
     def __init__(self, issue, reel, number, title=None, frame=None):
         super(Page, self).__init__()
-        self.issue = issue
-        self.reel = reel
-        self.number = number
         self.title = title
-        self.frame = frame
+        if issue is not None:
+            self.issue = issue
+        if reel is not None:
+            self.reel = reel
+        if number is not None:
+            self.number = number
+        if frame is not None:
+            self.frame = frame
         self.ordered = True
 
     def parse_ocr(self):


### PR DESCRIPTION
When loading NDNP data, allow for the reel-related elements to not be populated, and in such cases, do not create any triples relating to reels.

Also, do not create logs for the later creation of reel objects.