### PR TITLE
LIBFCREPO-854. Fixed missing columns in Letter and Poster exports.

### DIFF
--- a/plastron/commands/export.py
+++ b/plastron/commands/export.py
@@ -11,7 +11,7 @@ from paramiko import SFTPClient
 from plastron.exceptions import FailureException, DataReadException, RESTAPIException
 from plastron.namespaces import get_manager
 from plastron.pcdm import Object
-from plastron.serializers import EmptyItemListError, SERIALIZER_CLASSES
+from plastron.serializers import EmptyItemListError, SERIALIZER_CLASSES, detect_resource_class
 from plastron.util import get_ssh_client
 from tempfile import TemporaryDirectory
 from time import mktime
@@ -154,7 +154,10 @@ class Command:
                     raise DataReadException(f'No UUID found in {uri}')
                 item_dir = match[0]
 
-                obj = Object.from_repository(fcrepo, uri=uri)
+                graph = fcrepo.get_graph(uri)
+                model_class = detect_resource_class(graph, uri, fallback=Object)
+                obj = model_class.from_graph(graph, uri)
+
                 if args.export_binaries:
                     logger.info(f'Gathering binaries for {uri}')
                     binaries = list(filter(mime_type_filter, obj.gather_files(fcrepo)))

--- a/plastron/models/poster.py
+++ b/plastron/models/poster.py
@@ -6,7 +6,8 @@ from plastron.validation import is_edtf_formatted
 @rdf.object_property('place', dcterms.spatial)
 @rdf.object_property('rights', dcterms.rights)
 @rdf.data_property('identifier', dc.identifier)
-@rdf.data_property('format', dc.format)
+# must use the subscripting syntax, since dc.format returns the format method of Namespace
+@rdf.data_property('format', dc['format'])
 @rdf.data_property('type', edm.hasType)
 @rdf.data_property('subject', dc.subject)
 @rdf.data_property('location', dc.coverage)


### PR DESCRIPTION
- Detect resource class when exporting: Ensure that embedded objects are loaded form the graph correctly. Also added an optional fallback argument to the detect_resource_class function. If present, that class will be returned instead of raising an exception.
- Use dc['format'] instead of dc.format; Method call syntax was yielding the actual "format" method of the rdflib.Namespace class.

https://issues.umd.edu/browse/LIBFCREPO-854

