### PR TITLE
LIBFCREPO-856. Align Plastron validation to spreadsheet

### DIFF
--- a/plastron/models/letter.py
+++ b/plastron/models/letter.py
@@ -69,20 +69,16 @@ class Letter(pcdm.Object):
     }
     VALIDATION_RULESET = {
         'author': {
-            'required': True
         },
         'recipient': {
-            'required': True
         },
         'part_of': {
             'required': True,
             'exactly': 1
         },
         'place': {
-            'required': True
         },
         'subject': {
-            'required': True
         },
         'rights': {
             'required': True,
@@ -96,7 +92,6 @@ class Letter(pcdm.Object):
             'exactly': 1
         },
         'date': {
-            'required': True,
             'exactly': 1,
             'function': is_edtf_formatted
         },
@@ -117,6 +112,10 @@ class Letter(pcdm.Object):
             'exactly': 1
         },
         'rights_holder': {
+            'required': True,
+            'exactly': 1
+        },
+        'title': {
             'required': True,
             'exactly': 1
         },

--- a/plastron/models/letter.py
+++ b/plastron/models/letter.py
@@ -92,7 +92,8 @@ class Letter(pcdm.Object):
             'exactly': 1
         },
         'date': {
-            'exactly': 1,
+            # Can't do "exactly 1", because that makes it required
+            # 'exactly': 1,
             'function': is_edtf_formatted
         },
         'language': {

--- a/plastron/models/poster.py
+++ b/plastron/models/poster.py
@@ -5,7 +5,7 @@ from plastron.validation import is_edtf_formatted
 
 @rdf.object_property('place', dcterms.spatial)
 @rdf.object_property('rights', dcterms.rights)
-@rdf.data_property('identifier', dc.identifier)
+@rdf.data_property('identifier', dcterms.identifier)
 # must use the subscripting syntax, since dc.format returns the format method of Namespace
 @rdf.data_property('format', dc['format'])
 @rdf.data_property('type', edm.hasType)
@@ -41,14 +41,14 @@ class Poster(pcdm.Object):
         'longitude': 'Longitude',
         'latitude': 'Latitude',
         'subject': 'Subject',
-        'rights': 'Rights'
+        'rights': 'Rights',
+        'identifier': 'Identifier',
     }
     VALIDATION_RULESET = {
         'title': {
             'required': True
         },
         'alternative': {
-            'required': True
         },
         # "place" is not currently exported
         'place': {},
@@ -57,19 +57,25 @@ class Poster(pcdm.Object):
             'exactly': 1
         },
         # "identifier" is not currently exported
-        'identifier': {},
-        'format': {},
+        'identifier': {
+            'required': True,
+            'exactly': 1
+        },
+        'format': {
+            'required': True,
+            'exactly': 1
+        },
         'type': {
-            'required': True
+            'required': True,
+            # Can't do "exactly 1", because existing records have
+            # multiple entries
+            # 'exactly': 1,
         },
         'subject': {
-            'required': True
         },
         'location': {
-            'required': True
         },
         'date': {
-            'required': True,
             'exactly': 1,
             'function': is_edtf_formatted
         },
@@ -79,29 +85,24 @@ class Poster(pcdm.Object):
         },
         'description': {},
         'extent': {
-            'required': True,
-            'exactly': 1
+            'exactly': 1,
         },
         'issue': {
-            'required': True,
-            'exactly': 1
+            'exactly': 1,
         },
         'locator': {
             'required': True,
             'exactly': 1
         },
         'latitude': {
-            'required': True,
-            'exactly': 1
+            'exactly': 1,
         },
         'longitude': {
-            'required': True,
-            'exactly': 1
+            'exactly': 1,
         },
         'part_of': {
             'required': True
         },
         'publisher': {
-            'required': True
         }
     }

--- a/plastron/models/poster.py
+++ b/plastron/models/poster.py
@@ -76,7 +76,8 @@ class Poster(pcdm.Object):
         'location': {
         },
         'date': {
-            'exactly': 1,
+            # Can't do "exactly 1", because that makes it required
+            # 'exactly': 1,
             'function': is_edtf_formatted
         },
         'language': {
@@ -85,20 +86,24 @@ class Poster(pcdm.Object):
         },
         'description': {},
         'extent': {
-            'exactly': 1,
+            # Can't do "exactly 1", because that makes it required
+            # 'exactly': 1,
         },
         'issue': {
-            'exactly': 1,
+            # Can't do "exactly 1", because that makes it required
+            # 'exactly': 1,
         },
         'locator': {
             'required': True,
             'exactly': 1
         },
         'latitude': {
-            'exactly': 1,
+            # Can't do "exactly 1", because that makes it required
+            # 'exactly': 1,
         },
         'longitude': {
-            'exactly': 1,
+            # Can't do "exactly 1", because that makes it required
+            # 'exactly': 1,
         },
         'part_of': {
             'required': True

--- a/plastron/validation/__init__.py
+++ b/plastron/validation/__init__.py
@@ -4,6 +4,9 @@ from pyparsing import ParseException
 
 
 def is_edtf_formatted(value):
+    # Allow blank values
+    if str(value).strip() == "":
+        return True
     try:
         parse_edtf(value)
         return True


### PR DESCRIPTION
Modified the models to match the validation rules in the spreadsheet:

https://docs.google.com/spreadsheets/d/1b7zXCbsydUuhuQYvjVJrBaLHMnl4KVQg9QPw5YSHRP4

https://issues.umd.edu/browse/LIBFCREPO-856