### PR TITLE
LIBFCREPO-817. Count files even when running in validate-only mode.

### DIFF
--- a/plastron/commands/import.py
+++ b/plastron/commands/import.py
@@ -469,6 +469,10 @@ class Command:
                     delete_graph.remove(statement)
                     insert_graph.remove(statement)
 
+            # count the number of files referenced in this row
+            if 'FILES' in row and row['FILES'].strip() != '':
+                count['files'] = len(row['FILES'].split(';'))
+
             try:
                 report = validate(item)
             except NoValidationRulesetException as e:
@@ -512,7 +516,7 @@ class Command:
 
                             if 'FILES' in row and row['FILES'].strip() != '':
                                 logger.debug('Adding pages and files to new item')
-                                count['files'] += add_files(
+                                add_files(
                                     item,
                                     build_file_groups(row['FILES']),
                                     base_location=args.binaries_location,

--- a/plastron/stomp/inbox_watcher.py
+++ b/plastron/stomp/inbox_watcher.py
@@ -13,6 +13,12 @@ class InboxEventHandler(FileSystemEventHandler):
         self.command_listener = command_listener
         self.message_box = message_box
 
+    def on_created(self, event):
+        if isinstance(event, FileCreatedEvent):
+            logger.info(f"Triggering inbox processing due to {event}")
+            message = self.message_box.message_class.read(event.src_path)
+            self.command_listener.process_message(message)
+
     def on_modified(self, event):
         if isinstance(event, FileModifiedEvent):
             logger.info(f"Triggering inbox processing due to {event}")


### PR DESCRIPTION
Also restore the on_created callback to InboxWatcher.

https://issues.umd.edu/browse/LIBFCREPO-817