### PR TITLE
LIBFCREPO-801. Added "utf-8-sig" encoding for parsing CSV imports

### DIFF
--- a/plastron/commands/import.py
+++ b/plastron/commands/import.py
@@ -72,7 +72,7 @@ def configure_cli(subparsers):
     parser.add_argument(
         'import_file', nargs='?',
         help='name of the file to import from',
-        type=FileType('r'),
+        type=FileType('r', encoding='utf-8-sig'),
         action='store'
     )
     parser.set_defaults(cmd_name='import')
@@ -201,6 +201,7 @@ def add_files(item, filenames, base_location, access=None):
 
 def parse_message(message):
     access = message.args.get('access')
+    message.body = message.body.encode('utf-8').decode('utf-8-sig')
     if access is not None:
         try:
             access_uri = uri_or_curie(access)


### PR DESCRIPTION
A CSV file originating in Excel may have a Unicode "byte order mark"
(BOM) that throws off the parsing of the file.

Following the advice in https://stackoverflow.com/a/40310236, modified
the code to generate the message body using a "utf-8-sig" encoding,
which ameliorates the issue.

https://issues.umd.edu/browse/LIBFCREPO-801