### PR TITLE
LIBFCREPO-700. Created Docker configuration for plastron daemon.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.dockerignore
+.DS_Store
+.git*
+.idea
+*.egg-info
+*.key
+*.pem
+
+dist/
+logs/

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ data/*
 !config/templates/*
 !config/logging.yml
 
+# certificates
+*.key
+*.pem
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.6.2
+
+RUN mkdir -p /opt/plastron
+COPY . /opt/plastron
+WORKDIR /opt/plastron
+RUN pip install .
+ENV PYTHONUNBUFFERED=1
+
+CMD ["plastrond", "-c", "docker-plastron.yml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.2
+FROM python:3.6.2-slim
 
 RUN mkdir -p /opt/plastron
 COPY . /opt/plastron

--- a/README.md
+++ b/README.md
@@ -18,14 +18,15 @@ If you don't already have a Python 3 environment, or would like to install Plast
 into its own isolated environment, a very convenient way to do this is to use the
 [pyenv] Python version manager.
 
-[Installing pyenv](https://github.com/pyenv/pyenv#installation)
+See these instructions for [installing pyenv](https://github.com/pyenv/pyenv#installation),
+then run the following:
 
 ```
-# install Python 3.7.0
-pyenv install 3.7.0
+# install Python 3.6.2
+pyenv install 3.6.2
 
-# create a new virtual environment based on 3.7.0 for Plastron
-pyenv virtualenv 3.7.0 plastron
+# create a new virtual environment based on 3.6.2 for Plastron
+pyenv virtualenv 3.6.2 plastron
 
 # switch to that environment in your current shell
 pyenv shell plastron
@@ -41,241 +42,10 @@ cd plastron
 pip install -e .
 ```
 
-## Common Options
+## Running
 
-```
-$ plastron --help
-usage: plastron [-h] (-r REPO | -V) [-v] [-q]
-                {ping,load,list,ls,mkcol,delete,del,rm,extractocr} ...
-
-Batch operation tool for Fedora 4.
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -r REPO, --repo REPO  Path to repository configuration file.
-  -V, --version         Print version and exit.
-  -v, --verbose         increase the verbosity of the status output
-  -q, --quiet           decrease the verbosity of the status output
-
-commands:
-  {ping,load,list,ls,mkcol,delete,del,rm,extractocr}
-```
-
-### Check version
-
-```
-$ plastron --version
-3.0.0-dev
-```
-
-## Commands
-
-All commands require you to specify a repository configuration file using
-the `-r` or `--repo` option *before* the command name. For example,
-`plastron -r path/to/repo.yml ping`.
-
-### Ping (ping)
-
-```
-$ plastron ping --help
-usage: plastron ping [-h]
-
-Check connection to the repository
-
-optional arguments:
-  -h, --help  show this help message and exit
-```
-
-### Load (load)
-
-```
-$ plastron load --help
-usage: plastron load [-h] -b BATCH [-d] [-n] [-l LIMIT] [-% PERCENT]
-                     [--noannotations] [--ignore IGNORE] [--wait WAIT]
-
-Load a batch into the repository
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -d, --dryrun          iterate over the batch without POSTing
-  -n, --nobinaries      iterate without uploading binaries
-  -l LIMIT, --limit LIMIT
-                        limit the load to a specified number of top-level
-                        objects
-  -% PERCENT, --percent PERCENT
-                        load specified percentage of total items
-  --noannotations       iterate without loading annotations (e.g. OCR)
-  --ignore IGNORE, -i IGNORE
-                        file listing items to ignore
-  --wait WAIT, -w WAIT  wait n seconds between items
-
-required arguments:
-  -b BATCH, --batch BATCH
-                        path to batch configuration file                    
-```
-
-### List (list, ls)
-
-```
-$ plastron list --help
-usage: plastron list [-h] [-l] [-R RECURSIVE] [uris [uris ...]]
-
-List objects in the repository
-
-positional arguments:
-  uris                  URIs of repository objects to list
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -l, --long            Display additional information besides the URI
-  -R RECURSIVE, --recursive RECURSIVE
-                        List additional objects found by traversing the given
-                        predicate(s)
-```
-
-### Create Collection (mkcol)
-
-```
-$ plastron mkcol --help
-usage: plastron mkcol [-h] -n NAME [-b BATCH]
-
-Create a PCDM Collection in the repository
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -n NAME, --name NAME  Name of the collection.
-  -b BATCH, --batch BATCH
-                        Path to batch configuration file.
-```
-
-### Delete (delete, del, rm)
-
-```
-$ plastron delete --help
-usage: plastron delete [-h] [-R RECURSIVE] [-d] [-f FILE] [uris [uris ...]]
-
-Delete objects from the repository
-
-positional arguments:
-  uris                  Repository URIs to be deleted.
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -R RECURSIVE, --recursive RECURSIVE
-                        Delete additional objects found by traversing the
-                        given predicate(s)
-  -d, --dryrun          Simulate a delete without modifying the repository
-  -f FILE, --file FILE  File containing a list of URIs to delete
-```
-
-### Extract OCR (extractocr)
-
-```
-$ plastron extractocr --help
-usage: plastron extractocr [-h] [--ignore IGNORE]
-
-Create annotations from OCR data stored in the repository
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --ignore IGNORE, -i IGNORE
-                        file listing items to ignore
-```
-
-## Configuration
-
-### Configuration Templates
-Templates for creating the configuration files can be found at [config/templates](./config/templates)
-
-### Repository Configuration
-
-The repository connection is configured in a YAML file and passed to `plastron`
-with the `-r` or `--repo` option. These are the recognized configuration keys:
-
-#### Required
-
-| Option        | Description |
-| ------------- | ----------- |
-|`REST_ENDPOINT`|Repository root URL|
-|`RELPATH`      |Path within repository to load objects to|
-|`LOG_DIR`      |Directory to write log files|
-
-#### Client Certificate Authentication
-
-| Option      | Description |
-| ----------- | ----------- |
-|`CLIENT_CERT`|PEM-encoded client SSL cert for authentication|
-|`CLIENT_KEY` |PEM-encoded client SSL key for authentication|
-
-#### Password Authentication
-
-| Option          | Description |
-| --------------- | ----------- |
-|`FEDORA_USER`    |Username for authentication|
-|`FEDORA_PASSWORD`|Password for authentication|
-
-#### Optional
-
-| Option      | Description |
-| ----------- | ----------- |
-|`SERVER_CERT`|Path to a PEM-encoded copy of the server's SSL certificate; only needed for servers using self-signed certs|
-
-### Batch Configuration
-
-#### Required
-
-| Option | Description |
-| ------ | ----------- |
-|`BATCH_FILE`|The "main" file of the batch|
-|`COLLECTION`|URI of the repository collection that the objects will be added to|
-|`HANDLER`|The handler to use|
-
-#### Optional
-
-| Option | Description | Default |
-| ------ | ----------- | ------- |
-|`ROOT_DIR`| |The directory containing the batch configuration file|
-|`DATA_DIR`|Where to find the data files for the batch; relative paths are relative to `ROOT_DIR`|`data`|
-|`LOG_DIR`|Where to write the mapfile, skipfile, and other logging info; relative paths are relative to `ROOT_DIR`|`logs`|
-|`MAPFILE`|Where to store the record of completed items in this batch; relative paths are relative to `LOG_DIR`|`mapfile.csv`|
-|`HANDLER_OPTIONS`|Any additional options required by the handler| |
-
-**Note:** The `plastron.load.*.log` files are currently written to the repository log directory, *not* to batch log directory.
-
-## Extending
-
-### Adding Commands
-
-Commands are implemented as a package in `plastron.commands.{cmd_name}` that
-contain, at a minimum, a class name `Command`. This class must have an `__init__`
-method that takes an [argparse subparsers object] and creates and configures a
-subparser to handle its specific command-line arguments. It must also have a
-`__call__` method that takes a `pcdm.Repository` object and an [argparse.Namespace]
-object, and executes the actual command.
-
-For a simple example, see the ping command, as implemented in
-[`plastron/commands/ping.py`](plastron/commands/ping.py):
-
-```python
-from plastron.exceptions import FailureException
-
-class Command:
-    def __init__(self, subparsers):
-        parser_ping = subparsers.add_parser('ping',
-                description='Check connection to the repository')
-        parser_ping.set_defaults(cmd_name='ping')
-
-    def __call__(self, fcrepo, args):
-        try:
-            fcrepo.test_connection()
-        except:
-            raise FailureException()
-```
-
-The `FailureException` is caught by the `plastron` script and causes it to exit with
-a status code of 1. Any `KeyboardInterrupt` exceptions (for instance, due to the
-user pressing <kbd>Ctrl+C</kbd>) are also caught by the `plastron` script and cause
-it to exit with a status code of 2.
+* [Command-line client](docs/cli.md) ([plastron.cli](plastron/cli.py))
+* [Server](docs/daemon.md) ([plastron.daemon](plastron/daemon.py))
 
 ## License
 
@@ -283,5 +53,3 @@ See the [LICENSE](LICENSE.md) file for license rights and limitations (Apache 2.
 
 [pyenv]: https://github.com/pyenv/pyenv
 [development mode]: https://packaging.python.org/tutorials/installing-packages/#installing-from-vcs
-[argparse subparsers object]: https://docs.python.org/3/library/argparse.html#sub-commands
-[argparse.Namespace]: https://docs.python.org/3/library/argparse.html#the-namespace-object

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.7"
+services:
+  plastrond:
+    image: plastrond
+    secrets:
+      - batchloader.pem
+      - batchloader.key
+      - repository.pem
+secrets:
+  batchloader.pem:
+    external: true
+  batchloader.key:
+    external: true
+  repository.pem:
+    external: true

--- a/docker-plastron.yml
+++ b/docker-plastron.yml
@@ -1,0 +1,11 @@
+REPOSITORY:
+  REST_ENDPOINT: https://fcrepolocal/fcrepo/rest
+  RELPATH: /pcdm
+  CLIENT_CERT: /run/secrets/batchloader.pem
+  CLIENT_KEY: /run/secrets/batchloader.key
+  SERVER_CERT: /run/secrets/repository.pem
+  LOG_DIR: /var/log/plastron
+MESSAGE_BROKER:
+  SERVER: fcrepolocal:61613
+  EXPORT_JOBS_QUEUE: exportjobs
+  EXPORT_JOBS_COMPLETED_QUEUE: exportjobs.completed

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,240 @@
+# Plastron Command-line Client
+
+## Common Options
+
+```
+$ plastron --help
+usage: plastron [-h] (-r REPO | -V) [-v] [-q]
+                {ping,load,list,ls,mkcol,delete,del,rm,extractocr} ...
+
+Batch operation tool for Fedora 4.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -r REPO, --repo REPO  Path to repository configuration file.
+  -V, --version         Print version and exit.
+  -v, --verbose         increase the verbosity of the status output
+  -q, --quiet           decrease the verbosity of the status output
+
+commands:
+  {ping,load,list,ls,mkcol,delete,del,rm,extractocr}
+```
+
+### Check version
+
+```
+$ plastron --version
+3.0.0-dev
+```
+
+## Commands
+
+All commands require you to specify a repository configuration file using
+the `-r` or `--repo` option *before* the command name. For example,
+`plastron -r path/to/repo.yml ping`.
+
+### Ping (ping)
+
+```
+$ plastron ping --help
+usage: plastron ping [-h]
+
+Check connection to the repository
+
+optional arguments:
+  -h, --help  show this help message and exit
+```
+
+### Load (load)
+
+```
+$ plastron load --help
+usage: plastron load [-h] -b BATCH [-d] [-n] [-l LIMIT] [-% PERCENT]
+                     [--noannotations] [--ignore IGNORE] [--wait WAIT]
+
+Load a batch into the repository
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -d, --dryrun          iterate over the batch without POSTing
+  -n, --nobinaries      iterate without uploading binaries
+  -l LIMIT, --limit LIMIT
+                        limit the load to a specified number of top-level
+                        objects
+  -% PERCENT, --percent PERCENT
+                        load specified percentage of total items
+  --noannotations       iterate without loading annotations (e.g. OCR)
+  --ignore IGNORE, -i IGNORE
+                        file listing items to ignore
+  --wait WAIT, -w WAIT  wait n seconds between items
+
+required arguments:
+  -b BATCH, --batch BATCH
+                        path to batch configuration file                    
+```
+
+### List (list, ls)
+
+```
+$ plastron list --help
+usage: plastron list [-h] [-l] [-R RECURSIVE] [uris [uris ...]]
+
+List objects in the repository
+
+positional arguments:
+  uris                  URIs of repository objects to list
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -l, --long            Display additional information besides the URI
+  -R RECURSIVE, --recursive RECURSIVE
+                        List additional objects found by traversing the given
+                        predicate(s)
+```
+
+### Create Collection (mkcol)
+
+```
+$ plastron mkcol --help
+usage: plastron mkcol [-h] -n NAME [-b BATCH]
+
+Create a PCDM Collection in the repository
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -n NAME, --name NAME  Name of the collection.
+  -b BATCH, --batch BATCH
+                        Path to batch configuration file.
+```
+
+### Delete (delete, del, rm)
+
+```
+$ plastron delete --help
+usage: plastron delete [-h] [-R RECURSIVE] [-d] [-f FILE] [uris [uris ...]]
+
+Delete objects from the repository
+
+positional arguments:
+  uris                  Repository URIs to be deleted.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -R RECURSIVE, --recursive RECURSIVE
+                        Delete additional objects found by traversing the
+                        given predicate(s)
+  -d, --dryrun          Simulate a delete without modifying the repository
+  -f FILE, --file FILE  File containing a list of URIs to delete
+```
+
+### Extract OCR (extractocr)
+
+```
+$ plastron extractocr --help
+usage: plastron extractocr [-h] [--ignore IGNORE]
+
+Create annotations from OCR data stored in the repository
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --ignore IGNORE, -i IGNORE
+                        file listing items to ignore
+```
+
+## Configuration
+
+### Configuration Templates
+Templates for creating the configuration files can be found at [config/templates](../config/templates)
+
+### Repository Configuration
+
+The repository connection is configured in a YAML file and passed to `plastron`
+with the `-r` or `--repo` option. These are the recognized configuration keys:
+
+#### Required
+
+| Option        | Description |
+| ------------- | ----------- |
+|`REST_ENDPOINT`|Repository root URL|
+|`RELPATH`      |Path within repository to load objects to|
+|`LOG_DIR`      |Directory to write log files|
+
+#### Client Certificate Authentication
+
+| Option      | Description |
+| ----------- | ----------- |
+|`CLIENT_CERT`|PEM-encoded client SSL cert for authentication|
+|`CLIENT_KEY` |PEM-encoded client SSL key for authentication|
+
+#### Password Authentication
+
+| Option          | Description |
+| --------------- | ----------- |
+|`FEDORA_USER`    |Username for authentication|
+|`FEDORA_PASSWORD`|Password for authentication|
+
+#### Optional
+
+| Option      | Description |
+| ----------- | ----------- |
+|`SERVER_CERT`|Path to a PEM-encoded copy of the server's SSL certificate; only needed for servers using self-signed certs|
+
+### Batch Configuration
+
+#### Required
+
+| Option | Description |
+| ------ | ----------- |
+|`BATCH_FILE`|The "main" file of the batch|
+|`COLLECTION`|URI of the repository collection that the objects will be added to|
+|`HANDLER`|The handler to use|
+
+#### Optional
+
+| Option | Description | Default |
+| ------ | ----------- | ------- |
+|`ROOT_DIR`| |The directory containing the batch configuration file|
+|`DATA_DIR`|Where to find the data files for the batch; relative paths are relative to `ROOT_DIR`|`data`|
+|`LOG_DIR`|Where to write the mapfile, skipfile, and other logging info; relative paths are relative to `ROOT_DIR`|`logs`|
+|`MAPFILE`|Where to store the record of completed items in this batch; relative paths are relative to `LOG_DIR`|`mapfile.csv`|
+|`HANDLER_OPTIONS`|Any additional options required by the handler| |
+
+**Note:** The `plastron.load.*.log` files are currently written to the repository log directory, *not* to batch log directory.
+
+## Extending
+
+### Adding Commands
+
+Commands are implemented as a package in `plastron.commands.{cmd_name}` that
+contain, at a minimum, a class name `Command`. This class must have an `__init__`
+method that takes an [argparse subparsers object] and creates and configures a
+subparser to handle its specific command-line arguments. It must also have a
+`__call__` method that takes a `pcdm.Repository` object and an [argparse.Namespace]
+object, and executes the actual command.
+
+For a simple example, see the ping command, as implemented in
+[`plastron/commands/ping.py`](../plastron/commands/ping.py):
+
+```python
+from plastron.exceptions import FailureException
+
+class Command:
+    def __init__(self, subparsers):
+        parser_ping = subparsers.add_parser('ping',
+                description='Check connection to the repository')
+        parser_ping.set_defaults(cmd_name='ping')
+
+    def __call__(self, fcrepo, args):
+        try:
+            fcrepo.test_connection()
+        except:
+            raise FailureException()
+```
+
+The `FailureException` is caught by the `plastron` script and causes it to exit with
+a status code of 1. Any `KeyboardInterrupt` exceptions (for instance, due to the
+user pressing <kbd>Ctrl+C</kbd>) are also caught by the `plastron` script and cause
+it to exit with a status code of 2.
+
+[argparse subparsers object]: https://docs.python.org/3/library/argparse.html#sub-commands
+[argparse.Namespace]: https://docs.python.org/3/library/argparse.html#the-namespace-object

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -1,0 +1,67 @@
+# Plastron Server
+
+The Plastron server (a.k.a., "plastrond") is implemented by the
+[plastron.daemon](../plastron/daemon.py) module, and there is a
+*plastrond* entry point provided by [setup.py](../setup.py).
+
+## Running with Python
+
+```
+pip install -e .
+plastrond -c <config_file>
+```
+
+## Running with Docker
+
+```
+# if you are not already running in swarm mode
+docker swarm init
+
+# create secrets from the SSL client and server certs;
+# assume that $FCREPO_VAGRANT and $PLASTRON are your
+# fcrepo-vagrant and plastron source code directories
+cd $FCREPO_VAGRANT
+bin/clientcert batchloader $PLASTRON/batchloader
+cd $PLASTRON
+docker secret create batchloader.pem batchloader.pem 
+docker secret create batchloader.key batchloader.key 
+docker secret create repository.pem $FCREPO_VAGRANT/dist/fcrepo/ssl/crt/fcrepolocal.crt 
+
+# build the image
+docker build -t plastrond .
+
+# deploy the stack
+docker stack deploy -c docker-compose.yml plastrond
+```
+
+To watch the logs:
+
+```
+docker logs -f plastrond_plastrond.1.<generated_id>
+```
+
+## Configuration
+
+The plastrond configuration file is similar in format to the
+[CLI configuration](cli.md), with the notable exception that it
+introduces sections to separate the various systems in the
+configuration.
+
+See [docker-plastron.yml](../docker-plastron.yml) for an example
+of the config file.
+
+### `REPOSITORY` section
+
+Options in this section are identical to those in the [CLI configuration](cli.md).
+
+### `MESSAGE_BROKER` section
+
+This section configures the [STOMP] message broker (e.g., ActiveMQ).
+
+| Option                      |Description|
+|-----------------------------|-----------|
+|`SERVER`                     |The hostname and port of the STOMP server, e.g. `localhost:61613`|
+|`EXPORT_JOBS_QUEUE`          |The name of the queue to subscribe to for receiving export job requests|
+|`EXPORT_JOBS_COMPLETED_QUEUE`|The name of the queue to publish to when an export job is complete|
+
+[STOMP]: https://stomp.github.io/

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
             'rdflib',
             'requests',
             'setuptools',
+            'stomp.py'
             ],
     python_requires='>=3.6',
 
@@ -113,6 +114,7 @@ setup(
     entry_points={
         'console_scripts': [
             'plastron=plastron.cli:main',
+            'plastrond=plastron.daemon:main'
         ],
     },
 


### PR DESCRIPTION
* Based on the python:3.6.2 Docker image
* Uses secrets to pass the client and server certs to the container (requires it to be run in docker swarm mode)
* Includes a config file that contains settings for fcrepo-vagrant servers
* Adds a plastrond entry point in setup.py
* Split the CLI and daemon documentation
* Ensure that stomp.py is in the requirments section of setup.py

https://issues.umd.edu/browse/LIBFCREPO-700