### PR TITLE
LIBFCREPO-830. Include an error message when ping fails.

### DIFF
--- a/plastron/commands/ping.py
+++ b/plastron/commands/ping.py
@@ -13,5 +13,5 @@ class Command:
     def __call__(self, fcrepo, args):
         try:
             fcrepo.test_connection()
-        except Exception:
-            raise FailureException()
+        except ConnectionError as e:
+            raise FailureException(str(e)) from e

--- a/plastron/http.py
+++ b/plastron/http.py
@@ -137,8 +137,12 @@ class Repository:
         self.relpath = self._path_stack.pop()
 
     def is_reachable(self):
-        response = self.head(self.endpoint + self.relpath)
-        return response.status_code == 200
+        try:
+            response = self.head(self.fullpath)
+            return response.status_code == 200
+        except requests.exceptions.ConnectionError as e:
+            self.logger.error(str(e))
+            return False
 
     def test_connection(self):
         # test connection to fcrepo
@@ -148,8 +152,7 @@ class Repository:
         if self.is_reachable():
             self.logger.info("Connection successful.")
         else:
-            self.logger.warning("Unable to connect.")
-            raise Exception("Unable to connect")
+            raise ConnectionError(f'Unable to connect to {self.fullpath}')
 
     def request(self, method, url, headers=None, **kwargs):
         if headers is None:


### PR DESCRIPTION
Use the more specific ConnectionError builtin class.

https://issues.umd.edu/browse/LIBFCREPO-830