### PR TITLE
LIBFCREPO-695. Content-model-based CSV export.

### DIFF
--- a/plastron/authority.py
+++ b/plastron/authority.py
@@ -11,7 +11,6 @@ def create_authority(graph, subject):
 
 @rdf.data_property('label', rdfs.label)
 @rdf.object_property('same_as', owl.sameAs)
-@rdf.object_property('types', rdf.ns.type)
 class LabeledThing(ldp.Resource):
     pass
 

--- a/plastron/commands/export.py
+++ b/plastron/commands/export.py
@@ -1,15 +1,13 @@
 import logging
-import csv
-import tempfile
 from time import sleep
 
-import numpy as np
-from rdflib import Literal
-from plastron.namespaces import get_manager
 from plastron.exceptions import ConfigException
+from plastron.namespaces import get_manager
+from plastron.serializers import SERIALIZER_CLASSES
 
 logger = logging.getLogger(__name__)
 nsm = get_manager()
+
 
 def configure_cli(subparsers):
     parser = subparsers.add_parser(
@@ -25,7 +23,7 @@ def configure_cli(subparsers):
         '-f', '--format',
         help='Export job format',
         action='store',
-        choices=Command.SERIALIZER_CLASS_FOR.keys(),
+        choices=SERIALIZER_CLASSES.keys(),
         required=True
     )
     parser.add_argument(
@@ -36,116 +34,12 @@ def configure_cli(subparsers):
     parser.set_defaults(cmd_name='export')
 
 
-def get_nth_index(item_list, item, n):
-    """
-    Returns the Nth index of the specified item in the provided list
-    """
-    return [index for index, _item in enumerate(item_list) if _item == item][n - 1]
-
-
-class TurtleSerializer:
-    FILE_EXTENSION = 'ttl'
-
-    def __init__(self, filename):
-        self.filename = filename
-
-    def __enter__(self):
-        self.fh = open(self.filename, 'wb')
-        return self
-
-    def write(self, graph):
-        graph.serialize(destination=self.fh, format='turtle')
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.fh.close()
-
-
-class CSVSerializer:
-    FILE_EXTENSION = 'csv'
-
-    def __init__(self, filename):
-        self.filename = filename
-
-    def __enter__(self):
-        self.datarows_file = tempfile.TemporaryFile(mode='w+')
-        self.datarows_writer = csv.writer(self.datarows_file)
-        self.headers = ['Subject']
-        return self
-
-    def write(self, graph):
-        """
-        Serializes the given graph as CSV data rows.
-          - One row per subject, if there are multiple subjects (HashURIs)
-          - The data rows written to the csv writer with primary subject row first, followed by HashURI subject rows
-          - Appends new predicates if missing or for repeating values of the predicate to the provided headers object.
-        """
-        subject_rows = {}
-        subjects = set(graph.subjects())
-        for s in subjects:
-            used_headers = {}  # To track the number times a predicate repeats for the given subject
-            subject_row = [None] * len(self.headers)
-            subject_row[0] = s
-            subject_rows[s] = [subject_row, used_headers]
-
-        for (s, p, o) in graph.triples((None, None, None)):
-            p = p.n3(namespace_manager=nsm)
-            if isinstance(o, Literal):
-                if o.language is not None:
-                    p = f'{p}@{o.language}'
-                if o.datatype is not None:
-                    p = f'{p}^^{o.datatype.n3(namespace_manager=nsm)}'
-            subject_row, used_headers = subject_rows[s]
-            used_headers[p] = 1 if p not in used_headers else used_headers[p] + 1
-            # Create a new header for the predicate, if missing or need to duplicate predicate header more times
-            if (p not in self.headers) or (self.headers.count(p) < used_headers[p]):
-                self.headers.append(p)
-            predicate_index = get_nth_index(self.headers, p, used_headers[p])
-            if len(subject_row) <= predicate_index:
-                subject_row.extend([None] * ((predicate_index + 1) - len(subject_row)))
-            subject_row[predicate_index] = o
-
-        for subject in sorted(list(subjects)):
-            self.datarows_writer.writerow(subject_rows[subject][0])
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.write_csv_with_header()
-        self.datarows_file.close()
-
-    def write_csv_with_header(self):
-        """
-        Writes the provided headers and the datarows from datarows_file with the given csvwriter
-        - Sorts the headers alphabetically
-        - Sorts the datarows to match the sorted headers order
-        """
-        with open(self.filename, 'w') as fh:
-            writer = csv.writer(fh)
-            np_headers = np.array(self.headers)
-            sort_order = np.argsort(np_headers)
-            sorted_headers = np_headers[sort_order].tolist()
-            writer.writerow(sorted_headers)
-            self.datarows_file.flush()
-            self.datarows_file.seek(0)
-            for row in csv.reader(self.datarows_file):
-                row.extend([None] * (len(self.headers) - len(row)))
-                np_row = np.array(row)
-                sorted_row = np_row[sort_order].tolist()
-                writer.writerow(sorted_row)
-
-
 class Command:
-    SERIALIZER_CLASS_FOR = {
-        'text/turtle': TurtleSerializer,
-        'turtle': TurtleSerializer,
-        'ttl': TurtleSerializer,
-        'text/csv': CSVSerializer,
-        'csv': CSVSerializer
-    }
-
     def __call__(self, fcrepo, args):
         count = 0
         total = len(args.uris)
         try:
-            serializer_class = self.SERIALIZER_CLASS_FOR[args.format]
+            serializer_class = SERIALIZER_CLASSES[args.format]
         except KeyError:
             raise ConfigException(f'Unknown format: {args.format}')
 
@@ -161,7 +55,7 @@ class Command:
                     else:
                         rdf_uri = uri
                     logger.info(f'Exporting item {count + 1}/{total}: {uri}')
-                    graph = fcrepo.get_graph(rdf_uri)
+                    graph = fcrepo.get_graph(rdf_uri, include_server_managed=False)
                     serializer.write(graph)
                     count += 1
                     sleep(1)

--- a/plastron/models/letter.py
+++ b/plastron/models/letter.py
@@ -1,0 +1,78 @@
+from plastron import rdf, pcdm
+from plastron.authority import LabeledThing
+from plastron.namespaces import bibo, dc, dcmitype, dcterms, edm, geo, rel, skos
+
+
+@rdf.rdf_class(edm.Agent)
+class Author(LabeledThing):
+    pass
+
+
+@rdf.rdf_class(edm.Agent)
+class Recipient(LabeledThing):
+    pass
+
+
+@rdf.rdf_class(skos.Concept)
+class Subject(LabeledThing):
+    pass
+
+
+@rdf.rdf_class(edm.Place)
+@rdf.data_property('lat', geo.lat)
+@rdf.data_property('lon', geo.long)
+class Place(LabeledThing):
+    pass
+
+
+@rdf.rdf_class(dcmitype.Collection)
+class Collection(LabeledThing):
+    pass
+
+
+@rdf.object_property('author', rel.aut, embed=True, obj_class=Author)
+@rdf.object_property('recipient', bibo.recipient, embed=True, obj_class=Recipient)
+@rdf.object_property('part_of', dcterms.isPartOf, embed=True, obj_class=Collection)
+@rdf.object_property('place', dcterms.spatial, embed=True, obj_class=Place)
+@rdf.object_property('subject', dcterms.subject, embed=True, obj_class=Subject)
+@rdf.object_property('rights', dcterms.rights)
+@rdf.data_property('type', edm.hasType)
+@rdf.data_property('date', dc.date)
+@rdf.data_property('language', dc.language)
+@rdf.data_property('description', dcterms.description)
+@rdf.data_property('bibliographic_citation', dcterms.bibliographicCitation)
+@rdf.data_property('extent', dcterms.extent)
+@rdf.data_property('rights_holder', dcterms.rightsHolder)
+@rdf.rdf_class(bibo.Letter)
+class Letter(pcdm.Item):
+    HEADER_MAP = {
+        'title': 'Title',
+        # 'related_of',
+        # 'related',
+        # 'file_of',
+        # 'files',
+        # 'collections',
+        # 'components',
+        # 'last',
+        # 'first',
+        'rights_holder': 'Rights Holder',
+        'extent': 'Extent',
+        'bibliographic_citation': 'Bibliographic Citation',
+        'description': 'Description',
+        'language': 'Language',
+        'date': 'Date',
+        'type': 'Resource Type',
+        'rights': 'Rights',
+        # 'subject.same_as',
+        'subject.label': 'Subject',
+        # 'place.same_as',
+        'place.label': 'Location',
+        'place.lon': 'Longitude',
+        'place.lat': 'Latitude',
+        # 'part_of.same_as',
+        'part_of.label': 'Archival Collection',
+        # 'recipient.same_as',
+        'recipient.label': 'Recipient',
+        # 'author.same_as',
+        'author.label': 'Author'
+    }

--- a/plastron/models/poster.py
+++ b/plastron/models/poster.py
@@ -1,0 +1,27 @@
+from plastron import pcdm, rdf
+from plastron.namespaces import dcterms, dc, edm, bibo, geo
+
+
+@rdf.object_property('place', dcterms.spatial)
+@rdf.object_property('subject', dcterms.subject)
+@rdf.object_property('rights', dcterms.rights)
+@rdf.data_property('type', edm.hasType)
+@rdf.data_property('date', dc.date)
+@rdf.data_property('language', dc.language)
+@rdf.data_property('description', dcterms.description)
+@rdf.data_property('extent', dcterms.extent)
+@rdf.data_property('issue', bibo.issue)
+@rdf.data_property('locator', bibo.locator)
+@rdf.data_property('latitude', geo.lat)
+@rdf.data_property('longitude', geo.long)
+@rdf.data_property('part_of', dcterms.isPartOf)
+@rdf.data_property('publisher', dc.publisher)
+@rdf.data_property('alternative', dcterms.alternative)
+@rdf.rdf_class(bibo.Image)
+class Poster(pcdm.Item):
+    HEADER_MAP = {
+        'title': 'Title',
+        'publisher': 'Publisher',
+        'part_of': 'Collection',
+        'alternative': 'Alternate Title'
+    }

--- a/plastron/namespaces/__init__.py
+++ b/plastron/namespaces/__init__.py
@@ -26,7 +26,9 @@ premis   = Namespace('http://www.loc.gov/premis/rdf/v1#')
 prov     = Namespace('http://www.w3.org/ns/prov#')
 rdf      = Namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#')
 rdfs     = Namespace('http://www.w3.org/2000/01/rdf-schema#')
+rel      = Namespace('http://id.loc.gov/vocabulary/relators/')
 sc       = Namespace('http://www.shared-canvas.org/ns/')
+skos     = Namespace('http://www.w3.org/2004/02/skos/core#')
 xs       = Namespace('http://www.w3.org/2001/XMLSchema#')
 
 
@@ -58,6 +60,8 @@ def get_manager(graph=None):
     m.bind('prov', prov)
     m.bind('rdf', rdf)
     m.bind('rdfs', rdfs)
+    m.bind('rel', rel)
     m.bind('sc', sc)
+    m.bind('skos', skos)
     m.bind('xs', xs)
     return m

--- a/plastron/rdf.py
+++ b/plastron/rdf.py
@@ -8,45 +8,57 @@ ns = rdf
 
 
 def init_class_attr(cls, name, default):
-    if name not in cls.__dict__:
-        if hasattr(cls, name):
-            # there's a attribute set somewhere in the inheritance hierarchy
-            # copy it as the basis for this class's instance of that attribute
-            setattr(cls, name, copy(getattr(cls, name)))
-        else:
-            setattr(cls, name, default)
+    if hasattr(cls, name):
+        # there's a attribute set somewhere in the inheritance hierarchy
+        # copy it as the basis for this class's instance of that attribute
+        setattr(cls, name, copy(getattr(cls, name)))
+    else:
+        setattr(cls, name, default)
 
 
 def rdf_class(*types):
     def add_types(cls):
+        cls.rdf_types.update(types)
+        return cls
+    return add_types
+
+
+# metaclass that makes copies of specific class attributes
+# as we go down the inheritance hierarchy
+class Meta(type):
+    def __new__(mcs, name, bases, dct):
+        cls = super().__new__(mcs, name, bases, dct)
         # name and URI to property type class lookups
         init_class_attr(cls, 'name_to_prop', {})
         init_class_attr(cls, 'uri_to_prop', {})
         # list of property type classes for this class
         init_class_attr(cls, 'prop_types', [])
         # RDF types
-        init_class_attr(cls, 'types', set())
-        cls.types.update(types)
+        init_class_attr(cls, 'rdf_types', set())
         return cls
-
-    return add_types
 
 
 class RDFProperty(object):
     def __init__(self):
-        if self.is_multivalued:
-            self.value = []
-        else:
-            self.value = None
+        self.values = []
 
-    def values(self):
-        if isinstance(self.value, list):
-            return self.value
+    def append(self, other):
+        self.values.append(other)
+
+    def __str__(self):
+        if len(self.values) > 0:
+            return str(self.values[0])
         else:
-            return [self.value]
+            return ''
+
+    def __iter__(self):
+        return iter(self.values)
+
+    def __len__(self):
+        return len(self.values)
 
     def triples(self, subject):
-        for value in self.values():
+        for value in self.values:
             if value is not None:
                 yield (subject, self.uri, self.get_term(value))
 
@@ -66,16 +78,6 @@ class RDFObjectProperty(RDFProperty):
             raise ValueError('Expecting a URIRef or an object with a uri attribute')
 
 
-def add_property_type(name, uri, prop_type):
-    def add_property(cls):
-        cls.name_to_prop[name] = prop_type
-        cls.uri_to_prop[uri] = prop_type
-        cls.prop_types.append(prop_type)
-        return cls
-
-    return add_property
-
-
 def data_property(name, uri, multivalue=False, datatype=None):
     def add_property(cls):
         type_name = f'{cls.__name__}.{name}'
@@ -93,43 +95,11 @@ def data_property(name, uri, multivalue=False, datatype=None):
     return add_property
 
 
-def object_property(name, uri, multivalue=False, embed=False):
-    def add_property(cls):
-        type_name = f'{cls.__name__}.{name}'
-        prop_type = type(type_name, (RDFObjectProperty,), {
-            'name': name,
-            'uri': uri,
-            'is_multivalued': multivalue,
-            'is_embedded': embed
-        })
-        cls.name_to_prop[name] = prop_type
-        cls.uri_to_prop[uri] = prop_type
-        cls.prop_types.append(prop_type)
-        return cls
-
-    return add_property
-
-
-@rdf_class()
-class Resource(object):
+class Resource(metaclass=Meta):
 
     @classmethod
     def from_graph(cls, graph, subject=None):
-        return cls.from_triples(graph.triples((subject, None, None)))
-
-    @classmethod
-    def from_triples(cls, triples):
-        resource = cls()
-        for (s, p, o) in triples:
-            if p in cls.uri_to_prop:
-                prop_type = cls.uri_to_prop[p]
-                if prop_type.is_multivalued:
-                    getattr(resource, prop_type.name).append(o)
-                else:
-                    setattr(resource, prop_type.name, o)
-            else:
-                resource.unmapped_triples.append((s, p, o))
-        return resource
+        return cls(uri=subject).read(graph)
 
     def __init__(self, uri='', **kwargs):
         self.uri = URIRef(uri)
@@ -147,19 +117,38 @@ class Resource(object):
                     raise TypeError(f"Multivalued field '{key}' expects a list")
             setattr(self, key, value)
 
+    def read(self, graph):
+        for (s, p, o) in graph.triples((self.uri, None, None)):
+            if p in self.uri_to_prop:
+                prop_type = self.uri_to_prop[p]
+                if issubclass(prop_type, RDFObjectProperty) and prop_type.obj_class is not None:
+                    obj = prop_type.obj_class(uri=o)
+                    # recursively read embedded objects whose triples should be part of the same graph
+                    if prop_type.is_embedded:
+                        obj.read(graph)
+                else:
+                    obj = o
+                getattr(self, prop_type.name).append(obj)
+            else:
+                self.unmapped_triples.append((s, p, o))
+        return self
+
     def __getattr__(self, name):
         if name in self.name_to_prop:
-            return self.props[name].value
+            return self.props[name]
         else:
             raise AttributeError(f"No predicate mapped to {name}")
 
     def __setattr__(self, name, value):
         if name in self.name_to_prop:
-            self.props[name].value = value
+            if not isinstance(value, list):
+                value = [value]
+            # TODO: wrap these values in rdflib classes?
+            self.props[name].values = value
         else:
             # attribute names that aren't mapped to RDF properties
             # just get set like normal attributes
-            super(Resource, self).__setattr__(name, value)
+            super().__setattr__(name, value)
 
     def properties(self):
         return [prop for prop in self.props.values()]
@@ -189,7 +178,7 @@ class Resource(object):
     def graph(self, nsm=None):
         subject = URIRef(self.uri)
         graph = Graph(namespace_manager=nsm)
-        for rdf_type in self.types:
+        for rdf_type in self.rdf_types:
             graph.add((subject, RDF.type, rdf_type))
 
         for prop in self.properties():
@@ -200,7 +189,8 @@ class Resource(object):
         # for this resource; typically, these are resources that are have
         # hash URI identifiers
         for obj in self.embedded_objects():
-            graph = graph + obj.graph()
+            if obj is not None:
+                graph = graph + obj.graph()
 
         # any triples that were loaded from the source graph but that aren't
         # mapped to specific Python attributes
@@ -211,3 +201,20 @@ class Resource(object):
 
     def print(self, format='turtle', file=sys.stdout, nsm=None):
         print(self.graph(nsm=nsm).serialize(format=format).decode(), file=file)
+
+
+def object_property(name, uri, multivalue=False, embed=False, obj_class=None):
+    def add_property(cls):
+        type_name = f'{cls.__name__}.{name}'
+        prop_type = type(type_name, (RDFObjectProperty,), {
+            'name': name,
+            'uri': uri,
+            'is_multivalued': multivalue,
+            'is_embedded': embed,
+            'obj_class': obj_class
+        })
+        cls.name_to_prop[name] = prop_type
+        cls.uri_to_prop[uri] = prop_type
+        cls.prop_types.append(prop_type)
+        return cls
+    return add_property

--- a/plastron/serializers.py
+++ b/plastron/serializers.py
@@ -1,0 +1,149 @@
+import csv
+import logging
+from collections import defaultdict
+from urllib.parse import urlparse
+
+from rdflib import Literal
+
+from plastron.models.letter import Letter
+from plastron.models.poster import Poster
+from plastron.namespaces import get_manager, bibo, rdf
+from plastron.rdf import RDFObjectProperty, RDFDataProperty
+
+logger = logging.getLogger(__name__)
+nsm = get_manager()
+
+MODEL_MAP = {
+    bibo.Image: Poster,
+    bibo.Letter: Letter
+}
+
+
+class TurtleSerializer:
+    FILE_EXTENSION = 'ttl'
+
+    def __init__(self, filename):
+        self.filename = filename
+
+    def __enter__(self):
+        self.fh = open(self.filename, 'wb')
+        return self
+
+    def write(self, graph):
+        graph.serialize(destination=self.fh, format='turtle')
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.fh.close()
+
+
+def detect_resource_class(graph, subject):
+    types = set([o for s, p, o in graph.triples((subject, rdf.type, None))])
+
+    for rdf_type, cls in MODEL_MAP.items():
+        if rdf_type in types:
+            return cls
+    else:
+        raise Exception('Unable to detect resource type')
+
+
+class CSVSerializer:
+    FILE_EXTENSION = 'csv'
+
+    def __init__(self, filename):
+        self.filename = filename
+        self.resource_class = None
+        self.header_map = None
+        self.headers = None
+
+    def __enter__(self):
+        self.rows = []
+        return self
+
+    def write(self, graph):
+        """
+        Serializes the given graph as CSV data rows.
+          - One row per subject, if there are multiple subjects (HashURIs)
+          - The data rows written to the csv writer with primary subject row first, followed by HashURI subject rows
+          - Appends new predicates if missing or for repeating values of the predicate to the provided headers object.
+        """
+        main_subject = set([s for s in graph.subjects() if '#' not in str(s)]).pop()
+        if self.resource_class is None:
+            self.resource_class = detect_resource_class(graph, main_subject)
+
+        self.header_map = self.resource_class.HEADER_MAP
+        self.headers = list(self.header_map.values()) + ['URI', 'INDEX']
+
+        resource = self.resource_class.from_graph(graph, subject=main_subject)
+        row = {k: ';'.join(v) for k, v in self.flatten(resource).items()}
+        row['URI'] = main_subject
+        self.rows.append(row)
+
+    LANGUAGE_NAMES = {
+        'ja': 'Japanese',
+        'ja-latn': 'Japanese (Romanized)'
+    }
+
+    def flatten(self, resource, prefix=''):
+        columns = defaultdict(lambda: [])
+        for name, prop in resource.props.items():
+            if isinstance(prop, RDFObjectProperty) and prop.is_embedded:
+                for i, obj in enumerate(prop.values):
+                    # record the list position to hash URI correlation
+                    columns['INDEX'].append(f'{name}[{i}]=#{urlparse(obj.uri).fragment}')
+                    for header, value in self.flatten(obj, prefix=f'{name}.').items():
+                        columns[header].extend(value)
+            else:
+                key = prefix + name
+                if key not in self.header_map:
+                    continue
+                header = self.header_map[key]
+
+                # create additional columns (if needed) for different languages
+                if isinstance(prop, RDFDataProperty):
+                    header_index = self.headers.index(header)
+                    per_language_columns = defaultdict(lambda: [])
+                    for value in prop.values:
+                        if isinstance(value, Literal) and value.language:
+                            language_code = value.language
+                        else:
+                            language_code = ''
+                        per_language_columns[language_code].append(value)
+                    new_headers = []
+                    for language_code, values in per_language_columns.items():
+                        serialization = '|'.join(values)
+                        if language_code:
+                            language = self.LANGUAGE_NAMES[language_code]
+                            language_header = f'{header} [{language}]'
+                            new_headers.append(language_header)
+                            columns[language_header].append(serialization)
+                        else:
+                            columns[header].append(serialization)
+                    # sort and add the new headers that have language names
+                    for i, new_header in enumerate(sorted(new_headers), start=1):
+                        self.headers.insert(header_index + i, new_header)
+                else:
+                    serialization = '|'.join(prop.values)
+                    columns[header].append(serialization)
+        return columns
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # strip out headers that aren't used in any row
+        for header in self.headers:
+            has_column_values = any([True for row in self.rows if header in row])
+            if not has_column_values:
+                self.headers.remove(header)
+        # write the CSV file
+        with open(self.filename, 'w') as fh:
+            csv_writer = csv.DictWriter(fh, self.headers, extrasaction='ignore')
+            csv_writer.writeheader()
+            for row in self.rows:
+                csv_writer.writerow(row)
+
+
+SERIALIZER_CLASSES = {
+    'text/turtle': TurtleSerializer,
+    'turtle': TurtleSerializer,
+    'ttl': TurtleSerializer,
+    'text/csv': CSVSerializer,
+    'csv': CSVSerializer
+}


### PR DESCRIPTION
* Moved serializer classes into plastron.serializers module
* Omit server-managed triples from export command
* Add RDF model capability to read objects from a graph
* Object properties can have an obj_class
* Embedded object_properties with an obj_class get read into the model at the same time as their parent object
* Used a metaclass to make the RDF property inheritance work correctly
* Made values() method a generator
* Include subject URI and index of hash URIs in CSV output
* Always back properties with a values array
* Added Letter and Poster models
* Add additional language columns when serializing to CSV
* Remove completely unused columns from CSV export
* Auto-detect the plastron model class to use based on the RDF type of the graph

https://issues.umd.edu/browse/LIBFCREPO-695