### PR TITLE
LIBFCREPO-848. Fixed Plastron daemon "update" command header parsing

### DIFF
--- a/plastron/commands/update.py
+++ b/plastron/commands/update.py
@@ -3,6 +3,7 @@ import io
 import json
 import logging
 from argparse import Namespace
+from distutils.util import strtobool
 from email.utils import parsedate_to_datetime
 from plastron.exceptions import FailureException, RESTAPIException
 from plastron.ldp import Resource
@@ -191,14 +192,17 @@ class Command:
         body = json.loads(message.body)
         uris = body['uri']
         sparql_update = body['sparql_update']
+        dry_run = bool(strtobool(message.args.get('dry-run', 'false')))
+        do_validate = bool(strtobool(message.args.get('validate', 'false')))
+        # Default to no transactions, due to LIBFCREPO-842
+        use_transactions = not bool(strtobool(message.args.get('no-transactions', 'true')))
 
         return Namespace(
-            dry_run=bool(message.args.get('dry-run', False)),
-            validate=bool(message.args.get('validate', False)),
+            dry_run=dry_run,
+            validate=do_validate,
             model=message.args.get('model', None),
             recursive=message.args.get('recursive', None),
-            # Default to no transactions, due to LIBFCREPO-842
-            use_transactions=not bool(message.args.get('no-transactions', True)),
+            use_transactions=use_transactions,
             uris=uris,
             update_file=io.StringIO(sparql_update),
             file=None,

--- a/tests/test_update_command.py
+++ b/tests/test_update_command.py
@@ -1,0 +1,47 @@
+from plastron.stomp import PlastronCommandMessage
+from plastron.commands.update import Command
+# '{"uri":["https://fcrepolocal/fcrepo/rest/pcdm/19/de/84/7c/19de847c-8564-4387-9292-3352c01fa46d"],"sparql_update":"DELETE {\\n\\u003chttps://fcrepolocal/fcrepo/rest/pcdm/19/de/84/7c/19de847c-8564-4387-9292-3352c01fa46d\\u003e \\u003chttp://purl.org/dc/elements/1.1/date\\u003e \\"1926-01-12\\" .\\n } INSERT {\\n\\u003chttps://fcrepolocal/fcrepo/rest/pcdm/19/de/84/7c/19de847c-8564-4387-9292-3352c01fa46d\\u003e \\u003chttp://purl.org/dc/elements/1.1/date\\u003e \\"1926-01-13\\" .\\n } WHERE {}"}'
+def test_parse_message():
+    message_body = '{\"uri\": [\"test\"], \"sparql_update\": \"\" }'
+
+    headers = {
+        'PlastronJobId': 'test',
+        'PlastronCommand': 'update',
+        'PlastronArg-dry-run': 'True',
+        'PlastronArg-validate': 'False',
+        'PlastronArg-no-transactions': 'False'
+    }
+    message = PlastronCommandMessage(headers=headers, body=message_body)
+    namespace = Command.parse_message(message)
+
+    assert (namespace.dry_run is True)
+    assert (namespace.validate is False)
+    assert (namespace.use_transactions is True)  # Opposite of value in header
+
+    headers = {
+        'PlastronJobId': 'test',
+        'PlastronCommand': 'update',
+        'PlastronArg-dry-run': 'False',
+        'PlastronArg-validate': 'True',
+        'PlastronArg-no-transactions': 'False'
+    }
+    message = PlastronCommandMessage(headers=headers, body=message_body)
+    namespace = Command.parse_message(message)
+
+    assert (namespace.dry_run is False)
+    assert (namespace.validate is True)
+    assert (namespace.use_transactions is True)  # Opposite of value in header
+
+    headers = {
+        'PlastronJobId': 'test',
+        'PlastronCommand': 'update',
+        'PlastronArg-dry-run': 'False',
+        'PlastronArg-validate': 'False',
+        'PlastronArg-no-transactions': 'True'
+    }
+    message = PlastronCommandMessage(headers=headers, body=message_body)
+    namespace = Command.parse_message(message)
+
+    assert (namespace.dry_run is False)
+    assert (namespace.validate is False)
+    assert (namespace.use_transactions is False)  # Opposite of value in header


### PR DESCRIPTION
Corrected issue where the following "update" command arguments:

* dry-run
* validate
* use_transactions

would also be parsed as "true", even if a string such as "False" was
provided.

Modified the code to use the "strtobool" function from distutils.utils,
instead of the Python "bool" function.

https://issues.umd.edu/browse/LIBFCREPO-848