### PR TITLE
LIBFCREPO-837. Add synchronous message processing capability to plastrond

### DIFF
--- a/docker-plastron.yml
+++ b/docker-plastron.yml
@@ -12,3 +12,4 @@ MESSAGE_BROKER:
     JOBS: /queue/plastron.jobs
     JOB_STATUS: /topic/plastron.jobs.status
     COMPLETED_JOBS: /queue/plastron.jobs.completed
+    SYNCHRONOUS_JOBS: /queue/plastron.jobs.synchronous

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -246,6 +246,22 @@ optional arguments:
                         form "zip+sftp://<user>@<host>/<path to zipfile>"
 ```
 
+### Echo (echo)
+
+```
+$ plastron echo --help
+usage: plastron echo [-h] [-e ECHO_DELAY] -b BODY
+
+Diagnostic command for echoing input to output. Primarily intended for testing
+synchronous message processing.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -e ECHO_DELAY, --echo-delay ECHO_DELAY
+                        The amount of time to delay the reply, in seconds
+  -b BODY, --body BODY  The text to echo back
+```
+
 ## Configuration
 
 ### Configuration Templates

--- a/plastron/commands/echo.py
+++ b/plastron/commands/echo.py
@@ -1,0 +1,59 @@
+import logging
+import time
+from argparse import Namespace
+from plastron.namespaces import get_manager
+
+
+nsm = get_manager()
+logger = logging.getLogger(__name__)
+
+
+def configure_cli(subparsers):
+    parser = subparsers.add_parser(
+        name='echo',
+        description=(
+            'Diagnostic command for echoing input to output. '
+            'Primarily intended for testing synchronous message processing.'
+        )
+    )
+    parser.add_argument(
+        '-e', '--echo-delay',
+        help='The amount of time to delay the reply, in seconds',
+        required=False,
+        action='store'
+    )
+    parser.add_argument(
+        '-b', '--body',
+        help='The text to echo back',
+        required=True,
+        action='store'
+    )
+    parser.set_defaults(cmd_name='echo')
+
+
+class Command:
+    def __init__(self, config=None):
+        self.result = None
+        if config is None:
+            config = {}
+        self.ssh_private_key = config.get('SSH_PRIVATE_KEY')
+
+    def __call__(self, *args, **kwargs):
+        self.execute(*args, **kwargs)
+        print(self.result)
+
+    @staticmethod
+    def parse_message(message):
+        message_body = message.body.encode('utf-8').decode('utf-8-sig')
+        echo_delay = message.headers.get('echo-delay', "0")
+
+        return Namespace(
+            body=message_body,
+            echo_delay=echo_delay
+        )
+
+    def execute(self, _repo, args):
+        if args.echo_delay:
+            time.sleep(int(args.echo_delay))
+
+        self.result = args.body

--- a/plastron/stomp/inbox_watcher.py
+++ b/plastron/stomp/inbox_watcher.py
@@ -21,7 +21,8 @@ class InboxEventHandler(FileSystemEventHandler):
         if isinstance(event, FileCreatedEvent):
             logger.info(f"Triggering inbox processing due to {event}")
             message = self.message_box.message_class.read(event.src_path)
-            self.command_listener.process_message(message)
+            response_handler = self.command_listener.asynchronous_response_handler(message.id)
+            self.command_listener.process_message(message, response_handler)
 
 
 class InboxWatcher:

--- a/plastron/stomp/listeners.py
+++ b/plastron/stomp/listeners.py
@@ -20,6 +20,7 @@ class CommandListener(ConnectionListener):
         self.queue = self.broker.destinations['JOBS']
         self.completed_queue = self.broker.destinations['COMPLETED_JOBS']
         self.status_topic = self.broker.destinations['JOB_STATUS']
+        self.synchronous_queue = self.broker.destinations['SYNCHRONOUS_JOBS']
         self.inbox = MessageBox(os.path.join(self.broker.message_store_dir, 'inbox'))
         self.outbox = MessageBox(os.path.join(self.broker.message_store_dir, 'outbox'))
         self.executor = ThreadPoolExecutor(thread_name_prefix=__name__)
@@ -39,11 +40,16 @@ class CommandListener(ConnectionListener):
 
         # then process anything in the inbox
         for message in self.inbox(PlastronCommandMessage):
-            self.process_message(message)
+            response_handler = self.asynchronous_response_handler(message.id)
+            self.process_message(message, response_handler)
 
         # then subscribe to the queue to receive incoming messages
         self.broker.connection.subscribe(destination=self.queue, id='plastron')
         logger.info(f"Subscribed to {self.queue}")
+
+        # Subscribe for synchronous jobs
+        self.broker.connection.subscribe(destination=self.synchronous_queue, id='plastron')
+        logger.info(f"Subscribed to {self.synchronous_queue} for synchronous jobs")
 
         self.inbox_watcher = InboxWatcher(self, self.inbox)
         self.inbox_watcher.start()
@@ -53,6 +59,14 @@ class CommandListener(ConnectionListener):
         # respond to the inbox placing a file in the inbox message directory
         # containing the message
 
+        if headers['destination'] == self.synchronous_queue:
+            logger.debug(f'Received synchronous job message on {self.synchronous_queue} with headers: {headers}')
+            message = PlastronCommandMessage(headers=headers, body=body)
+            reply_to_queue = headers['reply-to']
+            response_handler = self.synchronous_response_handler(reply_to_queue)
+            self.process_message(message, response_handler)
+            return
+
         if headers['destination'] == self.queue:
             logger.debug(f'Received message on {self.queue} with headers: {headers}')
 
@@ -60,7 +74,7 @@ class CommandListener(ConnectionListener):
             message = PlastronCommandMessage(headers=headers, body=body)
             self.inbox.add(message.id, message)
 
-    def process_message(self, message):
+    def process_message(self, message, response_handler):
         # determine which command to load to process the message
         command_module = import_module('plastron.commands.' + message.command)
         # TODO: cache the command modules
@@ -120,9 +134,20 @@ class CommandListener(ConnectionListener):
                 )
 
         # process message
-        self.executor.submit(process).add_done_callback(self.get_response_handler(message.id))
+        self.executor.submit(process).add_done_callback(response_handler)
 
-    def get_response_handler(self, message_id):
+    def synchronous_response_handler(self, reply_to_queue):
+        # define the response handler for this message
+        def response_handler(future):
+            response = future.result()
+
+            # send to the specified "reply to" queue
+            self.broker.connection.send(reply_to_queue, response.body, headers=response.headers)
+            logger.debug(f'Response message sent to {reply_to_queue} with headers: {response.headers}')
+
+        return response_handler
+
+    def asynchronous_response_handler(self, message_id):
         # define the response handler for this message
         def response_handler(future):
             response = future.result()

--- a/plastron/stomp/listeners.py
+++ b/plastron/stomp/listeners.py
@@ -102,7 +102,7 @@ class CommandListener(ConnectionListener):
                 command = command_module.Command(config)
                 args = command.parse_message(message)
 
-                for status in command.execute(repo, args):
+                for status in (command.execute(repo, args) or []):
                     self.broker.connection.send(
                         self.status_topic,
                         headers={


### PR DESCRIPTION
Modified "process_message" method in CommandListener to take a "responseHandler" as a method parameter.

The "response_handler" parameter is a higher-order function which handles the actual STOMP response when message processing is complete.

Renamed "get_response_handler" to "asynchronous_response_handler", and updated existing "process_message" callers to pass it to "process_message". This preserves the existing asynchronous functionality.

Added a "synchronous_queue" (configurable via the "SYNCHRONOUS_JOBS" property). Jobs sent to this queue will use the "synchronous_response_handler" which will send the response to the queue specified in the "reply-to" header of the message.

Added code in "on_message" method to send messages on the synchronous queue directly to the message processor, bypassing the inbox mechanism.

Updated "plastron/stomp/inbox_watcher.py" to use the "asynchronous_response_handler" method for the response handler.

Added "echo" command to send the message input back as the output.

https://issues.umd.edu/browse/LIBFCREPO-837
