### PR TITLE
LIBFCREPO-914. Fix extra triples handling.

### DIFF
--- a/plastron/commands/load.py
+++ b/plastron/commands/load.py
@@ -301,7 +301,6 @@ class BatchConfig:
         else:
             self.extra = None
 
-
         # required fields
         missing_fields = []
         try:

--- a/plastron/commands/load.py
+++ b/plastron/commands/load.py
@@ -295,7 +295,12 @@ class BatchConfig:
         self.mapfile = os.path.join(self.log_dir, options.get('MAPFILE', 'mapfile.csv'))
 
         self.handler_options = options.get('HANDLER_OPTIONS', {})
-        self.extra = options.get('EXTRA', None)
+        extra = options.get('EXTRA', None)
+        if extra is not None:
+            self.extra = os.path.join(self.root_dir, extra)
+        else:
+            self.extra = None
+
 
         # required fields
         missing_fields = []

--- a/plastron/ldp.py
+++ b/plastron/ldp.py
@@ -161,6 +161,10 @@ class Resource(rdf.Resource):
             source=triples_file, format=rdf_format, publicID=self.uri
         )
 
+    # return any extra triples along with the main graph
+    def graph(self, nsm=None):
+        return super().graph(nsm) + self.extra
+
     # show the object's graph, serialized as turtle
     def print_graph(self):
         print(self.graph().serialize(format="turtle").decode())


### PR DESCRIPTION
- the extras file path is now relative to the batch root
- add the extra triples to the graph

https://issues.umd.edu/browse/LIBFCREPO-914