### PR TITLE
LIBFCREPO-944. Pinned "watchdog" package to v0.10.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ Pillow>=6.2.2
 pytest
 stomp.py==4.1.21
 numpy==1.17.1
-watchdog>=0.10.2
+watchdog==0.10.3
 bagit~=1.7.0

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
         'requests',
         'setuptools',
         'stomp.py',
-        'watchdog>=0.10.2'
+        'watchdog==0.10.3'
     ],
     python_requires='>=3.6',
 

--- a/tests/stomp/test_inbox_watcher.py
+++ b/tests/stomp/test_inbox_watcher.py
@@ -1,0 +1,53 @@
+from plastron.stomp.inbox_watcher import InboxWatcher
+from plastron.stomp.messages import MessageBox
+
+from unittest.mock import patch
+import tempfile
+import os
+import time
+
+from contextlib import contextmanager
+
+
+def test_new_file_in_inbox():
+    with tempfile.TemporaryDirectory() as inbox_dirname:
+        with patch('plastron.stomp.listeners.CommandListener') as mock_command_listener:
+            # Mock "process_message" and use to verify that CommandListener
+            # is called (when a file is created in the inbox).
+            mock_method = mock_command_listener.process_message
+
+            with inbox_watcher(inbox_dirname, mock_command_listener):
+                create_test_file(inbox_dirname)
+
+                wait_until_called(mock_method)
+
+                mock_method.assert_called_once()
+
+# Utility methods
+
+
+@contextmanager
+def inbox_watcher(inbox_dirname, mock_command_listener):
+    inbox = MessageBox(inbox_dirname)
+    inbox_watcher = InboxWatcher(mock_command_listener, inbox)
+    inbox_watcher.start()
+
+    try:
+        yield
+    finally:
+        inbox_watcher.stop()
+
+
+def create_test_file(inbox_dirname):
+    temp_file = open(os.path.join(inbox_dirname, 'test_new_file'), 'w')
+    temp_file.write("test:test")
+    temp_file.close()
+
+
+def wait_until_called(mock_method, interval=0.1, timeout=5):
+    '''Polls at the given interval until either the mock_method is called
+       or the timeout occurs.'''
+    # Inspired by https://stackoverflow.com/a/36040926
+    start = time.time()
+    while not mock_method.called and time.time() - start < timeout:
+        time.sleep(interval)


### PR DESCRIPTION
v0.10.4 of the "watchdog" package had an extensive update to the
"fsevent" observer, which appears to have broken functionality the
Plastron InboxWatcher relies on
(https://github.com/gorakhargosh/watchdog/pull/680).

In https://github.com/gorakhargosh/watchdog/pull/729 it is noted 
hat the watchdog MacOS tests are failing, and that there are
known issues with fsevent.

The problem still exists in the latest current watchdog version
(v1.0.2), so pinning the "watchdog" package to v0.10.3 is the simplest
fix for now.

The "tests/stomp/test_inbox_watcher.py" passed when using v0.10.3, and
fails in v0.10.4 and later, so it can be used to gauge whether
"watchdog" is performing as expected by Plastron.

https://issues.umd.edu/browse/LIBFCREPO-944