### PR TITLE
LIBFCREPO-579. Add image dimensions on ingest of pcdm files.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests==2.10.0
 lxml==3.6.0
 PyYAML==3.12
 paramiko==2.4.1
+Pillow==5.2.0


### PR DESCRIPTION
Use the Python Imaging Library to attempt to read the image file and add the width and height to the metadata.

https://issues.umd.edu/browse/LIBFCREPO-579