### PR TITLE
LIBFCREPO-851. Fixed required validation rule to mean at least one non-empty value.

### DIFF
--- a/plastron/models/letter.py
+++ b/plastron/models/letter.py
@@ -69,46 +69,55 @@ class Letter(pcdm.Object):
     }
     VALIDATION_RULESET = {
         'author': {
-            'min_values': 1
+            'required': True
         },
         'recipient': {
-            'min_values': 1
+            'required': True
         },
         'part_of': {
+            'required': True,
             'exactly': 1
         },
         'place': {
-            'min_values': 1
+            'required': True
         },
         'subject': {
-            'min_values': 1
+            'required': True
         },
         'rights': {
+            'required': True,
             'exactly': 1
         },
         'identifier': {
-            'min_values': 1
+            'required': True
         },
         'type': {
+            'required': True,
             'exactly': 1
         },
         'date': {
+            'required': True,
             'exactly': 1,
             'function': is_edtf_formatted
         },
         'language': {
+            'required': True,
             'exactly': 1
         },
         'description': {
+            'required': True,
             'exactly': 1
         },
         'bibliographic_citation': {
+            'required': True,
             'exactly': 1
         },
         'extent': {
+            'required': True,
             'exactly': 1
         },
         'rights_holder': {
+            'required': True,
             'exactly': 1
         },
     }

--- a/plastron/models/newspaper.py
+++ b/plastron/models/newspaper.py
@@ -23,19 +23,24 @@ class Issue(pcdm.Object):
     }
     VALIDATION_RULESET = {
         'title': {
+            'required': True,
             'exactly': 1
         },
         'date': {
+            'required': True,
             'exactly': 1,
             'value_pattern': r'^\d\d\d\d-\d\d-\d\d$'
         },
         'volume': {
+            'required': True,
             'exactly': 1
         },
         'issue': {
+            'required': True,
             'exactly': 1
         },
         'edition': {
+            'required': True,
             'exactly': 1
         }
     }

--- a/plastron/models/poster.py
+++ b/plastron/models/poster.py
@@ -44,55 +44,63 @@ class Poster(pcdm.Object):
     }
     VALIDATION_RULESET = {
         'title': {
-            'min_values': 1
+            'required': True
         },
         'alternative': {
-            'min_values': 1
+            'required': True
         },
         # "place" is not currently exported
         'place': {},
         'rights': {
+            'required': True,
             'exactly': 1
         },
         # "identifier" is not currently exported
         'identifier': {},
         'format': {},
         'type': {
-            'min_values': 1
+            'required': True
         },
         'subject': {
-            'min_values': 1
+            'required': True
         },
         'location': {
-            'min_values': 1
+            'required': True
         },
         'date': {
+            'required': True,
             'exactly': 1,
             'function': is_edtf_formatted
         },
         'language': {
+            'required': True,
             'exactly': 1
         },
         'description': {},
         'extent': {
+            'required': True,
             'exactly': 1
         },
         'issue': {
+            'required': True,
             'exactly': 1
         },
         'locator': {
+            'required': True,
             'exactly': 1
         },
         'latitude': {
+            'required': True,
             'exactly': 1
         },
         'longitude': {
+            'required': True,
             'exactly': 1
         },
         'part_of': {
-            'min_values': 1
+            'required': True
         },
         'publisher': {
-            'min_values': 1
+            'required': True
         }
     }

--- a/plastron/models/umd.py
+++ b/plastron/models/umd.py
@@ -54,15 +54,18 @@ class Item(pcdm.Object):
     }
     VALIDATION_RULESET = {
         'object_type': {
+            'required': True,
             'exactly': 1
         },
         'identifier': {
-            'min_values': 1
+            'required': True
         },
         'rights': {
+            'required': True,
             'exactly': 1
         },
         'title': {
+            'required': True,
             'exactly': 1
         },
         'format': {},

--- a/plastron/validation/rules.py
+++ b/plastron/validation/rules.py
@@ -6,11 +6,11 @@ from typing import Callable
 
 
 def non_empty(values):
-    return [v for v in values if len(v.strip()) > 0]
+    return [v for v in values if len(str(v).strip()) > 0]
 
 
-def required(prop, *args):
-    return min_values(prop, 1)
+def required(prop, is_required=True):
+    return len(non_empty(prop)) > 0 if is_required else True
 
 
 def min_values(prop, length):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,20 @@
+from plastron.validation.rules import required
+
+
+def test_required():
+    # no values fails
+    assert required([]) is False
+    # no values but not actually required passes
+    assert required([], False) is True
+    # empty string fails
+    assert required(['']) is False
+    # blank string fails
+    assert required(['  ']) is False
+    # non-empty strings pass
+    assert required(['foo']) is True
+    assert required(['0']) is True
+    # non-string values pass
+    assert required([0]) is True
+    assert required([1.0]) is True
+    # only need one non-empty string to pass
+    assert required(['foo', '']) is True


### PR DESCRIPTION
- non_empty casts its values to string before testing for blanks
- made all min values and exactly 1 fields in content model validation rulesets required
- added test for the required rule

https://issues.umd.edu/browse/LIBFCREPO-851