### PR TITLE
LIBFCREPO-968. Enable Plastron per-import specification of repository structure and relpath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ jobs/
 
 # virtualenv directory
 venv/
+
+.python-version
+

--- a/plastron/commands/__init__.py
+++ b/plastron/commands/__init__.py
@@ -3,3 +3,11 @@ class BaseCommand:
         if config is None:
             config = {}
         self.config = config
+
+    # Enable repository config dictionary to be overridden by the command before
+    # actually creating the respository.
+    #
+    # The default implemented of this method simply returns the provided
+    # repo_config dictionary without change
+    def override_repo_config(self, repo_config, args={}):
+        return repo_config

--- a/plastron/commands/__init__.py
+++ b/plastron/commands/__init__.py
@@ -4,10 +4,12 @@ class BaseCommand:
             config = {}
         self.config = config
 
-    # Enable repository config dictionary to be overridden by the command before
-    # actually creating the respository.
-    #
-    # The default implemented of this method simply returns the provided
-    # repo_config dictionary without change
-    def override_repo_config(self, repo_config, args={}):
+    def repo_config(self, repo_config, args={}):
+        """
+        Enable default repository config dictionary to be overridden by the
+        command before actually creating the repository.
+
+        The default implemention of this method simply returns the provided
+        repo_config dictionary without change
+        """
         return repo_config

--- a/plastron/commands/import.py
+++ b/plastron/commands/import.py
@@ -1,3 +1,4 @@
+import copy
 import csv
 import io
 import logging
@@ -369,6 +370,14 @@ class Command(BaseCommand):
         for _ in self.execute(*args, **kwargs):
             pass
 
+    def override_repo_config(self, repo_config, args):
+        result_config = copy.deepcopy(repo_config)
+
+        if args.structure:
+            result_config['STRUCTURE'] = args.structure
+
+        return result_config
+
     def get_source(self, base_location, path):
         """
         Get an appropriate BinarySource based on the type of ``base_location``.
@@ -477,7 +486,8 @@ class Command(BaseCommand):
             binaries_location=message.args.get('binaries-location'),
             container=message.args.get('container', None),
             extract_text_types=message.args.get('extract-text', None),
-            job_id=message.job_id
+            job_id=message.job_id,
+            structure=message.args.get('structure', None)
         )
 
     def execute(self, repo, args):

--- a/plastron/commands/import.py
+++ b/plastron/commands/import.py
@@ -370,7 +370,12 @@ class Command(BaseCommand):
         for _ in self.execute(*args, **kwargs):
             pass
 
-    def override_repo_config(self, repo_config, args):
+    def repo_config(self, repo_config, args):
+        """
+        Returns a deep copy of the provided repo_config, updated with
+        layout structure and relpath information from the args
+        (if provided).
+        """
         result_config = copy.deepcopy(repo_config)
 
         if args.structure:

--- a/plastron/commands/import.py
+++ b/plastron/commands/import.py
@@ -376,6 +376,9 @@ class Command(BaseCommand):
         if args.structure:
             result_config['STRUCTURE'] = args.structure
 
+        if args.relpath:
+            result_config['RELPATH'] = args.relpath
+
         return result_config
 
     def get_source(self, base_location, path):
@@ -487,7 +490,8 @@ class Command(BaseCommand):
             container=message.args.get('container', None),
             extract_text_types=message.args.get('extract-text', None),
             job_id=message.job_id,
-            structure=message.args.get('structure', None)
+            structure=message.args.get('structure', None),
+            relpath=message.args.get('relpath', None)
         )
 
     def execute(self, repo, args):

--- a/plastron/files.py
+++ b/plastron/files.py
@@ -301,6 +301,8 @@ class ZipFileSource(BinarySource):
             self.file.close()
         if self.source is not None:
             self.source.close()
+        if self.zip_file is not None:
+            self.zip_file = None
 
     def get_zip_file(self):
         if self.zip_file is not None:

--- a/plastron/stomp/listeners.py
+++ b/plastron/stomp/listeners.py
@@ -130,7 +130,7 @@ class MessageProcessor:
 
         args = command.parse_message(message)
 
-        cmd_repo_config = command.override_repo_config(self.repo_config, args)
+        cmd_repo_config = command.repo_config(self.repo_config, args)
 
         repo = Repository(
             config=cmd_repo_config,

--- a/tests/commands/test_base_command.py
+++ b/tests/commands/test_base_command.py
@@ -1,8 +1,8 @@
 from plastron.commands import BaseCommand
 
 
-def test_override_repo_config():
+def test_repo_config():
     # Default implementation simply returns the provided dictionary
     command = BaseCommand()
     repo_config = {'foo': 'bar', 'quuz': 'baz'}
-    assert repo_config is command.override_repo_config(repo_config)
+    assert repo_config is command.repo_config(repo_config)

--- a/tests/commands/test_base_command.py
+++ b/tests/commands/test_base_command.py
@@ -1,0 +1,8 @@
+from plastron.commands import BaseCommand
+
+
+def test_override_repo_config():
+    # Default implementation simply returns the provided dictionary
+    command = BaseCommand()
+    repo_config = {'foo': 'bar', 'quuz': 'baz'}
+    assert repo_config is command.override_repo_config(repo_config)

--- a/tests/test_import_command.py
+++ b/tests/test_import_command.py
@@ -115,31 +115,31 @@ hierarchical_structure_message = PlastronCommandMessage({
 })
 
 
-def test_override_repo_config_uses_structure_from_repo_config_if_no_structure_specified():
+def test_repo_config_uses_structure_from_repo_config_if_no_structure_specified():
     # Flat structure in repo_config
     args = cmd.parse_message(no_structure_message)
 
-    new_repo_config = cmd.override_repo_config(flat_repo_config, args)
+    new_repo_config = cmd.repo_config(flat_repo_config, args)
     assert new_repo_config['STRUCTURE'] == 'flat'
 
     # Hierarchical structure in repo_config
     args = cmd.parse_message(no_structure_message)
 
-    new_repo_config = cmd.override_repo_config(hierarchical_repo_config, args)
+    new_repo_config = cmd.repo_config(hierarchical_repo_config, args)
     assert new_repo_config['STRUCTURE'] == 'hierarchical'
 
 
-def test_override_repo_config_uses_structure_from_message():
+def test_repo_config_uses_structure_from_message():
     # Hierarchical structure specified in message
     args = cmd.parse_message(hierarchical_structure_message)
 
-    new_repo_config = cmd.override_repo_config(flat_repo_config, args)
+    new_repo_config = cmd.repo_config(flat_repo_config, args)
     assert new_repo_config['STRUCTURE'] == 'hierarchical'
 
     # Flat structure specified in message
     args = cmd.parse_message(flat_structure_message)
 
-    new_repo_config = cmd.override_repo_config(hierarchical_repo_config, args)
+    new_repo_config = cmd.repo_config(hierarchical_repo_config, args)
     assert new_repo_config['STRUCTURE'] == 'flat'
 
 
@@ -168,17 +168,17 @@ relpath_message = PlastronCommandMessage({
 })
 
 
-def test_override_repo_config_uses_relpath_from_repo_config_if_no_relpath_specified():
+def test_repo_config_uses_relpath_from_repo_config_if_no_relpath_specified():
     # Flat structure in repo_config
     args = cmd.parse_message(no_relpath_message)
 
-    new_repo_config = cmd.override_repo_config(relpath_repo_config, args)
+    new_repo_config = cmd.repo_config(relpath_repo_config, args)
     assert new_repo_config['RELPATH'] == '/pcdm'
 
 
-def test_override_repo_config_uses_relpath_from_message():
+def test_repo_config_uses_relpath_from_message():
     # Hierarchical structure specified in message
     args = cmd.parse_message(relpath_message)
 
-    new_repo_config = cmd.override_repo_config(flat_repo_config, args)
+    new_repo_config = cmd.repo_config(flat_repo_config, args)
     assert new_repo_config['RELPATH'] == '/test-relpath'

--- a/tests/test_import_command.py
+++ b/tests/test_import_command.py
@@ -1,7 +1,10 @@
+import copy
 from importlib import import_module
 from plastron.files import LocalFileSource, RemoteFileSource, ZipFileSource
+from plastron.http import Repository, FlatCreator, HierarchicalCreator
 from plastron.pcdm import Object
 from plastron.rdf import RDFDataProperty
+from plastron.stomp.messages import PlastronCommandMessage
 
 imp = import_module('plastron.commands.import')
 cmd = imp.Command()
@@ -70,3 +73,71 @@ def test_add_files_unpaged():
     assert len(item.proxies()) == 0
     # all 4 files should be attached directly to the item
     assert len(item.files) == 4
+
+
+# "Flat" layout config
+flat_repo_config = {
+    'REST_ENDPOINT': 'http://example.com/rest',
+    'RELPATH': '/pcdm',
+    'LOG_DIR': 'logs',
+    'STRUCTURE': 'flat'
+}
+
+# "Hierarchical" layout config
+hierarchical_repo_config = {
+    'REST_ENDPOINT': 'http://example.com/rest',
+    'RELPATH': '/dc/2021/2',
+    'LOG_DIR': 'logs',
+    'STRUCTURE': 'hierarchical'
+}
+
+# Import message does not specify structure
+no_structure_message = PlastronCommandMessage({
+    'message-id': 'TEST-no-structure',
+    'PlastronJobId': '1',
+    'PlastronCommand': 'import',
+})
+
+# Import message specifies "flat" structure
+flat_structure_message = PlastronCommandMessage({
+    'message-id': 'TEST-flat-structure',
+    'PlastronJobId': '1',
+    'PlastronCommand': 'import',
+    'PlastronArg-structure': 'flat'
+})
+
+# Import message specified "hierarchical" structure
+hierarchical_structure_message = PlastronCommandMessage({
+    'message-id': 'TEST-hierarchical-structure',
+    'PlastronJobId': '1',
+    'PlastronCommand': 'import',
+    'PlastronArg-structure': 'hierarchical'
+})
+
+
+def test_override_repo_config_uses_structure_from_repo_config_if_no_structure_specified():
+    # Flat structure in repo_config
+    args = cmd.parse_message(no_structure_message)
+
+    new_repo_config = cmd.override_repo_config(flat_repo_config, args)
+    assert new_repo_config['STRUCTURE'] == 'flat'
+
+    # Hierarchical structure in repo_config
+    args = cmd.parse_message(no_structure_message)
+
+    new_repo_config = cmd.override_repo_config(hierarchical_repo_config, args)
+    assert new_repo_config['STRUCTURE'] == 'hierarchical'
+
+
+def test_override_repo_config_uses_structure_from_message():
+    # Hierarchical structure specified in message
+    args = cmd.parse_message(hierarchical_structure_message)
+
+    new_repo_config = cmd.override_repo_config(flat_repo_config, args)
+    assert new_repo_config['STRUCTURE'] == 'hierarchical'
+
+    # Flat structure specified in message
+    args = cmd.parse_message(flat_structure_message)
+
+    new_repo_config = cmd.override_repo_config(hierarchical_repo_config, args)
+    assert new_repo_config['STRUCTURE'] == 'flat'

--- a/tests/test_import_command.py
+++ b/tests/test_import_command.py
@@ -141,3 +141,44 @@ def test_override_repo_config_uses_structure_from_message():
 
     new_repo_config = cmd.override_repo_config(hierarchical_repo_config, args)
     assert new_repo_config['STRUCTURE'] == 'flat'
+
+
+# "relpath" layout config
+relpath_repo_config = {
+    'REST_ENDPOINT': 'http://example.com/rest',
+    'RELPATH': '/pcdm',
+    'LOG_DIR': 'logs',
+    'STRUCTURE': 'flat'
+}
+
+# Import message without relpath
+no_relpath_message = PlastronCommandMessage({
+    'message-id': 'TEST-without-relpath',
+    'PlastronJobId': '1',
+    'PlastronCommand': 'import',
+    'PlastronArg-structure': 'flat'
+})
+
+relpath_message = PlastronCommandMessage({
+    'message-id': 'TEST-with-relpath',
+    'PlastronJobId': '1',
+    'PlastronCommand': 'import',
+    'PlastronArg-structure': 'flat',
+    'PlastronArg-relpath': '/test-relpath'
+})
+
+
+def test_override_repo_config_uses_relpath_from_repo_config_if_no_relpath_specified():
+    # Flat structure in repo_config
+    args = cmd.parse_message(no_relpath_message)
+
+    new_repo_config = cmd.override_repo_config(relpath_repo_config, args)
+    assert new_repo_config['RELPATH'] == '/pcdm'
+
+
+def test_override_repo_config_uses_relpath_from_message():
+    # Hierarchical structure specified in message
+    args = cmd.parse_message(relpath_message)
+
+    new_repo_config = cmd.override_repo_config(flat_repo_config, args)
+    assert new_repo_config['RELPATH'] == '/test-relpath'


### PR DESCRIPTION
Modified "BaseCommand" class, adding an "override_repo_config" method to allow subclasses to override the generic repository config with a configuration supplied by the command.

In "plastron/commands/import.py", used the "override_repo_config" method to set the layout structure and relpath for the repository, based on the contents of the import message.

In "plastron/stomp/listeners.py" moved the initialization of the "repo" Repository after calling the "override_repo_config" method for the command, so that it will use the overridden configuration.

Also fixed (with Peter Eichman's help) an issue where using "zip" files in the local development environment were not being closed and reopened as expected, leading to an inability to load in binaries from the zip file.

https://issues.umd.edu/browse/LIBFCREPO-968