### PR TITLE
LIBFCREPO-713. Use CURIEs in CSV export column headers.

### DIFF
--- a/plastron/commands/export.py
+++ b/plastron/commands/export.py
@@ -4,11 +4,11 @@ import os
 import tempfile
 import numpy as np
 from rdflib import Literal
-
+from plastron.namespaces import get_manager
 from plastron.exceptions import ConfigException
 
 logger = logging.getLogger(__name__)
-
+nsm = get_manager()
 
 def configure_cli(subparsers):
     parser = subparsers.add_parser(
@@ -87,11 +87,12 @@ class CSVSerializer:
             subject_rows[s] = [subject_row, used_headers]
 
         for (s, p, o) in graph.triples((None, None, None)):
+            p = p.n3(namespace_manager=nsm)
             if isinstance(o, Literal):
                 if o.language is not None:
                     p = f'{p}@{o.language}'
                 if o.datatype is not None:
-                    p = f'{p}^^{o.datatype}'
+                    p = f'{p}^^{o.datatype.n3(namespace_manager=nsm)}'
             subject_row, used_headers = subject_rows[s]
             used_headers[p] = 1 if p not in used_headers else used_headers[p] + 1
             # Create a new header for the predicate, if missing or need to duplicate predicate header more times

--- a/plastron/namespaces/__init__.py
+++ b/plastron/namespaces/__init__.py
@@ -11,6 +11,7 @@ ebucore  = Namespace('http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#')
 edm      = Namespace('http://www.europeana.eu/schemas/edm/')
 ex       = Namespace('http://www.example.org/terms/')
 fabio    = Namespace('http://purl.org/spar/fabio/')
+fedora   = Namespace('http://fedora.info/definitions/v4/repository#')
 foaf     = Namespace('http://xmlns.com/foaf/0.1/')
 geo      = Namespace('http://www.w3.org/2003/01/geo/wgs84_pos#')
 iana     = Namespace('http://www.iana.org/assignments/relation/')
@@ -25,6 +26,7 @@ prov     = Namespace('http://www.w3.org/ns/prov#')
 rdf      = Namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#')
 rdfs     = Namespace('http://www.w3.org/2000/01/rdf-schema#')
 sc       = Namespace('http://www.shared-canvas.org/ns/')
+xs       = Namespace('http://www.w3.org/2001/XMLSchema#')
 
 
 def get_manager(graph=None):
@@ -40,6 +42,7 @@ def get_manager(graph=None):
     m.bind('edm', edm)
     m.bind('ex', ex)
     m.bind('fabio', fabio)
+    m.bind('fedora', fedora)
     m.bind('foaf', foaf)
     m.bind('geo', geo)
     m.bind('iana', iana)
@@ -54,4 +57,5 @@ def get_manager(graph=None):
     m.bind('rdf', rdf)
     m.bind('rdfs', rdfs)
     m.bind('sc', sc)
+    m.bind('xs', xs)
     return m


### PR DESCRIPTION
Added "fedora:" and "xs:" prefixes to the namespace manager.

https://issues.umd.edu/browse/LIBFCREPO-713