### PR TITLE
LIBFCREPO-770. Standardized the process_message method into the command listener.

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -156,7 +156,8 @@ optional arguments:
 
 ```
 $ plastron export --help
-usage: plastron export [-h] [-o OUTPUT_FILE] -f
+usage: plastron export [-h] [-o OUTPUT_FILE | --upload-to UPLOAD_PATH]
+                       [--upload-name UPLOAD_FILENAME] -f
                        {text/turtle,turtle,ttl,text/csv,csv}
                        [--uri-template URI_TEMPLATE]
                        [uris [uris ...]]
@@ -170,6 +171,11 @@ optional arguments:
   -h, --help            show this help message and exit
   -o OUTPUT_FILE, --output-file OUTPUT_FILE
                         File to write export package to
+  --upload-to UPLOAD_PATH
+                        Repository path to POST the export file to
+  --upload-name UPLOAD_FILENAME
+                        Used to create the download filename for the uploaded
+                        export file in the repository
   -f {text/turtle,turtle,ttl,text/csv,csv}, --format {text/turtle,turtle,ttl,text/csv,csv}
                         Export job format
   --uri-template URI_TEMPLATE

--- a/plastron/commands/export.py
+++ b/plastron/commands/export.py
@@ -139,23 +139,26 @@ class Command:
         logger.info(f'Exported {count} of {total} items')
 
         download_uri = None
+        # upload to the repo if requested
         if args.upload_path is not None:
-            if args.upload_filename is None:
-                args.upload_filename = 'export_' + datetime.utcnow().strftime('%Y%m%d%H%M%S')
-            # upload to the repo if requested
-            filename = args.upload_filename + serializer.file_extension
-            # rewind to the beginning of the file
-            args.output_file.seek(0)
+            if count == 0:
+                logger.warning('No items exported, skipping upload to repository')
+            else:
+                if args.upload_filename is None:
+                    args.upload_filename = 'export_' + datetime.utcnow().strftime('%Y%m%d%H%M%S')
+                filename = args.upload_filename + serializer.file_extension
+                # rewind to the beginning of the file
+                args.output_file.seek(0)
 
-            file = pcdm.File(LocalFile(
-                args.output_file.name,
-                mimetype=serializer.content_type,
-                filename=filename
-            ))
-            with fcrepo.at_path(args.upload_path):
-                file.create_object(repository=fcrepo)
-                download_uri = file.uri
-                logger.info(f'Uploaded export file to {file.uri}')
+                file = pcdm.File(LocalFile(
+                    args.output_file.name,
+                    mimetype=serializer.content_type,
+                    filename=filename
+                ))
+                with fcrepo.at_path(args.upload_path):
+                    file.create_object(repository=fcrepo)
+                    download_uri = file.uri
+                    logger.info(f'Uploaded export file to {file.uri}')
 
         self.result = {
             'content_type': serializer.content_type,

--- a/plastron/commands/export.py
+++ b/plastron/commands/export.py
@@ -27,11 +27,13 @@ def configure_cli(subparsers):
     )
     file_or_upload.add_argument(
         '--upload-to',
+        help='Repository path to POST the export file to',
         dest='upload_path',
         action='store'
     )
     parser.add_argument(
         '--upload-name',
+        help='Used to create the download filename for the uploaded export file in the repository',
         dest='upload_filename',
         action='store'
     )
@@ -136,6 +138,7 @@ class Command:
 
         logger.info(f'Exported {count} of {total} items')
 
+        download_uri = None
         if args.upload_path is not None:
             if args.upload_filename is None:
                 args.upload_filename = 'export_' + datetime.utcnow().strftime('%Y%m%d%H%M%S')

--- a/plastron/commands/export.py
+++ b/plastron/commands/export.py
@@ -18,13 +18,14 @@ def configure_cli(subparsers):
         name='export',
         description='Export resources from the repository'
     )
-    parser.add_argument(
+    file_or_upload = parser.add_mutually_exclusive_group()
+    file_or_upload.add_argument(
         '-o', '--output-file',
         help='File to write export package to',
         type=FileType('w'),
         action='store',
     )
-    parser.add_argument(
+    file_or_upload.add_argument(
         '--upload-to',
         dest='upload_path',
         action='store'
@@ -136,6 +137,8 @@ class Command:
         logger.info(f'Exported {count} of {total} items')
 
         if args.upload_path is not None:
+            if args.upload_filename is None:
+                args.upload_filename = 'export_' + datetime.utcnow().strftime('%Y%m%d%H%M%S')
             # upload to the repo if requested
             filename = args.upload_filename + serializer.file_extension
             # rewind to the beginning of the file

--- a/plastron/serializers.py
+++ b/plastron/serializers.py
@@ -73,8 +73,8 @@ def write_csv_file(row_info, file):
 
 
 class CSVSerializer:
-    def __init__(self, filename, **kwargs):
-        self.filename = filename
+    def __init__(self, file, **kwargs):
+        self.file = file
         self.content_models = {}
         self.content_type = 'text/csv'
         self.file_extension = '.csv'
@@ -176,11 +176,10 @@ class CSVSerializer:
             logger.error("No items could be exported; skipping writing file")
         elif len(self.content_models) == 1:
             # write a single CSV file
-            with open(self.filename, mode='w') as fh:
-                write_csv_file(next(iter(self.content_models.values())), file=fh)
+            write_csv_file(next(iter(self.content_models.values())), file=self.file)
         else:
             # write a ZIP file containing individual CSV files
-            with ZipFile(self.filename, mode='w') as zip_fh:
+            with ZipFile(self.file) as zip_fh:
                 for resource_class, row_info in self.content_models.items():
                     # write the CSV file
                     tmp = NamedTemporaryFile(mode='w', encoding='utf-8', delete=False)


### PR DESCRIPTION
- use argparse FileType arguments for export output file
- pass around file handles instead of names

https://issues.umd.edu/browse/LIBFCREPO-770