### PR TITLE
LIBFCREPO-709. Use a docker config for plastrond.yml file.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,5 +6,8 @@
 *.key
 *.pem
 
+docker-compose.yml
+docker-plastron.yml
+
 dist/
 logs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ WORKDIR /opt/plastron
 RUN pip install .
 ENV PYTHONUNBUFFERED=1
 
-CMD ["plastrond", "-c", "docker-plastron.yml"]
+CMD ["plastrond", "-c", "/etc/plastrond.yml"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,16 @@ version: "3.7"
 services:
   plastrond:
     image: plastrond
+    configs:
+      - source: plastrond
+        target: /etc/plastrond.yml
     secrets:
       - batchloader.pem
       - batchloader.key
       - repository.pem
+configs:
+  plastrond:
+    file: docker-plastron.yml
 secrets:
   batchloader.pem:
     external: true


### PR DESCRIPTION
Helps decouple configuration from the image build.

https://issues.umd.edu/browse/LIBFCREPO-709