### PR TITLE
LIBFCREPO-734. Fixes and improvements to the CLI.

### DIFF
--- a/plastron/commands/delete.py
+++ b/plastron/commands/delete.py
@@ -8,16 +8,23 @@ def configure_cli(subparsers):
     parser = subparsers.add_parser(
         name='delete',
         aliases=['del', 'rm'],
-        description='Delete objects from the repository')
+        description='Delete objects from the repository'
+    )
     parser.add_argument(
         '-R', '--recursive',
         help='Delete additional objects found by traversing the given predicate(s)',
         action='store'
     )
     parser.add_argument(
-        '-d', '--dryrun',
+        '-d', '--dry-run',
         help='Simulate a delete without modifying the repository',
         action='store_true'
+    )
+    parser.add_argument(
+        '--no-transactions', '--no-txn',
+        help='run the update without using transactions',
+        action='store_false',
+        dest='use_transactions'
     )
     parser.add_argument(
         '-f', '--file',
@@ -38,7 +45,7 @@ class Command:
 
         self.repository = fcrepo
         self.repository.test_connection()
-        self.dry_run = args.dryrun
+        self.dry_run = args.dry_run
 
         if self.dry_run:
             logger.info('Dry run enabled, no actual deletions will take place')
@@ -49,16 +56,16 @@ class Command:
             uri_list=args.uris,
             file=args.file,
             recursive=args.recursive,
-            use_transaction=(not args.dryrun)
+            use_transaction=args.use_transactions
         )
 
         if not args.quiet:
             print_footer()
 
-    def delete_item(self, target_uri, graph):
+    def delete_item(self, resource, graph):
         title = get_title_string(graph)
         if self.dry_run:
-            logger.info(f'Would delete resource {target_uri} {title}')
+            logger.info(f'Would delete resource {resource} {title}')
         else:
-            self.repository.delete(target_uri)
-            logger.info(f'Deleted resource {target_uri} {title}')
+            self.repository.delete(resource.uri)
+            logger.info(f'Deleted resource {resource} {title}')

--- a/plastron/commands/list.py
+++ b/plastron/commands/list.py
@@ -1,5 +1,5 @@
 import logging
-from plastron.util import get_title_string, parse_predicate_list
+from plastron.util import get_title_string, process_resources
 
 logger = logging.getLogger(__name__)
 
@@ -30,18 +30,19 @@ def configure_cli(subparsers):
 
 class Command:
     def __call__(self, fcrepo, args):
-        if args.recursive is not None:
-            args.predicates = parse_predicate_list(args.recursive)
-            logger.info('Listing will traverse the following predicates: {0}'.format(
-                ', '.join([p.n3() for p in args.predicates]))
-            )
-        else:
-            args.predicates = []
+        self.long = args.long
 
-        for item_uri in args.uris:
-            for (uri, graph) in fcrepo.recursive_get(item_uri, traverse=args.predicates):
-                if args.long:
-                    title = get_title_string(graph)
-                    print("{0} {1}".format(uri, title))
-                else:
-                    print(uri)
+        process_resources(
+            method=self.list_item,
+            repository=fcrepo,
+            uri_list=args.uris,
+            recursive=args.recursive,
+            use_transaction=False
+        )
+
+    def list_item(self, resource, graph):
+        if self.long:
+            title = get_title_string(graph)
+            print(f'{resource} {title}')
+        else:
+            print(resource)

--- a/plastron/commands/update.py
+++ b/plastron/commands/update.py
@@ -1,4 +1,6 @@
 import logging
+
+from plastron.exceptions import RESTAPIException
 from plastron.util import get_title_string, process_resources, print_header, print_footer
 
 logger = logging.getLogger(__name__)
@@ -21,9 +23,15 @@ def configure_cli(subparsers):
         action='store'
     )
     parser.add_argument(
-        '-d', '--dryrun',
+        '-d', '--dry-run',
         help='Simulate an update without modifying the repository',
         action='store_true'
+    )
+    parser.add_argument(
+        '--no-transactions', '--no-txn',
+        help='run the update without using transactions',
+        action='store_false',
+        dest='use_transactions'
     )
     parser.add_argument(
         '-f', '--file',
@@ -44,10 +52,10 @@ class Command:
 
         self.repository = fcrepo
         self.repository.test_connection()
-        self.dry_run = args.dryrun
+        self.dry_run = args.dry_run
 
         with open(args.update_file, 'r') as update_file:
-            self.sparql_update = update_file.read()
+            self.sparql_update = update_file.read().encode('utf-8')
         logger.debug(f'SPARQL Update query:\n====BEGIN====\n{self.sparql_update}\n=====END=====')
 
         if self.dry_run:
@@ -59,17 +67,21 @@ class Command:
             uri_list=args.uris,
             file=args.file,
             recursive=args.recursive,
-            use_transaction=(not args.dryrun)
+            use_transaction=args.use_transactions
         )
 
         if not args.quiet:
             print_footer()
 
-    def update_item(self, target_uri, graph):
+    def update_item(self, resource, graph):
         headers = {'Content-Type': 'application/sparql-update'}
         title = get_title_string(graph)
         if self.dry_run:
-            logger.info(f'Would update resource {target_uri} {title}')
+            logger.info(f'Would update resource {resource} {title}')
         else:
-            self.repository.patch(target_uri, data=self.sparql_update, headers=headers)
-            logger.info(f'Updated resource {target_uri} {title}')
+            response = self.repository.patch(resource.description_uri, data=self.sparql_update, headers=headers)
+            if response.status_code == 204:
+                logger.info(f'Updated resource {resource} {title}')
+            else:
+                raise RESTAPIException(response)
+

--- a/plastron/util.py
+++ b/plastron/util.py
@@ -41,30 +41,32 @@ def process_resources(method, repository, uri_list=None, file=None, recursive=No
                 uri_list = [ line.rstrip() for line in fh ]
 
     # closure for processing the list of items
-    def process_list():
+    def process_list(transaction=None):
         for uri in uri_list:
-            for target_uri, graph in repository.recursive_get(uri, traverse=predicates):
-                method(target_uri, graph)
+            for resource, graph in repository.recursive_get(uri, traverse=predicates):
+                try:
+                    method(resource, graph)
+                except RESTAPIException as e:
+                    logger.error(f'{method.__name__} failed for {resource}: {e}: {e.response.text}')
+                    if transaction is not None:
+                        # if anything fails while processing of the list of uris, attempt to
+                        # rollback the transaction. Failures here will be caught by the main
+                        # loop's exception handler and should trigger a system exit
+                        transaction.rollback()
+                        logger.warning('Transaction rolled back.')
+                        return
+                    else:
+                        logger.warning(f'Continuing {method.__name__} with next item')
+        if transaction is not None:
+            transaction.commit()
 
     if use_transaction:
         try:
             with Transaction(repository, keep_alive=90) as txn:
-                try:
-                    process_list()
-                    txn.commit()
-
-                except RESTAPIException as e:
-                    # if anything fails while processing of the list of uris, attempt to
-                    # rollback the transaction. Failures here will be caught by the main
-                    # loop's exception handler and should trigger a system exit
-                    logger.error(f'Failed: {e}')
-                    txn.rollback()
-                    logger.warning('Transaction rolled back.')
-
+                process_list(txn)
         except RESTAPIException:
             logger.error('Unable to roll back transaction, aborting')
             raise FailureException()
-
     else:
         process_list()
 


### PR DESCRIPTION
* Use hyphens in dry-run, no-transactions, no-binaries, and no-annotations flags
* Use action=store_false plus more descriptive destinations to make the negative options more readable in code
* Return the target URI in the recursive_get (so binaries return their fcr:metadata URI)
* Move transaction commit/rollback handling into the process_list method
* Handle exceptions in the update command
* Use a lightweight http.Resource namedtuple-based class to hold a URI and the describedby URI thereof

https://issues.umd.edu/browse/LIBFCREPO-734