### PR TITLE
LIBFCREPO-861. Added "from_vocabulary" validation rules to Item model.

### DIFF
--- a/plastron/models/umd.py
+++ b/plastron/models/umd.py
@@ -57,22 +57,27 @@ class Item(pcdm.Object):
     VALIDATION_RULESET = {
         'object_type': {
             'required': True,
-            'exactly': 1
+            'exactly': 1,
+            'from_vocabulary': 'http://purl.org/dc/dcmitype/',
         },
         'identifier': {
             'required': True
         },
         'rights': {
             'required': True,
-            'exactly': 1
+            'exactly': 1,
+            'from_vocabulary': 'http://vocab.lib.umd.edu/rightsStatement#'
         },
         'title': {
             'required': True,
             'exactly': 1
         },
-        'format': {},
+        'format': {
+            'from_vocabulary': 'http://vocab.lib.umd.edu/form#'
+        },
         'archival_collection': {
-            'max_values': 1
+            'max_values': 1,
+            'from_vocabulary': 'http://vocab.lib.umd.edu/collection#'
         },
         'date': {
             'max_values': 1,


### PR DESCRIPTION
Also parameterized the test_required function, so the assertions all happen in their own tests.

https://issues.umd.edu/browse/LIBFCREPO-861