### PR TITLE
LIBFCREPO-820. Support "zip+sftp:" locations for import files.

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -241,8 +241,9 @@ optional arguments:
                         URI of the object that new items are PCDM members of
   --binaries-location BINARIES_LOCATION
                         where to find binaries; either a path to a directory,
-                        a "zip:<path to zipfile>" URI, or an SFTP URI in the
-                        form "sftp://<user>@<host>/<path to dir>"
+                        a "zip:<path to zipfile>" URI, an SFTP URI in the form
+                        "sftp://<user>@<host>/<path to dir>", or a URI in the
+                        form "zip+sftp://<user>@<host>/<path to zipfile>"
 ```
 
 ## Configuration

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,0 +1,27 @@
+from plastron.files import LocalFile, RemoteFile, ZipFile
+
+
+def test_local_file():
+    f = LocalFile('/foo/bar')
+    assert f.localpath == '/foo/bar'
+
+
+def test_remote_file():
+    f = RemoteFile('sftp://user@example.com/foo/bar.jpg')
+    assert f.sftp_uri.username == 'user'
+    assert f.sftp_uri.hostname == 'example.com'
+    assert f.sftp_uri.path == '/foo/bar.jpg'
+
+
+def test_zip_file():
+    f = ZipFile('foo.zip', 'bar.jpg')
+    assert f.zip_filename == 'foo.zip'
+    assert f.path == 'bar.jpg'
+
+
+def test_remote_zip_file():
+    f = ZipFile('sftp://user@example.com/foo.zip', 'bar.jpg')
+    assert f.zip_sftp_uri.username == 'user'
+    assert f.zip_sftp_uri.hostname == 'example.com'
+    assert f.zip_sftp_uri.path == '/foo.zip'
+    assert f.path == 'bar.jpg'

--- a/tests/test_import_command.py
+++ b/tests/test_import_command.py
@@ -1,0 +1,17 @@
+from importlib import import_module
+from plastron.files import LocalFile, RemoteFile, ZipFile
+
+imp = import_module('plastron.commands.import')
+
+
+def test_build_file_groups():
+    assert len(imp.build_file_groups('')) == 0
+    assert len(imp.build_file_groups('foo.jpg;foo.png')) == 1
+    assert len(imp.build_file_groups('foo.jpg;bar.jpg')) == 2
+
+
+def test_get_source():
+    assert isinstance(imp.get_source('zip:foo.zip', 'bar.jpg'), ZipFile)
+    assert isinstance(imp.get_source('sftp://user@example.com/foo', 'bar.jpg'), RemoteFile)
+    assert isinstance(imp.get_source('zip+sftp://user@example.com/foo.zip', 'bar.jpg'), ZipFile)
+    assert isinstance(imp.get_source('/foo', 'bar'), LocalFile)


### PR DESCRIPTION
Also:

- added tests for functions in the import command module.
- removed unused per-class loggers for classes in the plastron.files module

https://issues.umd.edu/browse/LIBFCREPO-820