### PR TITLE
LIBFCREPO-543. Standardize the batch.yml formats.

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,28 @@ with the `-r` or `--repo` option. These are the recognized configuration keys:
 | ----------- | ----------- |
 |`SERVER_CERT`|Path to a PEM-encoded copy of the server's SSL certificate; only needed for servers using self-signed certs|
 
+### Batch Configuration
+
+#### Required
+
+| Option | Description |
+| ------ | ----------- |
+|`BATCH_FILE`|The "main" file of the batch|
+|`COLLECTION`|URI of the repository collection that the objects will be added to|
+|`HANDLER`|The handler to use|
+
+#### Optional
+
+| Option | Description | Default |
+| ------ | ----------- | ------- |
+|`ROOT_DIR`| |The directory containing the batch configuration file|
+|`DATA_DIR`|Where to find the data files for the batch; relative to `ROOT_DIR`|`data`|
+|`LOG_DIR`|Where to write the mapfile, skipfile, and other logging info; relative to `ROOT_DIR`|`logs`|
+|`MAPFILE`|Where to store the record of completed items in this batch; relative to `LOG_DIR`|`mapfile.csv`|
+|`HANDLER_OPTIONS`|Any additional options required by the handler| |
+
+**Note:** The `plastron.load.*.log` files are currently written to the repository log directory, *not* to batch log directory.
+
 ## Extending
 
 ### Adding Commands

--- a/plastron/cli.py
+++ b/plastron/cli.py
@@ -90,6 +90,8 @@ def main():
 
     # log file configuration
     log_dirname = repo_config.get('LOG_DIR')
+    if not os.path.isdir(log_dirname):
+        os.makedirs(log_dirname)
     log_filename = 'plastron.{0}.{1}.log'.format(args.cmd_name, now)
     logfile = os.path.join(log_dirname, log_filename)
     logging_options['handlers']['file']['filename'] = logfile


### PR DESCRIPTION
* Provide default locations, based on batch.yml's own location, for many options
* The only required options for all handlers to load are now: BATCH_FILE, COLLECTION, and HANDLER
* Handler-specific options are grouped under a HANDLER_OPTIONS key

https://issues.umd.edu/browse/LIBFCREPO-543