### PR TITLE
LIBFCREPO-908. Added a from_source class method to ldp.NonRDFSource.

### DIFF
--- a/plastron/handlers/mapped-csv.py
+++ b/plastron/handlers/mapped-csv.py
@@ -11,25 +11,6 @@ from collections import OrderedDict
 
 nsm = namespaces.get_manager()
 
-FILE_CLASS_FOR = {
-    '.tif': pcdm.PreservationMasterFile,
-    '.jpg': pcdm.IntermediateFile,
-    '.txt': pcdm.ExtractedText,
-    '.xml': pcdm.ExtractedText,
-}
-
-
-def get_file_object(path, source=None):
-    extension = path[path.rfind('.'):]
-    if extension in FILE_CLASS_FOR:
-        cls = FILE_CLASS_FOR[extension]
-    else:
-        cls = pcdm.File
-    if source is None:
-        source = LocalFileSource(path)
-    f = cls(source)
-    return f
-
 
 class Batch:
     """Class representing the mapped and parsed CSV data"""
@@ -153,7 +134,7 @@ class Batch:
                             localpath = os.path.join(self.file_path, filename)
                             source = LocalFileSource(localpath)
 
-                        f = get_file_object(filename, source)
+                        f = pcdm.get_file_object(filename, source)
                         for column, conf in mapping.items():
                             set_value(f, column, conf, line)
                         yield f
@@ -178,7 +159,7 @@ class Batch:
                             # top-level
                             for entry in members[key]:
                                 source = LocalFileSource(entry.path)
-                                f = get_file_object(entry.name, source)
+                                f = pcdm.get_file_object(entry.name, source)
                                 yield f
 
                         elif len(key_parts) == 3:
@@ -189,7 +170,7 @@ class Batch:
                             page = pcdm.Page(number=str(sequence_number), title=f'Page {sequence_number}')
                             for entry in members[key]:
                                 source = LocalFileSource(entry.path)
-                                f = get_file_object(entry.name, source)
+                                f = pcdm.get_file_object(entry.name, source)
                                 for column, conf in mapping.items():
                                     set_value(f, column, conf, line)
                                 page.add_file(f)

--- a/plastron/handlers/ndnp.py
+++ b/plastron/handlers/ndnp.py
@@ -186,13 +186,13 @@ class BatchItem:
             issue.edition = root.find(m['edition']).text
 
         # add the issue and article-level XML files as related objects
-        issue.add_related(IssueMetadata(MetadataFile(
+        issue.add_related(IssueMetadata(MetadataFile.from_source(
             LocalFileSource(self.path),
-            title='{0}, issue METS metadata'.format(issue.title)
+            title=f'{issue.title}, issue METS metadata'
         )))
-        issue.add_related(IssueMetadata(MetadataFile(
+        issue.add_related(IssueMetadata(MetadataFile.from_source(
             LocalFileSource(self.article_path),
-            title='{0}, article METS metadata'.format(issue.title)
+            title=f'{issue.title}, article METS metadata'
         )))
 
         # create a page object for each page and append to list of pages
@@ -274,11 +274,13 @@ class BatchItem:
             localpath = os.path.join(self.dir, os.path.basename(href))
             basename = os.path.basename(localpath)
             mimetype = techmd['PREMIS'].find('.//premis:formatName', xmlns).text
-            source = LocalFileSource(localpath, mimetype=mimetype)
 
             file_class = FILE_CLASS_FOR[use]
 
-            file = file_class(source, title=f'{basename} ({use})')
+            file = file_class.from_source(
+                LocalFileSource(localpath, mimetype=mimetype),
+                title=f'{basename} ({use})'
+            )
             file.use = use
             file.basename = basename
             file.dcmitype = dcmitype.Text

--- a/plastron/ldp.py
+++ b/plastron/ldp.py
@@ -185,7 +185,11 @@ class NonRdfSource(Resource):
     """Class representing a Linked Data Platform Non-RDF Source (LDP-NR)
     An LDPR whose state is not represented in RDF. For example, these can be
     binary or text documents that do not have useful RDF representations."""
-    pass
+    @classmethod
+    def from_source(cls, source=None, **kwargs):
+        obj = cls(**kwargs)
+        obj.source = source
+        return obj
 
 
 class Container(RdfSource):

--- a/plastron/pcdm.py
+++ b/plastron/pcdm.py
@@ -62,7 +62,7 @@ class Object(ore.Aggregation):
 @rdf.object_property('dcmitype', dcterms.type)
 @rdf.data_property('title', dcterms.title)
 @rdf.rdf_class(pcdm.File)
-class File(ldp.Resource):
+class File(ldp.NonRdfSource):
     @classmethod
     def from_repository(cls, repo, uri, include_server_managed=True):
         obj = super().from_repository(repo, uri, include_server_managed)
@@ -162,12 +162,13 @@ FILE_CLASS_FOR = {
 }
 
 
-def get_file_object(path):
+def get_file_object(path, source=None):
     extension = path[path.rfind('.'):]
     if extension in FILE_CLASS_FOR:
         cls = FILE_CLASS_FOR[extension]
     else:
         cls = File
-    f = cls(LocalFileSource(path))
-    f.dcmitype = dcmitype.Text
+    if source is None:
+        source = LocalFileSource(path)
+    f = cls.from_source(source)
     return f


### PR DESCRIPTION
* Takes a BinarySource plus any number of metadata keyword arguments.
* Use this from_source factory method instead of the direct pcdm.File constructor anywhere we are creating a binary from a source.
* Unified the mapped.csv and pcdm versions of get_file_object.

https://issues.umd.edu/browse/LIBFCREPO-908