### PR TITLE
LIBFCREPO-720. Add configurable public URI template.

### DIFF
--- a/plastron/commands/export.py
+++ b/plastron/commands/export.py
@@ -27,6 +27,11 @@ def configure_cli(subparsers):
         required=True
     )
     parser.add_argument(
+        '--uri-template',
+        help='Public URI template',
+        action='store'
+    )
+    parser.add_argument(
         'uris',
         nargs='*',
         help='URIs of repository objects to export'
@@ -44,7 +49,7 @@ class Command:
             raise ConfigException(f'Unknown format: {args.format}')
 
         logger.debug(f'Exporting to file {args.output_file}')
-        with serializer_class(args.output_file) as serializer:
+        with serializer_class(args.output_file, public_uri_template=args.uri_template) as serializer:
             for uri in args.uris:
                 r = fcrepo.head(uri)
                 if r.status_code == 200:

--- a/plastron/daemon.py
+++ b/plastron/daemon.py
@@ -91,6 +91,7 @@ class ExportListener(ConnectionListener):
         self.inbox = MessageBox(os.path.join(config['MESSAGE_STORE_DIR'], 'inbox'))
         self.outbox = MessageBox(os.path.join(config['MESSAGE_STORE_DIR'], 'outbox'))
         self.executor = ThreadPoolExecutor(thread_name_prefix='ExportListener')
+        self.public_uri_template = config.get('PUBLIC_URI_TEMPLATE', os.environ.get('PUBLIC_URI_TEMPLATE', None))
 
     def on_connected(self, headers, body):
         # first attempt to send anything in the outbox
@@ -157,7 +158,12 @@ class ExportListener(ConnectionListener):
                     command = export.Command()
                     with tempfile.NamedTemporaryFile() as export_fh:
                         logger.debug(f'Export temporary file name is {export_fh.name}')
-                        args = argparse.Namespace(uris=uris, output_file=export_fh.name, format=export_format)
+                        args = argparse.Namespace(
+                            uris=uris,
+                            output_file=export_fh.name,
+                            format=export_format,
+                            uri_template=self.public_uri_template
+                        )
                         result = command(self.repository, args)
 
                         job_name = headers.get('ArchelonExportJobName', job_id)

--- a/plastron/serializers.py
+++ b/plastron/serializers.py
@@ -24,7 +24,7 @@ MODEL_MAP = {
 
 
 class TurtleSerializer:
-    def __init__(self, filename):
+    def __init__(self, filename, **kwargs):
         self.filename = filename
         self.content_type = 'text/turtle'
         self.file_extension = '.ttl'
@@ -71,17 +71,18 @@ def write_csv_file(row_info, file):
 
 
 class CSVSerializer:
-    def __init__(self, filename):
+    def __init__(self, filename, **kwargs):
         self.filename = filename
         self.content_models = {}
         self.content_type = 'text/csv'
         self.file_extension = '.csv'
+        self.public_uri_template = kwargs.get('public_uri_template', None)
 
     def __enter__(self):
         self.rows = []
         return self
 
-    SYSTEM_HEADERS = ['URI', 'CREATED', 'MODIFIED', 'INDEX']
+    SYSTEM_HEADERS = ['URI', 'PUBLIC URI', 'CREATED', 'MODIFIED', 'INDEX']
 
     def write(self, graph: Graph):
         """
@@ -105,6 +106,11 @@ class CSVSerializer:
         row['URI'] = str(main_subject)
         row['CREATED'] = str(graph.value(main_subject, fedora.created))
         row['MODIFIED'] = str(graph.value(main_subject, fedora.lastModified))
+        if self.public_uri_template is not None:
+            uri = urlparse(main_subject)
+            uuid = os.path.basename(uri.path)
+            row['PUBLIC URI'] = self.public_uri_template.format(uuid=uuid)
+
         self.content_models[resource_class]['rows'].append(row)
 
     LANGUAGE_NAMES = {


### PR DESCRIPTION
* Configure public URI template from a command argument that is then passed to the serializer.
* Read from the config file or fall back to getting the PUBLIC_URI_TEMPLATE from the environment.

https://issues.umd.edu/browse/LIBFCREPO-720