### PR TITLE
LIBFCREPO-849. Catch exception if the validation model can't be found.

### DIFF
--- a/tests/test_update_command.py
+++ b/tests/test_update_command.py
@@ -1,5 +1,8 @@
-from plastron.stomp import PlastronCommandMessage
+from argparse import Namespace
 from plastron.commands.update import Command
+from plastron.exceptions import FailureException
+from plastron.stomp import PlastronCommandMessage
+from pytest import raises
 # '{"uri":["https://fcrepolocal/fcrepo/rest/pcdm/19/de/84/7c/19de847c-8564-4387-9292-3352c01fa46d"],"sparql_update":"DELETE {\\n\\u003chttps://fcrepolocal/fcrepo/rest/pcdm/19/de/84/7c/19de847c-8564-4387-9292-3352c01fa46d\\u003e \\u003chttp://purl.org/dc/elements/1.1/date\\u003e \\"1926-01-12\\" .\\n } INSERT {\\n\\u003chttps://fcrepolocal/fcrepo/rest/pcdm/19/de/84/7c/19de847c-8564-4387-9292-3352c01fa46d\\u003e \\u003chttp://purl.org/dc/elements/1.1/date\\u003e \\"1926-01-13\\" .\\n } WHERE {}"}'
 def test_parse_message():
     message_body = '{\"uri\": [\"test\"], \"sparql_update\": \"\" }'
@@ -45,3 +48,18 @@ def test_parse_message():
     assert (namespace.dry_run is False)
     assert (namespace.validate is False)
     assert (namespace.use_transactions is False)  # Opposite of value in header
+
+class TinyRepoMock:
+    def test_connection(self): return True
+
+def test_validate_requires_model():
+    cmd = Command()
+    args = Namespace(
+        dry_run=False,
+        use_transactions=False,
+        validate=True,
+        model=''
+    )
+    with raises(FailureException) as exc_info:
+        cmd.execute(TinyRepoMock(), args)
+    assert exc_info.value.args[0] == "Model must be provided when performing validation"


### PR DESCRIPTION
Prevents the plastrond listener thread from just terminating and leaving the application hanging. Also moved the check for the validate and model attributes into the beginning of the execute method, to catch the error earlier.

https://issues.umd.edu/browse/LIBFCREPO-849