### PR TITLE
LIBFCREPO-811. Require EDTF dates for Letter and Poster content models.

### DIFF
--- a/plastron/models/letter.py
+++ b/plastron/models/letter.py
@@ -1,6 +1,7 @@
 from plastron import rdf, pcdm
 from plastron.authority import LabeledThing
 from plastron.namespaces import bibo, dc, dcmitype, dcterms, edm, geo, rel, skos
+from plastron.validation import is_edtf_formatted
 
 
 @rdf.rdf_class(edm.Agent)
@@ -92,7 +93,8 @@ class Letter(pcdm.Object):
             'exactly': 1
         },
         'date': {
-            'exactly': 1
+            'exactly': 1,
+            'function': is_edtf_formatted
         },
         'language': {
             'exactly': 1

--- a/plastron/models/poster.py
+++ b/plastron/models/poster.py
@@ -1,5 +1,6 @@
 from plastron import pcdm, rdf
 from plastron.namespaces import dcterms, dc, edm, bibo, geo
+from plastron.validation import is_edtf_formatted
 
 
 @rdf.object_property('place', dcterms.spatial)
@@ -66,7 +67,8 @@ class Poster(pcdm.Object):
             'min_values': 1
         },
         'date': {
-            'exactly': 1
+            'exactly': 1,
+            'function': is_edtf_formatted
         },
         'language': {
             'exactly': 1

--- a/plastron/models/umd.py
+++ b/plastron/models/umd.py
@@ -1,22 +1,7 @@
-from edtf import parse_edtf
-from iso639 import is_valid639_1, is_valid639_2
-from pyparsing import ParseException
-
 from plastron import pcdm, rdf
 from plastron.authority import LabeledThing
 from plastron.namespaces import dc, dcterms, edm
-
-
-def is_edtf_formatted(value):
-    try:
-        parse_edtf(value)
-        return True
-    except ParseException:
-        return False
-
-
-def is_valid_iso639_code(value):
-    return is_valid639_1(value) or is_valid639_2(value)
+from plastron.validation import is_edtf_formatted, is_valid_iso639_code
 
 
 @rdf.object_property('object_type', dcterms.type)

--- a/plastron/validation/__init__.py
+++ b/plastron/validation/__init__.py
@@ -1,3 +1,20 @@
+from edtf import parse_edtf
+from iso639 import is_valid639_1, is_valid639_2
+from pyparsing import ParseException
+
+
+def is_edtf_formatted(value):
+    try:
+        parse_edtf(value)
+        return True
+    except ParseException:
+        return False
+
+
+def is_valid_iso639_code(value):
+    return is_valid639_1(value) or is_valid639_2(value)
+
+
 class ResourceValidationResult:
     def __init__(self, resource):
         self.resource = resource


### PR DESCRIPTION
Moved the is_edtf_formatted and is_valid_iso639_code validation functions into the plastron.validation module.

https://issues.umd.edu/browse/LIBFCREPO-811