### PR TITLE
LIBFCREPO-803. RemoteFile uses an sftp: URI to specify the remote location.

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -240,8 +240,9 @@ optional arguments:
   --member-of MEMBER_OF
                         URI of the object that new items are PCDM members of
   --binaries-location BINARIES_LOCATION
-                        where to find binaries; either a path to a directory
-                        or a "zip:<path to zipfile>" URI
+                        where to find binaries; either a path to a directory,
+                        a "zip:<path to zipfile>" URI, or an SFTP URI in the
+                        form "sftp://<user>@<host>/<path to dir>"
 ```
 
 ## Configuration

--- a/plastron/commands/import.py
+++ b/plastron/commands/import.py
@@ -66,7 +66,11 @@ def configure_cli(subparsers):
     )
     parser.add_argument(
         '--binaries-location',
-        help='where to find binaries; either a path to a directory or a "zip:<path to zipfile>" URI',
+        help=(
+            'where to find binaries; either a path to a directory, '
+            'a "zip:<path to zipfile>" URI, or an SFTP URI in the form '
+            '"sftp://<user>@<host>/<path to dir>"'
+        ),
         action='store'
     )
     parser.add_argument(
@@ -173,6 +177,16 @@ def validate(item):
 
 
 def get_source(base_location, path):
+    """
+    Get an appropriate BinarySource based on the type of base_location.
+
+    :param base_location: The following forms are recognized:
+        "zip:<path to zipfile>"
+        "sftp:<user>@<host>/<path to dir>"
+        "<local dir path>"
+    :param path:
+    :return:
+    """
     if base_location.startswith('zip:'):
         return ZipFile(base_location[4:], path)
     elif base_location.startswith('sftp:'):

--- a/plastron/commands/import.py
+++ b/plastron/commands/import.py
@@ -11,7 +11,7 @@ from operator import attrgetter
 from plastron import rdf
 from plastron.exceptions import DataReadException, NoValidationRulesetException, RESTAPIException, FailureException, \
     ConfigException, BinarySourceNotFoundError
-from plastron.files import LocalFile, ZipFile
+from plastron.files import LocalFile, RemoteFile, ZipFile
 from plastron.http import Transaction
 from plastron.pcdm import File, Page
 from plastron.rdf import RDFDataProperty
@@ -175,6 +175,8 @@ def validate(item):
 def get_source(base_location, path):
     if base_location.startswith('zip:'):
         return ZipFile(base_location[4:], path)
+    elif base_location.startswith('sftp:'):
+        return RemoteFile(os.path.join(base_location, path))
     else:
         # with no URI prefix, assume a local file path
         return LocalFile(localpath=os.path.join(base_location, path))


### PR DESCRIPTION
* import uses a RemoteFile when binaries-location starts with "sftp:"

https://issues.umd.edu/browse/LIBFCREPO-803