### PR TITLE
Plastron CLI commands should not require "--coverage" parameter

### DIFF
--- a/plastron/commands/delete.py
+++ b/plastron/commands/delete.py
@@ -67,7 +67,7 @@ class Command:
         )
 
     def delete_item(self, resource, graph):
-        if resource.uri in self.resources.completed:
+        if self.resources.completed and resource.uri in self.resources.completed:
             logger.info(f'Resource {resource.uri} has already been deleted; skipping')
             return
         title = get_title_string(graph)

--- a/plastron/commands/update.py
+++ b/plastron/commands/update.py
@@ -81,7 +81,7 @@ class Command:
         )
 
     def update_item(self, resource, graph):
-        if resource.uri in self.resources.completed:
+        if self.resources.completed and resource.uri in self.resources.completed:
             logger.info(f'Resource {resource.uri} has already been updated; skipping')
             return
         headers = {'Content-Type': 'application/sparql-update'}

--- a/plastron/util.py
+++ b/plastron/util.py
@@ -130,7 +130,8 @@ class ResourceList:
                             logger.error('Unable to roll back transaction, aborting')
                             raise FailureException()
                 transaction.commit()
-                shutil.copyfile(self.completed_buffer.filename, self.completed.filename)
+                if self.completed and self.completed.filename:
+                    shutil.copyfile(self.completed_buffer.filename, self.completed.filename)
                 return True
         else:
             for resource, graph in self.get_resources(traverse=traverse):


### PR DESCRIPTION
Handle cases where ItemLog (represented by the "self.resources.completed"
variable can be None, to prevent runtime type errors.

Did this instead of setting "self.resources.completed" to an empty array
or set, because that did not seem to be in line with the use of
ItemLog as a single object.

https://issues.umd.edu/browse/LIBFCREPO-841