### PR TITLE
LIBFCREPO-794. Implemented InboxWatcher to monitor for new messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,8 @@ exports/*
 *.key
 *.pem
 
+# PyCharm IDE work directory
+.idea/
+
+# virtualenv directory
+venv/

--- a/plastron/daemon.py
+++ b/plastron/daemon.py
@@ -67,8 +67,10 @@ def main():
     logger.info(f'plastrond {version}')
 
     # setup listeners
-    broker.connection.set_listener('reconnect', ReconnectListener(broker))
+    # Order of listeners is important -- ReconnectListener should be the
+    # last listener
     broker.connection.set_listener('command', CommandListener(broker, repo_config))
+    broker.connection.set_listener('reconnect', ReconnectListener(broker))
 
     try:
         broker.connect()

--- a/plastron/stomp/inbox_watcher.py
+++ b/plastron/stomp/inbox_watcher.py
@@ -1,0 +1,48 @@
+import os
+import logging
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler, FileCreatedEvent, FileModifiedEvent
+
+logger = logging.getLogger(__name__)
+
+
+class InboxEventHandler(FileSystemEventHandler):
+    """Triggers message processing when a file is added or modified in the
+       inbox directory."""
+    def __init__(self, command_listener, message_box):
+        self.command_listener = command_listener
+        self.message_box = message_box
+
+    def on_created(self, event):
+        if isinstance(event, FileCreatedEvent):
+            logger.info(f"Triggering inbox processing due to {event}")
+            message = self.message_box.message_class.read(event.src_path)
+            self.command_listener.process_message(message)
+
+    def on_modified(self, event):
+        if isinstance(event, FileModifiedEvent):
+            logger.info(f"Triggering inbox processing due to {event}")
+            message = self.message_box.message_class.read(event.src_path)
+            self.command_listener.process_message(message)
+
+
+class InboxWatcher:
+    """
+    Watches for changes to the inbox directory, in order to trigger message
+    processing via InboxEventHandler
+    """
+    def __init__(self, command_listener, message_box):
+        """Constructs the watchdog Observer"""
+        self.observer = Observer()
+        self.observer.schedule(InboxEventHandler(command_listener, message_box), message_box.dir, recursive=True)
+
+    def start(self):
+        """Start the watcher"""
+        logger.debug(f"Starting InboxWatcher")
+        self.observer.start()
+
+    def stop(self):
+        """Stop the watcher"""
+        logger.debug(f"Stopping InboxWatcher")
+        self.observer.unschedule_all()
+        self.observer.stop()

--- a/plastron/stomp/listeners.py
+++ b/plastron/stomp/listeners.py
@@ -8,6 +8,7 @@ from plastron.exceptions import FailureException, RESTAPIException
 from plastron.http import Repository
 from plastron.stomp import MessageBox, PlastronCommandMessage, PlastronMessage, Message
 from stomp.listener import ConnectionListener
+from plastron.stomp.inbox_watcher import InboxWatcher
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +24,7 @@ class CommandListener(ConnectionListener):
         self.outbox = MessageBox(os.path.join(self.broker.message_store_dir, 'outbox'))
         self.executor = ThreadPoolExecutor(thread_name_prefix=__name__)
         self.public_uri_template = self.broker.public_uri_template
+        self.inbox_watcher = None
 
     def on_connected(self, headers, body):
         # first attempt to send anything in the outbox
@@ -42,16 +44,20 @@ class CommandListener(ConnectionListener):
         self.broker.connection.subscribe(destination=self.queue, id='plastron')
         logger.info(f"Subscribed to {self.queue}")
 
+        self.inbox_watcher = InboxWatcher(self, self.inbox)
+        self.inbox_watcher.start()
+
     def on_message(self, headers, body):
+        # Note: Processing will occur via the InboxWatcher, which will
+        # respond to the inbox placing a file in the inbox message directory
+        # containing the message
+
         if headers['destination'] == self.queue:
             logger.debug(f'Received message on {self.queue} with headers: {headers}')
 
             # save the message in the inbox until we can process it
             message = PlastronCommandMessage(headers=headers, body=body)
             self.inbox.add(message.id, message)
-
-            # and then process the message
-            self.process_message(message)
 
     def process_message(self, message):
         # determine which command to load to process the message
@@ -128,6 +134,10 @@ class CommandListener(ConnectionListener):
             self.outbox.remove(job_id)
 
         return response_handler
+
+    def on_disconnected(self):
+        if self.inbox_watcher:
+            self.inbox_watcher.stop()
 
 
 class ReconnectListener(ConnectionListener):

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ Pillow==6.2.0
 pytest
 stomp.py==4.1.21
 numpy==1.17.1
+watchdog>=0.10.2

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,8 @@ setup(
         'rdflib',
         'requests',
         'setuptools',
-        'stomp.py'
+        'stomp.py',
+        'watchdog>=0.10.2'
     ],
     python_requires='>=3.6',
 


### PR DESCRIPTION
Added the "watchdog" library to "requirements.txt" and "setup.py".

Used the "watchdog" library to create InboxWatcher/InboxEventHandler classes.

The InboxWatcher is created and started when via the "on_connected" method of the CommandListener class. The InboxEventHandler is set up to respond to the creation of new files, or the modification of existing files, in the "inbox" directory by converting the file into a message and calling the "process_message" method on CommandListener class.

The InboxWatcher is stopped when the via the "on_disconnected" method in CommandListener.

The handling of inbox messages is somewhat changed – all messages now call "process_message" in CommandListener via the InboxWatcher/InboxEventHandler classes. There are two sources of messages:

1) A file (or files) placed directly into the "inbox" directory.
2) File (or files) being send from Archelon.

In the prior implementation, the "on_message" method in CommandListener would write out the message to a file in the "inbox" directory (via the "add" method in the MessageBox class), and immediately process the message. This was problematic with InboxWatcher, because the writing of the file by CommandListener would trigger the "new file" event handler, and the message would get processed twice. In the current implementation, the "on_message" method only adds the file to the "inbox" directory (via "add" method in MessageBox), and relies on the InboxWatcher to trigger the message processing.

The startup processing of the "inbox" directory remains the same (i.e., in the "on_connected" method), and occurs before the InboxWatcher is started.

In testing, when ActiveMQ is stopped, the actions taken by the reconnection action taken in the "on_disconnected" method of ReconnectListener appears to cause the "on_disconnected" method in CommandListener not be to called (in which the InboxWatcher is stopped). This was corrected by reversing the order in which the CommandListener and ReconnectListener are added to the broker connection in "plastron/daemon.py", so that ReconnectListener is added last.

https://issues.umd.edu/browse/LIBFCREPO-794