### PR TITLE
LIBFCREPO-722. Property validation.

### DIFF
--- a/plastron/commands/load.py
+++ b/plastron/commands/load.py
@@ -220,7 +220,7 @@ def load_item_internal(fcrepo, item, args, extra=None):
     logger.info('Creating item')
     item.recursive_create(fcrepo)
     logger.info('Creating ordering proxies')
-    item.create_ordering(fcrepo)
+    item.create_proxies(fcrepo)
     if args.create_annotations:
         logger.info('Creating annotations')
         item.create_annotations(fcrepo)

--- a/plastron/handlers/mapped-csv.py
+++ b/plastron/handlers/mapped-csv.py
@@ -126,7 +126,7 @@ class Batch:
                         if isinstance(component, pcdm.File):
                             item.add_file(component)
                         else:
-                            item.add_component(component)
+                            item.add_member(component)
                 elif 'files' in key_conf:
                     # this key_column is a subject with file items
                     for component in self.get_items(sub_lines, key_conf['files']):
@@ -205,7 +205,7 @@ class Batch:
 
     def __iter__(self):
         for item in self.get_items(self.rows, self.mapping):
-            item.add_collection(self.collection)
+            item.member_of = self.collection
             yield BatchItem(item)
 
 

--- a/plastron/handlers/reel.py
+++ b/plastron/handlers/reel.py
@@ -42,11 +42,11 @@ class BatchItem:
 
     def read_data(self):
         id = os.path.splitext(os.path.basename(self.path))[0]
-        reel = Reel(id=id, title=f'Reel Number {id}', collections=[self.batch.collection])
+        reel = Reel(id=id, title=f'Reel Number {id}', member_of=self.batch.collection)
 
         with open(self.path, 'r') as f:
             reader = csv.DictReader(f)
             for row in reader:
-                reel.components.append(Page.from_repository(self.batch.repo, row['uri']))
+                reel.add_member(Page.from_repository(self.batch.repo, row['uri']))
 
         return reel

--- a/plastron/ldp.py
+++ b/plastron/ldp.py
@@ -14,8 +14,20 @@ class Resource(rdf.Resource):
     simple lifecycle patterns and conventions in section 4. Linked Data Platform
     Resources."""
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    @classmethod
+    def from_repository(cls, repo, uri):
+        graph = repo.get_graph(uri)
+        obj = cls.from_graph(graph, subject=uri)
+
+        # mark as created and updated so that the create_object and update_object
+        # methods doesn't try try to modify it
+        obj.created = True
+        obj.updated = True
+
+        return obj
+
+    def __init__(self, uri='', **kwargs):
+        super().__init__(uri=uri, **kwargs)
         self.annotations = []
         self.extra = Graph()
         self.created = False
@@ -155,6 +167,15 @@ class Resource(rdf.Resource):
     # called after creation of object in repo
     def post_creation_hook(self):
         pass
+
+    def create_annotations(self, repository):
+        with repository.at_path('annotations'):
+            for annotation in self.annotations:
+                annotation.recursive_create(repository)
+
+    def update_annotations(self, repository):
+        for annotation in self.annotations:
+            annotation.recursive_update(repository)
 
 
 class RdfSource(Resource):

--- a/plastron/models/letter.py
+++ b/plastron/models/letter.py
@@ -45,7 +45,7 @@ class Collection(LabeledThing):
 @rdf.data_property('extent', dcterms.extent)
 @rdf.data_property('rights_holder', dcterms.rightsHolder)
 @rdf.rdf_class(bibo.Letter)
-class Letter(pcdm.Item):
+class Letter(pcdm.Object):
     HEADER_MAP = {
         'title': 'Title',
         'rights_holder': 'Rights Holder',

--- a/plastron/models/newspaper.py
+++ b/plastron/models/newspaper.py
@@ -12,7 +12,7 @@ from plastron.util import RepositoryFile
 @rdf.data_property('issue', bibo.issue)
 @rdf.data_property('edition', bibo.edition)
 @rdf.rdf_class(bibo.Issue)
-class Issue(pcdm.Item):
+class Issue(pcdm.Object):
     """Newspaper issue"""
     HEADER_MAP = {
         'title': 'Title',
@@ -50,9 +50,8 @@ class TextblockOnPage(oa.Annotation):
         self.motivation = sc.painting
 
 
-@rdf.data_property('title', dcterms.title)
 @rdf.rdf_class(fabio.Metadata)
-class IssueMetadata(pcdm.Component):
+class IssueMetadata(pcdm.Object):
     """Additional metadata about an issue"""
 
     def __init__(self, file, title=None):
@@ -74,7 +73,7 @@ class MetadataFile(pcdm.File):
 @rdf.data_property('number', ndnp.number)
 @rdf.data_property('frame', ndnp.sequence)
 @rdf.rdf_class(ndnp.Page)
-class Page(pcdm.Component):
+class Page(pcdm.Object):
     """Newspaper page"""
 
     @classmethod
@@ -168,7 +167,7 @@ class File(pcdm.File):
 @rdf.data_property('start_page', bibo.pageStart)
 @rdf.data_property('end_page', bibo.pageEnd)
 @rdf.rdf_class(bibo.Article)
-class Article(pcdm.Component):
+class Article(pcdm.Object):
     """Newspaper article"""
 
     def __init__(self, pages=None, **kwargs):
@@ -180,7 +179,7 @@ class Article(pcdm.Component):
 
 @rdf.data_property('id', dcterms.identifier)
 @rdf.rdf_class(carriers.hd)
-class Reel(pcdm.Item):
+class Reel(pcdm.Object):
     """NDNP reel is an ordered sequence of frames"""
 
     def __init__(self, **kwargs):

--- a/plastron/models/poster.py
+++ b/plastron/models/poster.py
@@ -21,7 +21,7 @@ from plastron.namespaces import dcterms, dc, edm, bibo, geo
 @rdf.data_property('publisher', dc.publisher)
 @rdf.data_property('alternative', dcterms.alternative)
 @rdf.rdf_class(bibo.Image)
-class Poster(pcdm.Item):
+class Poster(pcdm.Object):
     HEADER_MAP = {
         'title': 'Title',
         'alternative': 'Alternate Title',

--- a/plastron/oa.py
+++ b/plastron/oa.py
@@ -7,8 +7,8 @@ ns = oa
 
 
 # Annotation resources
-@rdf.object_property('body', oa.hasBody, multivalue=True, embed=True)
-@rdf.object_property('target', oa.hasTarget, multivalue=True, embed=True)
+@rdf.object_property('body', oa.hasBody, embed=True)
+@rdf.object_property('target', oa.hasTarget, embed=True)
 @rdf.object_property('motivation', oa.motivatedBy)
 @rdf.rdf_class(oa.Annotation)
 class Annotation(ldp.Resource):
@@ -35,7 +35,7 @@ class TextualBody(ldp.Resource):
             return self.value[:24] + '…'
 
 
-@rdf.object_property('selector', oa.hasSelector, multivalue=True, embed=True)
+@rdf.object_property('selector', oa.hasSelector, embed=True)
 @rdf.object_property('source', oa.hasSource)
 @rdf.rdf_class(oa.SpecificResource)
 class SpecificResource(ldp.Resource):

--- a/plastron/ore.py
+++ b/plastron/ore.py
@@ -12,7 +12,52 @@ ns = ore
 @rdf.data_property('title', dcterms.title)
 @rdf.rdf_class(ore.Proxy)
 class Proxy(ldp.Resource):
-    # create proxy object by putting object graph
-    def create_object(self, repository, uri=None):
-        uri = '/'.join([p.strip('/') for p in (self.proxy_for.values[0].uri, self.proxy_in.values[0].uuid)])
-        super().create_object(repository, uri=uri)
+    pass
+
+
+@rdf.object_property('first', iana.first)
+@rdf.object_property('last', iana.last)
+class Aggregation(ldp.Resource):
+    def append(self, proxy):
+        if len(self.first) == 0:
+            self.first = proxy
+        else:
+            last = self.last[0]
+            # update the current last item to point to the new item
+            last.next = proxy
+            proxy.prev = last
+        # new item is always the last in the list
+        self.last = proxy
+
+    def append_proxy(self, proxy_for, title=None):
+        if title is None:
+            title = f'Proxy for {proxy_for} in {self}'
+        self.append(Proxy(
+            title=title,
+            proxy_for=proxy_for,
+            proxy_in=self
+        ))
+
+    def __iter__(self):
+        if len(self.first) == 0:
+            # no members of the aggregation
+            self.next = None
+        else:
+            self.next = self.first.values[0]
+        return self
+
+    def __next__(self):
+        if self.next is None:
+            raise StopIteration()
+        current = self.next
+        try:
+            self.next = current.next.values[0]
+        except IndexError:
+            # we have reached the last item of the aggregation
+            # set next to None so the iterator will stop on the next iteration
+            self.next = None
+        return current
+
+    def create_proxies(self, repository):
+        for proxy in self:
+            proxy.create_object(repository)

--- a/plastron/pcdm.py
+++ b/plastron/pcdm.py
@@ -1,7 +1,7 @@
 from rdflib import URIRef
 from plastron import ldp, ore, rdf
 from plastron.exceptions import RESTAPIException
-from plastron.namespaces import dcterms, dcmitype, fabio, iana, pcdm, ebucore, pcdmuse
+from plastron.namespaces import dcterms, dcmitype, ebucore, fabio, pcdm, pcdmuse
 from plastron.util import LocalFile
 from PIL import Image
 
@@ -9,148 +9,35 @@ from PIL import Image
 ns = pcdm
 
 
-# ============================================================================
-# PCDM RESOURCE (COMMON METHODS FOR ALL OBJECTS)
-# ============================================================================
-
-@rdf.object_property('components', pcdm.hasMember, multivalue=True)
-@rdf.object_property('collections', pcdm.memberOf, multivalue=True)
-@rdf.object_property('files', pcdm.hasFile, multivalue=True)
-@rdf.object_property('file_of', pcdm.fileOf, multivalue=True)
-@rdf.object_property('related', pcdm.hasRelatedObject, multivalue=True)
-@rdf.object_property('related_of', pcdm.relatedObjectOf, multivalue=True)
+@rdf.object_property('members', pcdm.hasMember)
+@rdf.object_property('member_of', pcdm.memberOf)
+@rdf.object_property('files', pcdm.hasFile)
+@rdf.object_property('related', pcdm.hasRelatedObject)
+@rdf.object_property('related_of', pcdm.relatedObjectOf)
 @rdf.data_property('title', dcterms.title)
-class Resource(ldp.Resource):
-    def ordered_components(self):
-        orig_list = [obj for obj in self.components if obj.ordered]
-        if not orig_list:
-            return []
-        else:
-            sort_key = self.sequence_attr[1]
-
-            def get_key(item):
-                return int(str(getattr(item, sort_key)))
-
-            sorted_list = sorted(orig_list, key=get_key)
-            return sorted_list
-
-    def unordered_components(self):
-        return [obj for obj in self.components if not obj.ordered]
-
-    def add_component(self, obj):
-        self.components.append(obj)
-        obj.collections.append(self)
+class Object(ore.Aggregation):
+    def add_member(self, obj):
+        self.members.append(obj)
+        obj.member_of.append(self)
 
     def add_file(self, obj):
         self.files.append(obj)
         obj.file_of.append(self)
 
-    def add_collection(self, obj):
-        self.collections.append(obj)
-
     def add_related(self, obj):
         self.related.append(obj)
         obj.related_of.append(self)
 
-    # show the item graph and tree of related objects
-    def print_item_tree(self, indent='', label=None):
-        if label is not None:
-            print(indent + '[' + label + '] ' + str(self))
-        else:
-            print(indent + str(self))
 
-        ordered = self.ordered_components()
-        if ordered:
-            print(indent + '  {Ordered Components}')
-            for n, p in enumerate(ordered):
-                p.print_item_tree(indent='    ' + indent, label=n)
-
-        unordered = self.unordered_components()
-        if unordered:
-            print(indent + '  {Unordered Components}')
-            for p in unordered:
-                p.print_item_tree(indent='     ' + indent)
-
-        files = self.files()
-        if files:
-            print(indent + '  {Files}')
-            for f in files:
-                print(indent + '    ' + str(f))
-
-
-# ============================================================================
-# PCDM ITEM-OBJECT
-# ============================================================================
-
-@rdf.object_property('first', iana.first)
-@rdf.object_property('last', iana.last)
-@rdf.rdf_class(pcdm.Object)
-class Item(Resource):
-
-    # iterate over each component and create ordering proxies
-    def create_ordering(self, repository):
-        proxies = []
-        ordered_components = self.ordered_components()
-        for component in ordered_components:
-            position = " ".join([self.sequence_attr[0],
-                                 str(getattr(component, self.sequence_attr[1]))])
-            proxy = ore.Proxy(
-                title=f'Proxy for {position} in {self}',
-                proxy_for=component,
-                proxy_in=self
-            )
-            proxies.append(proxy)
-
-        for proxy in proxies:
-            proxy.create_object(repository)
-
-        for (position, component) in enumerate(ordered_components):
-            proxy = proxies[position]
-
-            if position == 0:
-                self.first = proxy
-            else:
-                proxy.prev = proxies[position - 1]
-
-            if position == len(ordered_components) - 1:
-                self.last = proxy
-            else:
-                proxy.next = proxies[position + 1]
-
-            proxy.update_object(repository)
-
-    def create_annotations(self, repository):
-        with repository.at_path('annotations'):
-            for annotation in self.annotations:
-                annotation.recursive_create(repository)
-
-    def update_annotations(self, repository):
-        for annotation in self.annotations:
-            annotation.recursive_update(repository)
-
-
-# ============================================================================
-# PCDM COMPONENT-OBJECT
-# ============================================================================
-
-@rdf.rdf_class(pcdm.Object)
-class Component(Resource):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.ordered = False
-
-
-# ============================================================================
-# PCDM FILE
-# ============================================================================
-
+@rdf.object_property('file_of', pcdm.fileOf)
 @rdf.data_property('mimetype', ebucore.hasMimeType)
 @rdf.data_property('filename', ebucore.filename)
 @rdf.data_property('width', ebucore.width)
 @rdf.data_property('height', ebucore.height)
 @rdf.object_property('dcmitype', dcterms.type)
+@rdf.data_property('title', dcterms.title)
 @rdf.rdf_class(pcdm.File)
-class File(Resource):
+class File(ldp.Resource):
     def __init__(self, source, **kwargs):
         super().__init__(**kwargs)
         self.source = source
@@ -234,41 +121,16 @@ class ExtractedText(File):
     pass
 
 
-# ============================================================================
-# PCDM COLLECTION OBJECT
-# ============================================================================
-
-@rdf.data_property('title', dcterms.title)
 @rdf.rdf_class(pcdm.Collection)
-class Collection(Resource):
-
-    @classmethod
-    def from_repository(cls, repo, uri):
-        graph = repo.get_graph(uri)
-        collection = cls()
-        collection.uri = URIRef(uri)
-
-        # mark as created and updated so that the create_object and update_object
-        # methods doesn't try try to modify it
-        collection.created = True
-        collection.updated = True
-
-        # default title is the URI
-        collection.title = str(collection.uri)
-        for o in graph.objects(subject=collection.uri, predicate=dcterms.title):
-            collection.title = str(o)
-
-        return collection
+class Collection(Object):
+    pass
 
 
 @rdf.data_property('number', fabio.hasSequenceIdentifier)
 @rdf.rdf_class(fabio.Page)
-class Page(Resource):
+class Page(Object):
     """One page of an item-level resource"""
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.ordered = True
+    pass
 
 
 FILE_CLASS_FOR = {

--- a/plastron/validation/__init__.py
+++ b/plastron/validation/__init__.py
@@ -1,0 +1,28 @@
+class ResourceValidationResult:
+    def __init__(self, resource):
+        self.resource = resource
+        self.outcomes = []
+
+    def __bool__(self):
+        return self.is_valid()
+
+    def is_valid(self):
+        return len(list(self.failed())) == 0
+
+    def passes(self, prop, rule, expected):
+        self.outcomes.append((prop, 'passed', rule, expected))
+
+    def fails(self, prop, rule, expected):
+        self.outcomes.append((prop, 'failed', rule, expected))
+
+    def passed(self):
+        for prop, status, rule, expected in self.outcomes:
+            if status != 'passed':
+                continue
+            yield prop.name, status, rule.__name__, expected
+
+    def failed(self):
+        for prop, status, rule, expected in self.outcomes:
+            if status != 'failed':
+                continue
+            yield prop.name, status, rule.__name__, expected

--- a/plastron/validation/rules.py
+++ b/plastron/validation/rules.py
@@ -1,0 +1,46 @@
+import re
+from functools import lru_cache
+
+from plastron.namespaces import rdf, rdfs
+from rdflib import Graph
+
+
+vocab_cache = {}
+
+
+def non_empty(values):
+    return [v for v in values if len(v.strip()) > 0]
+
+
+def required(prop):
+    return min_len(prop, 1)
+
+
+def min_len(prop, length):
+    return len(prop) >= length
+
+
+def max_len(prop, length):
+    return len(prop) <= length
+
+
+def exactly(prop, length):
+    return len(prop) == length
+
+
+def allowed_values(prop, values):
+    return not any(True for v in prop.values if str(v) not in values)
+
+
+@lru_cache()
+def get_subjects(vocab_uri):
+    graph = Graph().parse(vocab_uri)
+    return [str(s) for s in set(graph.subjects())]
+
+
+def from_vocabulary(prop, vocab_uri):
+    return allowed_values(prop, get_subjects(vocab_uri))
+
+
+def value_pattern(prop, pattern):
+    return not any(True for v in prop.values if not re.search(pattern, v))


### PR DESCRIPTION
- removed explicit setting of multivalued property
- add default class attributes to property classes
- renamed collections and components to member_of and members to align with PCDM terminology
- implement proxy and aggregation through a separate class
- change get_term to a class method for data and object properties
- added validation rules for min_len, max_len, exactly, required, allowed_values, and from_vocabulary
- rules are applied using an external ruleset, and not defined in the model class itself
- vocabulary fetch for from_vocabulary rule use an LRU cache

https://issues.umd.edu/browse/LIBFCREPO-722