### PR TITLE
LIBFCREPO-952. Switch to edtf-validate library.

### DIFF
--- a/plastron/validation/__init__.py
+++ b/plastron/validation/__init__.py
@@ -1,17 +1,12 @@
-from edtf import parse_edtf
+from edtf_validate.valid_edtf import is_valid as is_valid_edtf
 from iso639 import is_valid639_1, is_valid639_2
-from pyparsing import ParseException
 
 
 def is_edtf_formatted(value):
     # Allow blank values
     if str(value).strip() == "":
         return True
-    try:
-        parse_edtf(value)
-        return True
-    except ParseException:
-        return False
+    return is_valid_edtf(value)
 
 
 def is_valid_iso639_code(value):

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     install_requires=[
         'bagit',
         'BeautifulSoup4',
-        'edtf',
+        'edtf-validate',
         'iso639',
         'jwcrypto',
         'lxml>3.6.0',

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,3 +1,5 @@
+import pytest
+from plastron.validation import is_edtf_formatted
 from plastron.validation.rules import required
 
 
@@ -18,3 +20,21 @@ def test_required():
     assert required([1.0]) is True
     # only need one non-empty string to pass
     assert required(['foo', '']) is True
+
+
+@pytest.mark.parametrize(
+    'datetime_string',[
+        # dates at 11pm fail in edtf 4.0.1
+        # these pass when using edtf-validate 1.1.0
+        '2020-07-10T23:44:38Z',
+        '2020-07-10T23:15:47Z',
+        '2020-07-20T23:52:29Z',
+        '2020-07-24T23:46:17Z',
+        # same dates, but at 10pm, pass
+        '2020-07-10T22:44:38Z',
+        '2020-07-10T22:15:47Z',
+        '2020-07-20T22:52:29Z',
+        '2020-07-24T22:46:17Z',
+    ])
+def test_is_edtf_formatted(datetime_string):
+    assert is_edtf_formatted(datetime_string) is True


### PR DESCRIPTION
The edtf-validate library passes EDTF datetime strings with an hour of "23".

https://issues.umd.edu/browse/LIBFCREPO-952