### PR TITLE
LIBFCREPO-943. Provide a default "container", if not specified in "args"

### DIFF
--- a/plastron/commands/import.py
+++ b/plastron/commands/import.py
@@ -579,7 +579,14 @@ class Command:
                                     create_pages=create_pages
                                 )
 
-                            item.create(repo, container_path=args.container)
+                            # Use "repo.relpath" as default for "container",
+                            # but allow it to be overridden by args
+                            container = repo.relpath
+                            if hasattr(args, 'container'):
+                                container = args.container
+                            logger.debug(f"container: {container}")
+
+                            item.create(repo, container_path=container)
                             item.recursive_update(repo)
 
                             count['created'] += 1


### PR DESCRIPTION
Modified the "execute" method so that the "container" variable will
default to the RELPATH entry in the configuration if a "container"
attribute is not provided in args.

https://issues.umd.edu/browse/LIBFCREPO-943