### PR TITLE
LIBFCREPO-796. Added accession_number to UMD Item model.

### DIFF
--- a/plastron/commands/import.py
+++ b/plastron/commands/import.py
@@ -332,6 +332,10 @@ class Command:
                     values = [v for v in row[header].split('|') if len(v.strip()) > 0]
 
                     if issubclass(prop_type, RDFDataProperty):
+                        if datatype is None:
+                            # default to the property's defined datatype
+                            # if it was not specified in the column header
+                            datatype = prop_type.datatype
                         new_values.extend(Literal(v, lang=language_code, datatype=datatype) for v in values)
                     else:
                         new_values = [URIRef(v) for v in values]

--- a/plastron/models/umd.py
+++ b/plastron/models/umd.py
@@ -1,10 +1,12 @@
 from edtf import parse_edtf
 from iso639 import is_valid639_1, is_valid639_2
-from pyparsing import ParseException
-
 from plastron import pcdm, rdf
 from plastron.authority import LabeledThing
 from plastron.namespaces import dc, dcterms, edm
+from pyparsing import ParseException
+from rdflib import Namespace
+
+umdtype = Namespace('http://vocab.lib.umd.edu/datatype#')
 
 
 def is_edtf_formatted(value):
@@ -37,6 +39,7 @@ def is_valid_iso639_code(value):
 @rdf.data_property('language', dc.language)
 @rdf.object_property('rights_holder', dcterms.rightsHolder, embed=True, obj_class=LabeledThing)
 @rdf.data_property('bibliographic_citation', dcterms.bibliographicCitation)
+@rdf.data_property('accession_number', dcterms.identifier, datatype=umdtype.accessionNumber)
 class Item(pcdm.Object):
     HEADER_MAP = {
         'object_type': 'Object Type',
@@ -59,7 +62,8 @@ class Item(pcdm.Object):
         'subject.label': 'Subject',
         'language': 'Language',
         'rights_holder.label': 'Rights Holder',
-        'bibliographic_citation': 'Collection Information'
+        'bibliographic_citation': 'Collection Information',
+        'accession_number': 'Accession Number'
     }
     VALIDATION_RULESET = {
         'object_type': {
@@ -97,6 +101,9 @@ class Item(pcdm.Object):
         },
         'rights_holder': {},
         'bibliographic_citation': {
+            'max_values': 1
+        },
+        'accession_number': {
             'max_values': 1
         }
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@ lxml>3.6.0
 PyYAML>3.12
 paramiko>=2.4.2
 Pillow==6.2.0
+pytest
 stomp.py==4.1.21
 numpy==1.17.1

--- a/setup.py
+++ b/setup.py
@@ -92,10 +92,10 @@ setup(
     #
     # Similar to `install_requires` above, these must be valid existing
     # projects.
-    # extras_require={  # Optional
+    extras_require={  # Optional
     #    'dev': ['check-manifest'],
-    #    'test': ['coverage'],
-    # },
+       'test': ['pytest'],
+    },
 
     # TODO: config/templates/*.yml?
     # If there are data files included in your packages that need to be

--- a/tests/test_umd_model.py
+++ b/tests/test_umd_model.py
@@ -1,0 +1,26 @@
+from plastron.models.umd import Item
+from rdflib import Graph, Literal, URIRef
+
+rdf = (
+    '@prefix dcterms: <http://purl.org/dc/terms/> .'
+    '@prefix umdtype: <http://vocab.lib.umd.edu/datatype#> .'
+    '<> dcterms:identifier "foo" .'
+    '<> dcterms:identifier "1212XN1"^^umdtype:accessionNumber .'
+)
+
+base_uri = 'http://example.com/xyz'
+item = Item.from_graph(
+    graph=Graph().parse(data=rdf, format='turtle', publicID=base_uri),
+    subject=base_uri
+)
+
+def test_identifier_distinct_from_accession_number():
+    assert len(item.identifier) == 1
+    assert item.identifier[0] == Literal('foo')
+
+    assert len(item.accession_number) == 1
+    assert item.accession_number[0] == Literal('1212XN1', datatype=URIRef('http://vocab.lib.umd.edu/datatype#accessionNumber'))
+
+    graph = item.graph()
+    assert (URIRef(base_uri), URIRef('http://purl.org/dc/terms/identifier'), Literal('foo')) in graph
+

--- a/tests/test_umd_model.py
+++ b/tests/test_umd_model.py
@@ -1,5 +1,5 @@
 from plastron.models.umd import Item
-from rdflib import Graph, Literal, URIRef
+from rdflib import Graph, Literal, Namespace, URIRef
 
 rdf = (
     '@prefix dcterms: <http://purl.org/dc/terms/> .'
@@ -13,14 +13,17 @@ item = Item.from_graph(
     graph=Graph().parse(data=rdf, format='turtle', publicID=base_uri),
     subject=base_uri
 )
+dcterms = Namespace('http://purl.org/dc/terms/')
+umdtype = Namespace('http://vocab.lib.umd.edu/datatype#')
 
 def test_identifier_distinct_from_accession_number():
     assert len(item.identifier) == 1
     assert item.identifier[0] == Literal('foo')
 
     assert len(item.accession_number) == 1
-    assert item.accession_number[0] == Literal('1212XN1', datatype=URIRef('http://vocab.lib.umd.edu/datatype#accessionNumber'))
+    assert item.accession_number[0] == Literal('1212XN1', datatype=umdtype.accessionNumber)
 
     graph = item.graph()
-    assert (URIRef(base_uri), URIRef('http://purl.org/dc/terms/identifier'), Literal('foo')) in graph
+    assert (URIRef(base_uri), dcterms.identifier, Literal('foo')) in graph
+    assert (URIRef(base_uri), dcterms.identifier, Literal('1212XN1', datatype=umdtype.accessionNumber)) in graph
 


### PR DESCRIPTION
* Added ability to distinguish predicate to property mappings by the datatype of the literal
* Added pytest as a dev dependency
* Added a test for the accession_number property

https://issues.umd.edu/browse/LIBFCREPO-796