### PR TITLE
LIBFCREPO-785. Raise DataReadExceptions for unrecognized CSV headers.

### DIFF
--- a/plastron/stomp/listeners.py
+++ b/plastron/stomp/listeners.py
@@ -89,11 +89,11 @@ class CommandListener(ConnectionListener):
                 )
 
             except (FailureException, RESTAPIException) as e:
-                logger.error(f"Export job {message.job_id} failed: {e}")
+                logger.error(f"Job {message.job_id} failed: {e}")
                 return Message(
                     headers={
                         'PlastronJobId': message.job_id,
-                        'PlastronJobStatus': 'Failed',
+                        'PlastronJobStatus': 'Error',
                         'PlastronJobError': str(e),
                         'persistent': 'true'
                     }


### PR DESCRIPTION
Use message status "Error" for any caught exceptions.

https://issues.umd.edu/browse/LIBFCREPO-785