### PR TITLE
LIBFCREPO-719. Write multiple CSV files into a ZIP file.

### DIFF
--- a/plastron/commands/export.py
+++ b/plastron/commands/export.py
@@ -65,3 +65,12 @@ class Command:
                     sleep(1)
 
         logger.info(f'Exported {count} of {total} items')
+        return {
+            'content_type': serializer.content_type,
+            'file_extension': serializer.file_extension,
+            'count': {
+                'total': total,
+                'exported': count,
+                'skipped': total - count
+            }
+        }

--- a/plastron/util.py
+++ b/plastron/util.py
@@ -2,7 +2,7 @@ import csv
 import hashlib
 import logging
 import mimetypes
-import os
+from os.path import basename, isfile
 from paramiko import SSHClient, SFTPClient
 from plastron import namespaces
 from plastron.namespaces import dcterms, ebucore
@@ -41,7 +41,7 @@ class ItemLog:
         self.fh = None
         self.writer = None
 
-        if not os.path.isfile(self.filename):
+        if not isfile(self.filename):
             with open(self.filename, 'w', 1) as fh:
                 writer = csv.DictWriter(fh, fieldnames=self.fieldnames)
                 writer.writeheader()
@@ -85,13 +85,13 @@ class BinarySource(object):
 
 
 class LocalFile(BinarySource):
-    def __init__(self, localpath, mimetype=None):
+    def __init__(self, localpath, mimetype=None, filename=None):
         super().__init__()
         if mimetype is None:
             mimetype = mimetypes.guess_type(localpath)[0]
         self._mimetype = mimetype
         self.localpath = localpath
-        self.filename = os.path.basename(localpath)
+        self.filename = filename if filename is not None else basename(localpath)
 
     def data(self):
         return open(self.localpath, 'rb')
@@ -142,7 +142,7 @@ class RemoteFile(BinarySource):
         self.sftp_client = None
         self.host = host
         self.remotepath = remotepath
-        self.filename = os.path.basename(remotepath)
+        self.filename = basename(remotepath)
         self._mimetype = mimetype
 
     def __del__(self):


### PR DESCRIPTION
* If there are 2 or more content models detected in the output, create separate CSV files for each one and package them all into a single ZIP file.
* Update the LocalFile class to take an explicit filename argument
* The export command now returns a result dict summarizing the export run

https://issues.umd.edu/browse/LIBFCREPO-719