### PR TITLE
LIBFCREPO-821. Removed "on_modified" event handler in InboxEventHandler

### DIFF
--- a/plastron/stomp/inbox_watcher.py
+++ b/plastron/stomp/inbox_watcher.py
@@ -1,4 +1,3 @@
-import os
 import logging
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler, FileCreatedEvent, FileModifiedEvent
@@ -7,20 +6,19 @@ logger = logging.getLogger(__name__)
 
 
 class InboxEventHandler(FileSystemEventHandler):
-    """Triggers message processing when a file is added or modified in the
+    """Triggers message processing when a file is added in the
        inbox directory."""
+    # Note to maintainers: The original implementation of this class included
+    # both "on_created" and "on_modified" event handlers. On Mac OS X, new file
+    # creation only triggers the "on_created" event. On Linux, new file
+    # creation triggers both an "on_created" event and "on_modified" event,
+    # leading to duplicate processing (see LIBFCREPO-821).
     def __init__(self, command_listener, message_box):
         self.command_listener = command_listener
         self.message_box = message_box
 
     def on_created(self, event):
         if isinstance(event, FileCreatedEvent):
-            logger.info(f"Triggering inbox processing due to {event}")
-            message = self.message_box.message_class.read(event.src_path)
-            self.command_listener.process_message(message)
-
-    def on_modified(self, event):
-        if isinstance(event, FileModifiedEvent):
             logger.info(f"Triggering inbox processing due to {event}")
             message = self.message_box.message_class.read(event.src_path)
             self.command_listener.process_message(message)


### PR DESCRIPTION
When a new file is created on Linux both the "on_created" and
"on_modified" event handlers were being triggered, unlike on Mac OS X
where only the "on_created" event handler was triggered.

Since the expectation is that files in the inbox will only be created
(as opposed to modified manually in-place), the "on_modified" event
handler is redundant, and so was removed.

https://issues.umd.edu/browse/LIBFCREPO-821