### PR TITLE
LIBFCREPO-953. Use the correct rootname for the body of the pool report email.

### DIFF
--- a/plastron/models/umd.py
+++ b/plastron/models/umd.py
@@ -102,7 +102,7 @@ class Item(pcdm.Object):
 
     def get_new_member(self, rootname, number):
         if str(self.object_type) == str(umdform.pool_reports):
-            if rootname == 'body-processed-redacted':
+            if rootname.startswith('body-'):
                 return Page(title=f'Body', number=number)
             else:
                 return Page(title=f'Attachment {number - 1}', number=number)


### PR DESCRIPTION
https://issues.umd.edu/browse/LIBFCREPO-953