### PR TITLE
LIBFCREPO-768. Added validation to the plastron import command.

### DIFF
--- a/plastron/commands/import.py
+++ b/plastron/commands/import.py
@@ -1,13 +1,12 @@
 import csv
 import logging
-import re
-from datetime import datetime
-
 import plastron.models
-from collections import defaultdict
-from operator import attrgetter
+import re
 
-from plastron.exceptions import FailureException
+from collections import defaultdict
+from datetime import datetime
+from operator import attrgetter
+from plastron.exceptions import FailureException, NoValidationRulesetException
 from plastron.rdf import RDFDataProperty
 from plastron.serializers import CSVSerializer
 from rdflib import URIRef, Graph, Literal
@@ -30,6 +29,11 @@ def configure_cli(subparsers):
         help='limit the number of rows to read from the import file',
         type=int,
         action='store'
+    )
+    parser.add_argument(
+        '--validate-only',
+        help='only validate, do not do the actual import',
+        action='store_true'
     )
     parser.add_argument(
         'filename', nargs=1,
@@ -100,12 +104,33 @@ def build_fields(fieldnames, property_attrs):
     return fields
 
 
+def validate(item):
+    try:
+        result = item.validate()
+    except NoValidationRulesetException as e:
+        logger.error(f'Unable to run validation: {e.message}')
+        raise FailureException()
+
+    if result.is_valid():
+        logger.info(f'"{item}" is valid')
+        for outcome in result.passed():
+            logger.debug(f'  ✓ {outcome}')
+        return True
+    else:
+        logger.warning(f'{item} is invalid')
+        for outcome in result.failed():
+            logger.warning(f'  ✗ {outcome}')
+        for outcome in result.passed():
+            logger.debug(f'  ✓ {outcome}')
+        return False
+
+
 class Command:
     def __init__(self):
         self.result = None
 
     def __call__(self, *args, **kwargs):
-        for status in self.execute(*args, **kwargs):
+        for _ in self.execute(*args, **kwargs):
             pass
 
     def execute(self, repo, args):
@@ -118,6 +143,9 @@ class Command:
 
         csv_filename = args.filename[0]
 
+        if args.validate_only:
+            logger.info('Validation-only mode, skipping imports')
+
         property_attrs = {header: attrs for attrs, header in model_class.HEADER_MAP.items()}
 
         with open(csv_filename) as file:
@@ -127,13 +155,15 @@ class Command:
             row_count = 0
             updated_count = 0
             unchanged_count = 0
+            invalid_count = 0
             errors = 0
             for row_number, row in enumerate(csv_file, 1):
                 if args.limit is not None and row_number > args.limit:
                     logger.info(f'Stopping after {args.limit} rows')
                     break
-                logger.debug(f'Processing {args.filename[0]}:{row_number + 1}')
+                logger.debug(f'Processing {csv_filename}:{row_number + 1}')
                 uri = URIRef(row['URI'])
+                row_count += 1
 
                 # read the object from the repo
                 item = model_class.from_graph(repo.get_graph(uri, False), uri)
@@ -191,7 +221,15 @@ class Command:
                         delete_graph.remove(statement)
                         insert_graph.remove(statement)
 
-                row_count += 1
+                if not validate(item):
+                    invalid_count += 1
+                    logger.warning(f'Skipping "{item}"')
+                    continue
+
+                if args.validate_only:
+                    # validation-only mode
+                    continue
+
                 # construct the SPARQL Update query if there are any deletions or insertions
                 if len(delete_graph) > 0 or len(insert_graph) > 0:
                     logger.info(f'Sending update for {item}')
@@ -221,11 +259,13 @@ class Command:
 
         logger.info(f'{unchanged_count} of {row_count} items remained unchanged')
         logger.info(f'Updated {updated_count} of {row_count} items')
+        logger.info(f'Found {invalid_count} invalid items')
         self.result = {
             'count': {
                 'total': row_count,
                 'updated': updated_count,
                 'unchanged': unchanged_count,
+                'invalid': invalid_count,
                 'errors': errors
             }
         }

--- a/plastron/exceptions.py
+++ b/plastron/exceptions.py
@@ -24,3 +24,11 @@ class RESTAPIException(Exception):
 
 class FailureException(Exception):
     pass
+
+
+class NoValidationRulesetException(Exception):
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return self.message

--- a/plastron/models/newspaper.py
+++ b/plastron/models/newspaper.py
@@ -21,6 +21,24 @@ class Issue(pcdm.Object):
         'issue': 'Issue',
         'edition': 'Edition'
     }
+    VALIDATION_RULESET = {
+        'title': {
+            'exactly': 1
+        },
+        'date': {
+            'exactly': 1,
+            'value_pattern': '^\d\d\d\d-\d\d-\d\d$'
+        },
+        'volume': {
+            'exactly': 1
+        },
+        'issue': {
+            'exactly': 1
+        },
+        'edition': {
+            'exactly': 1
+        }
+    }
 
 
 @rdf.object_property('derived_from', prov.wasDerivedFrom, embed=True)

--- a/plastron/rdf.py
+++ b/plastron/rdf.py
@@ -2,6 +2,8 @@ import plastron.validation.rules
 import sys
 from copy import copy
 from rdflib import Graph, RDF, URIRef, Literal
+
+from plastron.exceptions import NoValidationRulesetException
 from plastron.namespaces import rdf
 from plastron.validation import ResourceValidationResult
 
@@ -235,7 +237,12 @@ class Resource(metaclass=Meta):
     def print(self, format='turtle', file=sys.stdout, nsm=None):
         print(self.graph(nsm=nsm).serialize(format=format).decode(), file=file)
 
-    def validate(self, ruleset):
+    def validate(self, ruleset=None):
+        if ruleset is None:
+            try:
+                ruleset = self.VALIDATION_RULESET
+            except AttributeError:
+                raise NoValidationRulesetException(f'No ruleset given, and "{self}" does not have a default ruleset')
         result = ResourceValidationResult(self)
         for field, rules in ruleset.items():
             for rule_name, arg in rules.items():

--- a/plastron/validation/__init__.py
+++ b/plastron/validation/__init__.py
@@ -19,10 +19,10 @@ class ResourceValidationResult:
         for prop, status, rule, expected in self.outcomes:
             if status != 'passed':
                 continue
-            yield prop.name, status, rule.__name__, expected
+            yield prop.name, status, rule.__name__, getattr(expected, '__name__', expected)
 
     def failed(self):
         for prop, status, rule, expected in self.outcomes:
             if status != 'failed':
                 continue
-            yield prop.name, status, rule.__name__, expected
+            yield prop.name, status, rule.__name__, getattr(expected, '__name__', expected)

--- a/plastron/validation/rules.py
+++ b/plastron/validation/rules.py
@@ -1,26 +1,23 @@
 import re
+
 from functools import lru_cache
-
-from plastron.namespaces import rdf, rdfs
 from rdflib import Graph
-
-
-vocab_cache = {}
+from typing import Callable
 
 
 def non_empty(values):
     return [v for v in values if len(v.strip()) > 0]
 
 
-def required(prop):
-    return min_len(prop, 1)
+def required(prop, *args):
+    return min_values(prop, 1)
 
 
-def min_len(prop, length):
+def min_values(prop, length):
     return len(prop) >= length
 
 
-def max_len(prop, length):
+def max_values(prop, length):
     return len(prop) <= length
 
 
@@ -44,3 +41,7 @@ def from_vocabulary(prop, vocab_uri):
 
 def value_pattern(prop, pattern):
     return not any(True for v in prop.values if not re.search(pattern, v))
+
+
+def function(prop, func: Callable):
+    return not any(True for v in prop.values if not func(v))


### PR DESCRIPTION
- plastron import always attempts to run validation on each item from the import file
- added a function validation rule that can call an arbitrary callable to check property values
- renamed *_len rules to *_values
- if no ruleset is given to validate, check the object itself for a default VALIDATION_RULESET attribute
- added a validation-only mode to plastron import
- added a basic validation ruleset to the newspaper issue model

https://issues.umd.edu/browse/LIBFCREPO-768