### PR TITLE
LIBFCREPO-613. Fix the Digest header param name.

### DIFF
--- a/plastron/util.py
+++ b/plastron/util.py
@@ -102,7 +102,7 @@ class LocalFile(BinarySource):
                 if not data:
                     break
                 sha1.update(data)
-        return 'sha1=' + sha1.hexdigest()
+        return 'sha=' + sha1.hexdigest()
 
 class RepositoryFile(BinarySource):
     def __init__(self, repo, file_uri):
@@ -173,4 +173,4 @@ class RemoteFile(BinarySource):
 
     def digest(self):
         sha1sum = self.ssh_exec(f'sha1sum "{self.remotepath}"').split()[0]
-        return 'sha1=' + sha1sum
+        return 'sha=' + sha1sum


### PR DESCRIPTION
RFC 3230 and the Fedora API specify "sha" as the parameter name for passing a SHA-1 digest in the Digest header.

https://issues.umd.edu/browse/LIBFCREPO-613