### PR TITLE
LIBFCREPO-763. Fixed "JOBS_COMPLETED" property in docker-plastron.yml

### DIFF
--- a/docker-plastron.yml
+++ b/docker-plastron.yml
@@ -10,4 +10,4 @@ MESSAGE_BROKER:
   MESSAGE_STORE_DIR: /var/opt/plastron/msg/export
   DESTINATIONS:
     JOBS: /queue/plastron.jobs
-    JOBS_COMPLETED: /queue/plastron.jobs.completed
+    COMPLETED_JOBS: /queue/plastron.jobs.completed

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -19,6 +19,7 @@ optional arguments:
 
 commands:
   {delete,del,rm,export,extractocr,imgsize,list,ls,load,mkcol,ping,update}```
+```
 
 ### Check version
 
@@ -73,7 +74,7 @@ optional arguments:
 
 required arguments:
   -b BATCH, --batch BATCH
-                        path to batch configuration file              
+                        path to batch configuration file
 ```
 
 ### List (list, ls)
@@ -135,6 +136,7 @@ optional arguments:
   --completed COMPLETED
                         file recording the URIs of deleted resources
   -f FILE, --file FILE  File containing a list of URIs to delete```
+```
 
 ### Extract OCR (extractocr)
 
@@ -202,6 +204,7 @@ optional arguments:
 ## Configuration
 
 ### Configuration Templates
+
 Templates for creating the configuration files can be found at [config/templates](../config/templates)
 
 ### Repository Configuration


### PR DESCRIPTION
Based on the code in the "__init__" method of the "CommandListener"
class in "plastron/stomp/listeners.py", changed the "COMPLETED_JOBS"
property in "docker-plastron.yml" from "JOBS_COMPLETED" to
"COMPLETED_JOBS". Without this change, the Docker container reports
an error and continuously restarts.

Also fixed some mismatched code blocks in docs/cli.md.

https://issues.umd.edu/browse/LIBFCREPO-763