### PR TITLE
LIBFCREPO-798. Ensure there is an exception message on validation failure.

### DIFF
--- a/plastron/cli.py
+++ b/plastron/cli.py
@@ -118,8 +118,9 @@ def main():
             logger.info(f'Running repository operations on behalf of {args.delegated_user}')
         command(fcrepo, args)
         print_footer(args)
-    except FailureException:
+    except FailureException as e:
         # something failed, exit with non-zero status
+        logger.error(str(e))
         sys.exit(1)
     except KeyboardInterrupt:
         # aborted due to Ctrl+C


### PR DESCRIPTION
Otherwise, the Archelon STOMP client will complain about an empty header field and fail to process the message.

Also, when constructing the index in validation-only mode of existing objects, create embedded objects as needed.

https://issues.umd.edu/browse/LIBFCREPO-798