### PR TITLE
LIBFCREPO-877. Write the CSV row for skipped rows.

### DIFF
--- a/plastron/commands/stub.py
+++ b/plastron/commands/stub.py
@@ -89,6 +89,7 @@ class Command:
             id = row[args.identifier_column]
             if not row[args.binary_column]:
                 logger.warning(f'No binary source URI found for {id}; skipping')
+                csv_writer.writerow(row)
                 continue
             source = HTTPFileSource(row[args.binary_column])
             item = Item(identifier=id, title=f'Stub for {id}')


### PR DESCRIPTION
This way, we do not drop any of the input rows from the output CSV, even if the stub resource could not be created.

https://issues.umd.edu/browse/LIBFCREPO-877