### PR TITLE
LIBFCREPO-815. Configuration options for SSH/SFTP exports.

### DIFF
--- a/plastron/commands/export.py
+++ b/plastron/commands/export.py
@@ -98,6 +98,7 @@ class Command:
             config = {}
         self.binaries_dest = config.get('BINARIES_DEST', os.path.curdir)
         self.exports_collection = config.get('COLLECTION', '/exports')
+        self.ssh_private_key = config.get('SSH_PRIVATE_KEY')
         self.result = None
 
     def __call__(self, *args, **kwargs):
@@ -117,7 +118,7 @@ class Command:
             if self.binaries_dest.startswith('sftp:'):
                 # remote (SFTP) destination
                 sftp_uri = urlsplit(self.binaries_dest)
-                ssh_client = get_ssh_client(sftp_uri)
+                ssh_client = get_ssh_client(sftp_uri, key_filename=self.ssh_private_key)
                 sftp_client = SFTPClient.from_transport(ssh_client.get_transport())
                 binaries_file = sftp_client.open(os.path.join(sftp_uri.path, binaries_filename), mode='wb')
             else:

--- a/plastron/stomp/inbox_watcher.py
+++ b/plastron/stomp/inbox_watcher.py
@@ -13,12 +13,6 @@ class InboxEventHandler(FileSystemEventHandler):
         self.command_listener = command_listener
         self.message_box = message_box
 
-    def on_created(self, event):
-        if isinstance(event, FileCreatedEvent):
-            logger.info(f"Triggering inbox processing due to {event}")
-            message = self.message_box.message_class.read(event.src_path)
-            self.command_listener.process_message(message)
-
     def on_modified(self, event):
         if isinstance(event, FileModifiedEvent):
             logger.info(f"Triggering inbox processing due to {event}")


### PR DESCRIPTION
- added SSH_PRIVATE_KEY config to the export config
- get_ssh_client() passes on extra keyword args to the SSHClient.connect() method
- auto-add unknown SSH host keys
- inbox watcher only triggers on file modification to prevent double processing

https://issues.umd.edu/browse/LIBFCREPO-815