### PR TITLE
LIBFCREPO-758. Create new objects via import command.

### DIFF
--- a/plastron/models/__init__.py
+++ b/plastron/models/__init__.py
@@ -1,3 +1,4 @@
 from .letter import *
 from .newspaper import *
 from .poster import *
+from .umd import *

--- a/plastron/models/newspaper.py
+++ b/plastron/models/newspaper.py
@@ -27,7 +27,7 @@ class Issue(pcdm.Object):
         },
         'date': {
             'exactly': 1,
-            'value_pattern': '^\d\d\d\d-\d\d-\d\d$'
+            'value_pattern': r'^\d\d\d\d-\d\d-\d\d$'
         },
         'volume': {
             'exactly': 1

--- a/plastron/models/umd.py
+++ b/plastron/models/umd.py
@@ -1,0 +1,97 @@
+from edtf import parse_edtf
+from iso639 import is_valid639_1, is_valid639_2
+from pyparsing import ParseException
+
+from plastron import pcdm, rdf
+from plastron.authority import LabeledThing
+from plastron.namespaces import dc, dcterms, edm
+
+
+def is_edtf_formatted(value):
+    try:
+        parse_edtf(value)
+        return True
+    except ParseException:
+        return False
+
+
+def is_valid_iso639_code(value):
+    return is_valid639_1(value) or is_valid639_2(value)
+
+
+@rdf.object_property('object_type', dcterms.type)
+@rdf.data_property('identifier', dcterms.identifier)
+@rdf.object_property('rights', dcterms.rights)
+@rdf.data_property('title', dcterms.title)
+@rdf.object_property('format', edm.hasType)
+@rdf.object_property('archival_collection', dcterms.isPartOf, embed=True, obj_class=LabeledThing)
+@rdf.data_property('date', dc.date)
+@rdf.data_property('description', dcterms.description)
+@rdf.data_property('alternate_title', dcterms.alternative)
+@rdf.object_property('creator', dcterms.creator, embed=True, obj_class=LabeledThing)
+@rdf.object_property('contributor', dcterms.contributor, embed=True, obj_class=LabeledThing)
+@rdf.object_property('publisher', dcterms.publisher, embed=True, obj_class=LabeledThing)
+@rdf.object_property('location', dcterms.spatial, embed=True, obj_class=LabeledThing)
+@rdf.data_property('extent', dcterms.extent)
+@rdf.object_property('subject', dcterms.subject, embed=True, obj_class=LabeledThing)
+@rdf.data_property('language', dc.language)
+@rdf.object_property('rights_holder', dcterms.rightsHolder, embed=True, obj_class=LabeledThing)
+class Item(pcdm.Object):
+    HEADER_MAP = {
+        'object_type': 'Object Type',
+        'identifier': 'Identifier',
+        'rights': 'Rights Statement',
+        'title': 'Title',
+        'format': 'Format',
+        'archival_collection.label': 'Archival Collection',
+        'date': 'Date',
+        'description': 'Description',
+        'alternate_title': 'Alternate Title',
+        'creator.label': 'Creator',
+        'creator.same_as': 'Creator URI',
+        'contributor.label': 'Contributor',
+        'contributor.same_as': 'Contributor URI',
+        'publisher.label': 'Publisher',
+        'publisher.same_as': 'Publisher URI',
+        'location.label': 'Location',
+        'extent': 'Extent',
+        'subject.label': 'Subject',
+        'language': 'Language',
+        'rights_holder.label': 'Rights Holder'
+    }
+    VALIDATION_RULESET = {
+        'object_type': {
+            'exactly': 1
+        },
+        'identifier': {
+            'min_values': 1
+        },
+        'rights': {
+            'exactly': 1
+        },
+        'title': {
+            'exactly': 1
+        },
+        'format': {},
+        'archival_collection': {
+            'max_values': 1
+        },
+        'date': {
+            'max_values': 1,
+            'function': is_edtf_formatted
+        },
+        'description': {
+            'max_values': 1
+        },
+        'alternate_title': {},
+        'creator': {},
+        'contributor': {},
+        'publisher': {},
+        'location': {},
+        'extent': {},
+        'subject': {},
+        'language': {
+            'function': is_valid_iso639_code
+        },
+        'rights_holder': {}
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+iso639
+pyparsing
+edtf
 setuptools==39.0.1
 rdflib==4.2.1
 requests>=2.20.0

--- a/setup.py
+++ b/setup.py
@@ -71,10 +71,13 @@ setup(
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
+        'edtf',
+        'iso639'
         'lxml>3.6.0',
         'numpy',
         'paramiko',
         'Pillow>=6.2.0',
+        'pyparsing',
         'PyYAML>3.12',
         'rdflib',
         'requests',

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
         'edtf',
-        'iso639'
+        'iso639',
         'lxml>3.6.0',
         'numpy',
         'paramiko',


### PR DESCRIPTION
- create a new object when there is no URI in the CSV spreadsheet
- includes support for creation of new embedded objects
- added --make-template option to import command that makes a CSV template using the header map from the given model
- use argparse.FileType for file-like CLI arguments; enables us to pass a file-like handle of the STOMP message body string
- added UMD Item model

https://issues.umd.edu/browse/LIBFCREPO-758