### PR TITLE
LIBFCREPO-840. Modified error reporting to return multiple errors

### DIFF
--- a/plastron/commands/update.py
+++ b/plastron/commands/update.py
@@ -170,8 +170,8 @@ class Command:
             is_valid = validation_result.is_valid()
             if not is_valid:
                 for failed in validation_result.failed():
-                    errors.append(failed)
-                    raise FailureException(errors)
+                    errors.append(str(failed))
+                raise FailureException(errors)
 
         if self.dry_run:
             logger.info(f'Would update resource {resource} {title}')


### PR DESCRIPTION
Fixed an issue where only the first validation error was being
returned.

https://issues.umd.edu/browse/LIBFCREPO-840