### PR TITLE
LIBFCREPO-996. Added a "create" command.

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,7 +6,7 @@
 $ plastron --help
 usage: plastron [-h] (-r REPO | -c CONFIG_FILE | -V) [-v] [-q]
                 [--on-behalf-of DELEGATED_USER]
-                {annotate,delete,del,rm,echo,export,extractocr,imgsize,import,list,ls,load,mkcol,ping,reindex,stub,update}
+                {annotate,create,delete,del,rm,echo,export,extractocr,imgsize,import,list,ls,load,mkcol,ping,reindex,stub,update}
                 ...
 
 Batch operation tool for Fedora 4.
@@ -23,7 +23,7 @@ optional arguments:
                         delegate repository operations to this username
 
 commands:
-  {annotate,delete,del,rm,echo,export,extractocr,imgsize,import,list,ls,load,mkcol,ping,reindex,stub,update}
+  {annotate,create,delete,del,rm,echo,export,extractocr,imgsize,import,list,ls,load,mkcol,ping,reindex,stub,update}
 ```
 
 ### Check version
@@ -54,7 +54,42 @@ optional arguments:
   -h, --help  show this help message and exit
 ```
 
+### Create (create)
+
+```
+$ plastron create -h
+usage: plastron create [-h] [-D PREDICATE VALUE] [-O PREDICATE VALUE]
+                       [-T TYPE] [--collection NAME] [--container PATH]
+                       [path]
+
+Create a resource in the repository
+
+positional arguments:
+  path                  path to the new resource
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -D PREDICATE VALUE, --data-property PREDICATE VALUE
+                        an RDF data property to set on the newly created
+                        resource; VALUE is treated as a Literal; repeatable
+  -O PREDICATE VALUE, --object-property PREDICATE VALUE
+                        an RDF object property to set on the newly created
+                        resource; VALUE is treated as a CURIE or URIRef;
+                        repeatable
+  -T TYPE, --rdf-type TYPE
+                        RDF type to add to the newly created resource;
+                        equivalent to "-O rdf:type TYPE"; TYPE is treated as a
+                        CURIE or URIRef; repeatable
+  --collection NAME     shortcut for "-T pcdm:collection -D dcterms:title
+                        NAME"
+  --container PATH      parent container for the new resource; use this to
+                        create a new resource with a repository-generated
+                        identifier
+```
+
 ### Create Collection (mkcol)
+
+**DEPRECATED:** Use `plastron create --collection` instead.
 
 ```
 $ plastron mkcol --help

--- a/plastron/commands/create.py
+++ b/plastron/commands/create.py
@@ -1,0 +1,183 @@
+import logging
+from argparse import Namespace
+from pathlib import Path
+from plastron.commands import BaseCommand
+from plastron.http import Repository
+from plastron.namespaces import dcterms, get_manager, pcdm, rdf
+from rdflib import Graph, Literal, URIRef
+from rdflib.util import from_n3
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+manager = get_manager()
+
+
+def configure_cli(subparsers):
+    parser = subparsers.add_parser(
+        name='create',
+        description='Create a resource in the repository'
+    )
+    parser.add_argument(
+        '-D', '--data-property',
+        help=(
+            'an RDF data property to set on the newly created resource; '
+            'VALUE is treated as a Literal; repeatable'
+        ),
+        action='append',
+        nargs=2,
+        dest='data_properties',
+        metavar=('PREDICATE', 'VALUE'),
+        default=[]
+    )
+    parser.add_argument(
+        '-O', '--object-property',
+        help=(
+            'an RDF object property to set on the newly created resource; '
+            'VALUE is treated as a CURIE or URIRef; repeatable'
+        ),
+        action='append',
+        nargs=2,
+        dest='object_properties',
+        metavar=('PREDICATE', 'VALUE'),
+        default=[]
+    )
+    parser.add_argument(
+        '-T', '--rdf-type',
+        help=(
+            'RDF type to add to the newly created resource; equivalent to '
+            '"-O rdf:type TYPE"; TYPE is treated as a CURIE or URIRef; '
+            'repeatable'
+        ),
+        action='append',
+        dest='types',
+        metavar='TYPE',
+        default=[]
+    )
+    parser.add_argument(
+        '--collection',
+        help='shortcut for "-T pcdm:collection -D dcterms:title NAME"',
+        metavar='NAME',
+        action='store',
+        dest='collection_name'
+    )
+    container_or_path = parser.add_mutually_exclusive_group(required=True)
+    container_or_path.add_argument(
+        'path',
+        nargs='?',
+        help='path to the new resource',
+        action='store'
+    )
+    container_or_path.add_argument(
+        '--container',
+        help=(
+            'parent container for the new resource; use this to create a new '
+            'resource with a repository-generated identifier'
+        ),
+        metavar='PATH',
+        action='store'
+    )
+    parser.set_defaults(cmd_name='create')
+
+
+def paths_to_create(repo: Repository, path: Path) -> List[Path]:
+    if repo.path_exists(str(path)):
+        return []
+    to_create = [path]
+    for ancestor in path.parents:
+        if not repo.path_exists(str(ancestor)):
+            to_create.insert(0, ancestor)
+    return to_create
+
+
+def parse_data_property(p: str, o: str):
+    return [from_n3(p, nsm=manager), Literal(o)]
+
+
+def parse_object_property(p: str, o: str):
+    predicate = from_n3(p, nsm=manager)
+    obj = from_curie_or_uri(o)
+    return [predicate, obj]
+
+
+def from_curie_or_uri(o: str):
+    try:
+        return from_n3(o, nsm=manager)
+    except KeyError:
+        # not a known prefix, assume it is a URI
+        return URIRef(o)
+
+
+def serialize(graph: Graph, **kwargs):
+    logger.info('Including properties:')
+    for _, p, o in graph:
+        logger.info(f'  {p.n3(namespace_manager=manager)} {o.n3(namespace_manager=manager)}')
+    return graph.serialize(**kwargs)
+
+
+class Command(BaseCommand):
+    def __call__(self, repo: Repository, args: Namespace):
+        self.repo = repo
+
+        properties = [parse_data_property(p, o) for p, o in args.data_properties] \
+            + [parse_object_property(p, o) for p, o in args.object_properties]
+
+        if args.collection_name is not None:
+            properties.append([rdf.type, pcdm.Collection])
+            properties.append([dcterms.title, Literal(args.collection_name)])
+
+        if len(args.types) > 0:
+            for type in args.types:
+                properties.append([rdf.type, from_curie_or_uri(type)])
+
+        graph = Graph(namespace_manager=manager)
+        for p, o in properties:
+            graph.add((URIRef(''), p, o))
+
+        if args.path is not None:
+            self.create_at_path(Path(args.path), graph)
+        elif args.container is not None:
+            self.create_in_container(Path(args.container), graph)
+
+    def create_at_path(self, target_path: Path, graph: Graph = None):
+        all_paths = paths_to_create(self.repo, target_path)
+
+        if len(all_paths) == 0:
+            logger.info(f'{target_path} already exists')
+            return
+
+        resource = None
+        for path in all_paths:
+            logger.info(f'Creating {path}')
+            if path == target_path and graph:
+                resource = self.repo.create(
+                    path=str(path),
+                    headers={
+                        'Content-Type': 'text/turtle'
+                    },
+                    data=serialize(graph, format='turtle')
+                )
+            else:
+                resource = self.repo.create(path=str(path))
+
+            logger.info(f'Created {resource}')
+
+        return resource
+
+    def create_in_container(self, container_path: Path, graph: Graph = None):
+        if not self.repo.path_exists(str(container_path)):
+            logger.error(f'Container path "{container_path}" not found')
+            return
+        if graph:
+            resource = self.repo.create(
+                container_path=str(container_path),
+                headers={
+                    'Content-Type': 'text/turtle'
+                },
+                data=serialize(graph, format='turtle')
+            )
+        else:
+            resource = self.repo.create(container_path=str(container_path))
+
+        logger.info(f'Created {resource}')
+        return resource

--- a/plastron/commands/mkcol.py
+++ b/plastron/commands/mkcol.py
@@ -35,6 +35,9 @@ def configure_cli(subparsers):
 
 class Command(BaseCommand):
     def __call__(self, fcrepo, args):
+        logger.warning('The "mkcol" command is deprecated and will be removed in a future release.')
+        logger.warning(f'Use: plastron create --container "{fcrepo.relpath}" --collection "{args.name}"')
+
         if args.notransactions:
             try:
                 collection = pcdm.Collection()

--- a/tests/commands/test_create.py
+++ b/tests/commands/test_create.py
@@ -1,0 +1,88 @@
+import re
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from flask import url_for
+from http_server_mock import HttpServerMock
+
+from plastron.commands import create
+from plastron.http import Repository
+
+
+@pytest.fixture
+def repo_app():
+    app = HttpServerMock(__name__, is_alive_route='/')
+    app.config['RESOURCES'] = set()
+
+    @app.route('/')
+    def root():
+        return 'Mock fcrepo server', 200
+
+    @app.route('/<path:repo_path>', methods=['GET'])
+    def get_resource(repo_path):
+        if repo_path in app.config['RESOURCES']:
+            return repo_path, 200
+        else:
+            return 'Not Found', 404
+
+    @app.route('/<path:repo_path>', methods=['PUT'])
+    def put_resource(repo_path):
+        uri = url_for('get_resource', _external=True, repo_path=repo_path)
+        app.config['RESOURCES'].add(repo_path)
+        return uri, 201, {'Location': uri}
+
+    @app.route('/<path:repo_path>', methods=['POST'])
+    def post_resource(repo_path):
+        uuid = str(uuid4())
+        pairtree = [uuid[0:2], uuid[2:4], uuid[4:6], uuid[6:8]]
+        path = str(Path(repo_path, *pairtree, uuid))
+        app.config['RESOURCES'].add(path)
+        uri = url_for('get_resource', _external=True, repo_path=path)
+        return uri, 201, {'Location': uri}
+
+    return app
+
+
+@pytest.fixture
+def repo_base_config():
+    """Required parameters for Repository configuration"""
+    return {
+        'REST_ENDPOINT': 'http://localhost:9999',
+        'RELPATH': '/pcdm',
+        'LOG_DIR': '/logs',
+        'AUTH_TOKEN': 'foobar'
+    }
+
+
+def test_create_at_path(repo_base_config, repo_app):
+    cmd = create.Command()
+    cmd.repo = Repository(repo_base_config)
+    with repo_app.run('localhost', 9999):
+        assert not cmd.repo.path_exists('/foo')
+        cmd.create_at_path(Path('/foo'))
+        assert cmd.repo.path_exists('/foo')
+
+
+def test_create_at_path_nested(repo_base_config, repo_app):
+    cmd = create.Command()
+    cmd.repo = Repository(repo_base_config)
+    with repo_app.run('localhost', 9999):
+        assert not cmd.repo.path_exists('/foo')
+        assert not cmd.repo.path_exists('/foo/bar')
+        assert not cmd.repo.path_exists('/foo/bar/baz')
+        cmd.create_at_path(Path('/foo/bar/baz'))
+        assert cmd.repo.path_exists('/foo')
+        assert cmd.repo.path_exists('/foo/bar')
+        assert cmd.repo.path_exists('/foo/bar/baz')
+
+
+def test_create_in_container(repo_base_config, repo_app):
+    cmd = create.Command()
+    cmd.repo = Repository(repo_base_config)
+    with repo_app.run('localhost', 9999):
+        cmd.create_at_path(Path('/foo'))
+        assert cmd.repo.path_exists('/foo')
+        resource = cmd.create_in_container(Path('/foo'))
+        assert resource.uri
+        assert re.match('http://localhost:9999/foo/.+', str(resource.uri))


### PR DESCRIPTION
Can create at a specific path (PUT) or with an auto-generated path inside a given container (POST).

- use the "-D" option to set data properties
- use the "-O" option to set object properties
- use the "-T" option to set RDF type(s)
- use the "--collection" option as a shortcut to create a pcdm:Collection with a dcterms:title

Includes tests against a mock repository app; also updated the test_transaction tests to use the Flask app-factory-fixture style.

Marked the mkcol command as deprecated.

https://issues.umd.edu/browse/LIBFCREPO-996