### PR TITLE
LIBFCREPO-977. Updated Docker configuration to work with "umd-fcrepo" Docker stack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,7 @@ exports/
 logs/
 msg/
 plastron.egg-info/
+
+# SSH Keys
+archelon_id
+archelon_id.pub

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,7 @@ venv/
 
 .python-version
 
+# SSH Keys
+archelon_id
+archelon_id.pub
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,18 @@
 version: "3.7"
 services:
   plastrond:
-    image: plastrond
+    image: docker.lib.umd.edu/plastrond
     configs:
       - source: plastrond
         target: /etc/plastrond.yml
-    secrets:
-      - batchloader.pem
-      - batchloader.key
-      - repository.pem
     volumes:
       - plastrond:/var/opt/plastron
 configs:
   plastrond:
     file: docker-plastron.yml
-secrets:
-  batchloader.pem:
-    external: true
-  batchloader.key:
-    external: true
-  repository.pem:
-    external: true
 volumes:
   plastrond:
+networks:
+  default:
+    external: true
+    name: umd-fcrepo_default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,18 @@ services:
     configs:
       - source: plastrond
         target: /etc/plastrond.yml
+      - source: archelon_id
+        target: /etc/plastron/auth/archelon_id
+        mode: 0400
     volumes:
       - plastrond:/var/opt/plastron
 configs:
   plastrond:
     file: docker-plastron.yml
+  archelon_id:
+    # Private key for archelon SFTP
+    # The corresponding public key should be added to Archelon
+    file: archelon_id
 volumes:
   plastrond:
 networks:

--- a/docker-plastron.yml
+++ b/docker-plastron.yml
@@ -1,15 +1,14 @@
 REPOSITORY:
-  REST_ENDPOINT: https://fcrepolocal/fcrepo/rest
+  REST_ENDPOINT: http://repository:8080/rest
+  REPO_EXTERNAL_URL: http://localhost:8080/rest
   RELPATH: /pcdm
-  CLIENT_CERT: /run/secrets/batchloader.pem
-  CLIENT_KEY: /run/secrets/batchloader.key
-  SERVER_CERT: /run/secrets/repository.pem
+  JWT_SECRET: <REPLACE WITH JWT_SECRET FROM umd-fcrepo>
   LOG_DIR: /var/log/plastron
 MESSAGE_BROKER:
-  SERVER: fcrepolocal:61613
+  SERVER: activemq:61613
   MESSAGE_STORE_DIR: /var/opt/plastron/msg/export
   DESTINATIONS:
     JOBS: /queue/plastron.jobs
-    JOB_STATUS: /topic/plastron.jobs.status
-    COMPLETED_JOBS: /queue/plastron.jobs.completed
+    JOB_PROGRESS: /topic/plastron.jobs.progress
+    JOB_STATUS: /queue/plastron.jobs.status
     SYNCHRONOUS_JOBS: /queue/plastron.jobs.synchronous

--- a/docker-plastron.yml
+++ b/docker-plastron.yml
@@ -12,3 +12,8 @@ MESSAGE_BROKER:
     JOB_PROGRESS: /topic/plastron.jobs.progress
     JOB_STATUS: /queue/plastron.jobs.status
     SYNCHRONOUS_JOBS: /queue/plastron.jobs.synchronous
+COMMANDS:
+  EXPORT:
+    SSH_PRIVATE_KEY: /etc/plastron/auth/archelon_id
+  IMPORT:
+    SSH_PRIVATE_KEY: /etc/plastron/auth/archelon_id

--- a/docker-plastron.yml
+++ b/docker-plastron.yml
@@ -1,6 +1,6 @@
 REPOSITORY:
   REST_ENDPOINT: http://repository:8080/rest
-  REPO_EXTERNAL_URL: http://localhost:8080/rest
+  REPO_EXTERNAL_URL: http://fcrepo-local:8080/rest
   RELPATH: /pcdm
   JWT_SECRET: <REPLACE WITH JWT_SECRET FROM umd-fcrepo>
   LOG_DIR: /var/log/plastron

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -17,18 +17,13 @@ plastrond -c <config_file>
 # if you are not already running in swarm mode
 docker swarm init
 
-# create secrets from the SSL client and server certs;
-# assume that $FCREPO_VAGRANT and $PLASTRON are your
-# fcrepo-vagrant and plastron source code directories
-cd $FCREPO_VAGRANT
-bin/clientcert batchloader $PLASTRON/batchloader
-cd $PLASTRON
-docker secret create batchloader.pem batchloader.pem 
-docker secret create batchloader.key batchloader.key 
-docker secret create repository.pem $FCREPO_VAGRANT/dist/fcrepo/ssl/crt/fcrepolocal.crt 
-
 # build the image
 docker build -t plastrond .
+
+# Create an "archelon_id" private/public key pair
+# The Archelon instance should be configured with "archelon_id.pub" as the
+# PLASTRON_PUBLIC_KEY
+ssh-keygen -q -t rsa -N '' -f archelon_id
 
 # deploy the stack
 docker stack deploy -c docker-compose.yml plastrond

--- a/plastron/http.py
+++ b/plastron/http.py
@@ -98,7 +98,7 @@ class Repository:
         # Extract endpoint URL components for managing forward host
         parsed_endpoint_url = urlsplit(self.endpoint)
         endpoint_proto = parsed_endpoint_url.scheme
-        endpoint_host = parsed_endpoint_url.hostname
+        endpoint_host = parsed_endpoint_url.netloc
         self.endpoint_base_path = parsed_endpoint_url.path
 
         # default container path
@@ -125,7 +125,7 @@ class Repository:
         if repo_external_url is not None:
             parsed_repo_external_url = urlsplit(repo_external_url)
             proto = parsed_repo_external_url.scheme
-            host = parsed_repo_external_url.hostname
+            host = parsed_repo_external_url.netloc
             if (proto != endpoint_proto) or (host != endpoint_host):
                 # We are forwarding
                 self.forwarded_host = host

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -153,6 +153,21 @@ def test_forwarded_params_are_optional(repo_base_config):
     assert not ('X-Forwarded-Proto' in repository.session.headers.keys())
 
 
+def test_forwarded_endpoint_should_include_port_if_present(repo_base_config):
+    config = repo_base_config
+    config['REPO_EXTERNAL_URL'] = 'https://forwarded-host.com:1234/'
+
+    repository = Repository(config)
+
+    assert repository.is_forwarded()
+    assert ('X-Forwarded-Host' in repository.session.headers.keys())
+    assert ('X-Forwarded-Proto' in repository.session.headers.keys())
+    assert 'forwarded-host.com:1234' == repository.session.headers['X-Forwarded-Host']
+    assert 'https' == repository.session.headers['X-Forwarded-Proto']
+
+    assert repository.forwarded_endpoint == 'https://forwarded-host.com:1234/rest'
+
+
 def test_forwarded_params_not_used_if_rest_endpoint_and_fcrepo_base_url_match(repo_base_config):
     config = repo_base_config
     repo_base_config['REPO_EXTERNAL_URL'] = 'http://base-host.com:8080/'


### PR DESCRIPTION
Updated the Plastron Docker configuration so that it can run as a "plastron" Docker stack, in concert with the "umd-fcrepo" Docker stack.

Modified the "plastron/http.py" file to support endpoints that include a hostname and port, instead of just a hostname.

https://issues.umd.edu/browse/LIBFCREPO-977