### PR TITLE
LIBFCREPO-910. Added reindex command to Plastron

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To install Plastron in [development mode], do the following:
 ```
 git clone git@github.com:umd-lib/plastron.git
 cd plastron
-pip install -e .
+pip install -e .[dev,test]
 ```
 
 This allows for in-place editing of Plastron's source code in the

--- a/plastron/commands/reindex.py
+++ b/plastron/commands/reindex.py
@@ -1,0 +1,55 @@
+import logging
+
+from plastron.util import ResourceList, parse_predicate_list
+
+logger = logging.getLogger(__name__)
+
+
+def configure_cli(subparsers):
+    parser = subparsers.add_parser(
+        name='reindex',
+        description='Reindex objects in the repository'
+    )
+    parser.add_argument(
+        '-R', '--recursive',
+        help='Reindex additional objects found by traversing the given predicate(s)',
+        action='store'
+    )
+    parser.add_argument(
+        'uris', nargs='*',
+        help='URIs of repository objects to reindex'
+    )
+    parser.set_defaults(cmd_name='reindex')
+
+
+class Command:
+    def __init__(self):
+        self.broker = None
+        self.repo = None
+
+    def __call__(self, repo, args):
+        self.broker.connect()
+        self.reindexing_queue = self.broker.destination('reindexing'),
+        self.username = args.delegated_user or 'plastron'
+        resources = ResourceList(
+            repository=self.repo,
+            uri_list=args.uris
+        )
+
+        resources.process(
+            method=self.reindex_item,
+            traverse=parse_predicate_list(args.recursive),
+            use_transaction=False
+        )
+        self.broker.disconnect()
+
+    def reindex_item(self, resource, _graph):
+        self.broker.send_message(
+            destination=self.reindexing_queue,
+            headers={
+                'CamelFcrepoUri': resource.uri,
+                'CamelFcrepoPath': resource.uri.replace(self.repo.endpoint, ''),
+                'CamelFcrepoUser': self.username,
+                'persistent': 'true'
+            }
+        )

--- a/plastron/stomp/__init__.py
+++ b/plastron/stomp/__init__.py
@@ -93,7 +93,7 @@ class Broker:
         # set up STOMP client
         broker_server = tuple(config['SERVER'].split(':', 2))
         self.connection = Connection([broker_server])
-        self.destinations = config['DESTINATIONS']
+        self.destinations = config.get('DESTINATIONS', {})
         self.message_store_dir = config['MESSAGE_STORE_DIR']
         self.public_uri_template = config.get('PUBLIC_URI_TEMPLATE', os.environ.get('PUBLIC_URI_TEMPLATE', None))
 
@@ -105,3 +105,19 @@ class Broker:
             except ConnectFailedException:
                 logger.warning('Connection attempt failed')
                 sleep(1)
+
+    def destination(self, name : str):
+        return self.destinations[name.upper()]
+
+    def send_message(self, destination, headers=None, body='', **kwargs):
+        if headers is None:
+            headers = {}
+        self.connection.send(
+            destination=destination,
+            headers=headers,
+            body=body,
+            **kwargs
+        )
+
+    def disconnect(self):
+        self.connection.disconnect()

--- a/plastron/stomp/__init__.py
+++ b/plastron/stomp/__init__.py
@@ -106,7 +106,7 @@ class Broker:
                 logger.warning('Connection attempt failed')
                 sleep(1)
 
-    def destination(self, name : str):
+    def destination(self, name: str):
         return self.destinations[name.upper()]
 
     def send_message(self, destination, headers=None, body='', **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ setup(
     # Similar to `install_requires` above, these must be valid existing
     # projects.
     extras_require={  # Optional
+        'dev': ['pycodestyle'],
         'test': ['pytest'],
     },
 


### PR DESCRIPTION
* Requires the use of the plastrond-style config file via the new -c option to the plastron.cli
* There must be a "REINDEXING" destination defined in the BROKER.DESTINATIONS section of the config file
* Added some convenience methods to the plastron.stomp.Broker class

https://issues.umd.edu/browse/LIBFCREPO-910