### PR TITLE
LIBFCREPO-1039. Fixed "import" command in Plastron CLI

### DIFF
--- a/plastron/cli.py
+++ b/plastron/cli.py
@@ -21,6 +21,18 @@ logger = logging.getLogger(__name__)
 now = datetime.utcnow().strftime('%Y%m%d%H%M%S')
 
 
+def load_commands(subparsers):
+    # load all defined subcommands from the plastron.commands package, using
+    # introspection
+    command_modules = {}
+    for finder, name, ispkg in iter_modules(commands.__path__):
+        module = import_module(commands.__name__ + '.' + name)
+        if hasattr(module, 'configure_cli'):
+            module.configure_cli(subparsers)
+            command_modules[name] = module
+    return command_modules
+
+
 def main():
     """Parse args and handle options."""
 
@@ -69,13 +81,7 @@ def main():
 
     subparsers = parser.add_subparsers(title='commands')
 
-    # load all defined subcommands from the plastron.commands package
-    command_modules = {}
-    for finder, name, ispkg in iter_modules(commands.__path__):
-        module = import_module(commands.__name__ + '.' + name)
-        if hasattr(module, 'configure_cli'):
-            module.configure_cli(subparsers)
-            command_modules[name] = module
+    command_modules = load_commands(subparsers)
 
     # parse command line args
     args = parser.parse_args()

--- a/plastron/cli.py
+++ b/plastron/cli.py
@@ -26,7 +26,14 @@ def load_commands(subparsers):
     # introspection
     command_modules = {}
     for finder, name, ispkg in iter_modules(commands.__path__):
-        module = import_module(commands.__name__ + '.' + name)
+        module_name = name
+        if module_name == "importcommand":
+            # Special case handling for "importcommand", because "import" is
+            # a Python reserved word that is not usable as a module name,
+            # while we want "import" to be the Plastron command
+            name = "import"
+
+        module = import_module(commands.__name__ + '.' + module_name)
         if hasattr(module, 'configure_cli'):
             module.configure_cli(subparsers)
             command_modules[name] = module

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,19 @@
+from argparse import ArgumentParser
+from plastron.cli import load_commands
+from plastron.commands import importcommand
+
+
+def test_find_commands_correctly_handles_import_command():
+    # The "import" command is special, because the name of the command
+    # is "import", but the module is "importcommand"
+    parser = ArgumentParser(
+        prog='plastron',
+        description='Batch operation tool for Fedora 4.'
+    )
+    parser.set_defaults(cmd_name=None)
+
+    subparsers = parser.add_subparsers(title='commands')
+
+    command_modules = load_commands(subparsers)
+    assert "import" in command_modules
+    assert command_modules["import"] == importcommand


### PR DESCRIPTION
* Refactored the Plastron command loading functionality into a
"load_commands" function in "plastron/cli.py" to make it more amenable
to testing.
* Modified the "load_commands" function in "plastron/cli.py" to handle the
"importcommand" module, allowing the name used on the command-line to
be "import".

https://issues.umd.edu/browse/LIBFCREPO-1039