### PR TITLE
LIBFCREPO-578. Added imgsize command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,25 @@ add end-user instructions here once this is available via PyPI/pip
 **TODO**
 ```
 
+### Installing Python 3 with pyenv (Optional)
+
+If you don't already have a Python 3 environment, or would like to install Plastron
+into its own isolated environment, a very convenient way to do this is to use the
+[pyenv] Python version manager.
+
+[Installing pyenv](https://github.com/pyenv/pyenv#installation)
+
+```
+# install Python 3.7.0
+pyenv install 3.7.0
+
+# create a new virtual environment based on 3.7.0 for Plastron
+pyenv virtualenv 3.7.0 plastron
+
+# switch to that environment in your current shell
+pyenv shell plastron
+```
+
 ### Installation for development
 
 To install Plastron in [development mode], do the following:
@@ -240,6 +259,7 @@ it to exit with a status code of 2.
 
 See the [LICENSE](LICENSE.md) file for license rights and limitations (Apache 2.0).
 
+[pyenv]: https://github.com/pyenv/pyenv
 [development mode]: https://packaging.python.org/tutorials/installing-packages/#installing-from-vcs
 [argparse subparsers object]: https://docs.python.org/3/library/argparse.html#sub-commands
 [argparse.Namespace]: https://docs.python.org/3/library/argparse.html#the-namespace-object

--- a/plastron/commands/imgsize.py
+++ b/plastron/commands/imgsize.py
@@ -1,0 +1,50 @@
+import sys
+from PIL import Image
+from plastron import pcdm
+from plastron.exceptions import FailureException
+from plastron.util import RepositoryFile
+from rdflib import URIRef
+import logging
+
+Image.MAX_IMAGE_PIXELS = None
+
+logger = logging.getLogger(__name__)
+
+class Command:
+    def __init__(self, subparsers):
+        parser = subparsers.add_parser('imgsize',
+                description='Add width and height to image resources')
+        parser.add_argument('uris', nargs='*',
+                            help='URIs of repository objects to get image info'
+                            )
+        parser.set_defaults(cmd_name='imgsize')
+
+    def __call__(self, fcrepo, args):
+        for uri in args.uris:
+            source = RepositoryFile(fcrepo, uri)
+            if source.mimetype().startswith('image/'):
+                logger.info(f'Reading image data from {uri}')
+
+                file = pcdm.File(source)
+                image = Image.open(source.data())
+
+                logger.info(f'URI: {uri}, Width: {image.width}, Height: {image.height}')
+
+                # construct SPARQL query to replace image size metadata
+                prolog = 'PREFIX ebucore: <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#>'
+                delete = 'DELETE { <> ebucore:width ?w ; ebucore:height ?h }'
+                statements = f'<> ebucore:width {image.width} ; ebucore:height {image.height}'
+                insert = 'INSERT { ' + statements + ' }'
+                where = 'WHERE {}'
+                sparql = '\n'.join((prolog, delete, insert, where))
+
+                # update the metadata
+                headers = {'Content-Type': 'application/sparql-update'}
+                response = fcrepo.patch(source.metadata_uri, data=sparql, headers=headers)
+                if response.status_code == 204:
+                    logger.info(f'Updated image dimensions on {uri}')
+                else:
+                    logger.warn(f'Unable to update {uri}')
+
+            else:
+                logger.warn(f'{uri} is not of type image/*; skipping')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 setuptools==39.0.1
 rdflib==4.2.1
 requests==2.10.0
-lxml==3.6.0
-PyYAML==3.12
+lxml>3.6.0
+PyYAML>3.12
 paramiko==2.4.1
 Pillow==5.2.0


### PR DESCRIPTION
Loads binaries from URIs in the repository, uses PIL to determine a width and height, then PATCHes the repository metadata to add those dimensions using ebucore RDF predicates.

https://issues.umd.edu/browse/LIBFCREPO-578