### PR TITLE
LIBFCREPO-855. Modified validation to handle embedded objects

### DIFF
--- a/plastron/authority.py
+++ b/plastron/authority.py
@@ -1,4 +1,5 @@
 from plastron import ldp, rdf
+import plastron.validation.rules
 from plastron.namespaces import edm, geo, rdfs, owl
 
 
@@ -12,7 +13,27 @@ def create_authority(graph, subject):
 @rdf.data_property('label', rdfs.label)
 @rdf.object_property('same_as', owl.sameAs)
 class LabeledThing(ldp.Resource):
-    pass
+    VALIDATION_RULESET = {
+        'label': {
+            'required': True
+        },
+        'same_as': {}
+    }
+
+    def validate(self, parent_prop, result):
+        '''
+        Validates this object based on its internal ruleset, populating
+        the provided result object with the result of the validation.
+        '''
+        ruleset = self.VALIDATION_RULESET
+        for field, rules in ruleset.items():
+            for rule_name, arg in rules.items():
+                rule = getattr(plastron.validation.rules, rule_name)
+                prop = getattr(self, field)
+                if rule(prop, arg):
+                    result.passes(parent_prop, rule, arg)
+                else:
+                    result.fails(parent_prop, rule, arg)
 
 
 @rdf.data_property('lat', geo.lat)

--- a/plastron/rdf.py
+++ b/plastron/rdf.py
@@ -282,8 +282,11 @@ class Resource(metaclass=Meta):
             for rule_name, arg in rules.items():
                 rule = getattr(plastron.validation.rules, rule_name)
                 prop = getattr(self, field)
-                if rule(prop, arg):
-                    result.passes(prop, rule, arg)
+                if isinstance(prop, RDFObjectProperty) and prop.is_embedded:
+                    prop.validate(prop, result)
                 else:
-                    result.fails(prop, rule, arg)
+                    if rule(prop, arg):
+                        result.passes(prop, rule, arg)
+                    else:
+                        result.fails(prop, rule, arg)
         return result


### PR DESCRIPTION
Modified the RDF validation to validate embedded objects (such as
LabeledThing) by passing control to a "validate" method on those
objects.

Added a "validate" method to LabeledThing to handle validation.

https://issues.umd.edu/browse/LIBFCREPO-855