### PR TITLE
LIBFCREPO-971. Clear RemoteFileSource references on close

### DIFF
--- a/plastron/files.py
+++ b/plastron/files.py
@@ -217,10 +217,13 @@ class RemoteFileSource(BinarySource):
         """
         if self.file is not None:
             self.file.close()
+            self.file = None
         if self.sftp_client is not None:
             self.sftp_client.close()
+            self.sftp_client = None
         if self.ssh_client is not None:
             self.ssh_client.close()
+            self.ssh_client = None
 
     def ssh(self):
         if self.ssh_client is None:


### PR DESCRIPTION
When closing, clear the references held by RemoteFileSource, so that
they are not accidentally used again.

https://issues.umd.edu/browse/LIBFCREPO-971