### PR TITLE
LIBFCREPO-950. Delegate creation of members to the model class.

### DIFF
--- a/plastron/commands/import.py
+++ b/plastron/commands/import.py
@@ -15,7 +15,7 @@ from plastron.exceptions import DataReadException, NoValidationRulesetException,
 from plastron.files import HTTPFileSource, LocalFileSource, RemoteFileSource, ZipFileSource
 from plastron.http import Transaction
 from plastron.namespaces import get_manager
-from plastron.pcdm import File, Page
+from plastron.pcdm import File
 from plastron.rdf import RDFDataProperty
 from plastron.serializers import CSVSerializer
 from plastron.util import uri_or_curie
@@ -295,23 +295,24 @@ class Command:
 
         count = 0
 
-        for n, filenames in enumerate(file_groups.values(), 1):
+        for n, (rootname, filenames) in enumerate(file_groups.items(), 1):
             if create_pages:
-                # create a page object for each rootname
-                page = Page(title=f'Page {n}', number=n)
+                # create a member object for each rootname
+                # delegate to the item model how to build the member object
+                member = item.get_new_member(rootname, n)
                 # add to the item
-                item.add_member(page)
-                proxy = item.append_proxy(page, title=page.title)
-                # add the access class to the page resources
+                item.add_member(member)
+                proxy = item.append_proxy(member, title=member.title)
+                # add the access class to the member resources
                 if access is not None:
-                    page.rdf_type.append(access)
+                    member.rdf_type.append(access)
                     proxy.rdf_type.append(access)
-                file_parent = page
+                file_parent = member
             else:
                 # files will be added directly to the item
                 file_parent = item
 
-            # add the files to their parent object (either the item or a page)
+            # add the files to their parent object (either the item or a member)
             for filename in filenames:
                 file = File(title=filename)
                 file.source = self.get_source(base_location, filename)

--- a/plastron/models/umd.py
+++ b/plastron/models/umd.py
@@ -1,11 +1,13 @@
 from plastron import pcdm, rdf
 from plastron.authority import LabeledThing
 from plastron.namespaces import dc, dcterms, edm
+from plastron.pcdm import Page
 from plastron.validation import is_edtf_formatted, is_valid_iso639_code
 from rdflib import Namespace
 
 
 umdtype = Namespace('http://vocab.lib.umd.edu/datatype#')
+umdform = Namespace('http://vocab.lib.umd.edu/form#')
 
 
 @rdf.object_property('object_type', dcterms.type)
@@ -97,3 +99,12 @@ class Item(pcdm.Object):
             'max_values': 1
         }
     }
+
+    def get_new_member(self, rootname, number):
+        if str(self.object_type) == str(umdform.pool_reports):
+            if rootname == 'body-processed-redacted':
+                return Page(title=f'Body', number=number)
+            else:
+                return Page(title=f'Attachment {number - 1}', number=number)
+        else:
+            return Page(title=f'Page {number}', number=number)

--- a/plastron/pcdm.py
+++ b/plastron/pcdm.py
@@ -52,6 +52,9 @@ class Object(ore.Aggregation):
             repository.create_files(self)
             repository.create_related(self)
 
+    def get_new_member(self, rootname, number):
+        return Page(title=f'Page {number}', number=number)
+
 
 @rdf.object_property('file_of', pcdm.fileOf)
 @rdf.data_property('mimetype', ebucore.hasMimeType)

--- a/tests/test_umd_model.py
+++ b/tests/test_umd_model.py
@@ -1,5 +1,7 @@
-from plastron.models.umd import Item
+from plastron.models.umd import Item, umdform
 from rdflib import Graph, Literal, Namespace, URIRef
+
+from plastron.pcdm import Page
 
 rdf = (
     '@prefix dcterms: <http://purl.org/dc/terms/> .'
@@ -27,3 +29,25 @@ def test_identifier_distinct_from_accession_number():
     graph = item.graph()
     assert (URIRef(base_uri), dcterms.identifier, Literal('foo')) in graph
     assert (URIRef(base_uri), dcterms.identifier, Literal('1212XN1', datatype=umdtype.accessionNumber)) in graph
+
+
+def test_get_new_member():
+    basic_item = Item()
+    page = basic_item.get_new_member('foo', 1)
+    assert isinstance(page, Page)
+    assert str(page.number) == '1'
+    assert str(page.title) == 'Page 1'
+
+
+def test_get_new_member_pool_report():
+    pool_report = Item(object_type=umdform.pool_reports)
+
+    body = pool_report.get_new_member('body-processed-redacted', 1)
+    assert isinstance(body, Page)
+    assert str(body.number) == '1'
+    assert str(body.title) == 'Body'
+
+    attachment = pool_report.get_new_member('foo', 2)
+    assert isinstance(attachment, Page)
+    assert str(attachment.number) == '2'
+    assert str(attachment.title) == 'Attachment 1'


### PR DESCRIPTION
Calls a "get_new_member" method with the current file rootname and sequence position.

https://issues.umd.edu/browse/LIBFCREPO-950