### PR TITLE
LIBFCREPO-1041. Configured docker-plastron.yml to use /fcrepo/rest

### DIFF
--- a/docker-plastron.yml
+++ b/docker-plastron.yml
@@ -1,6 +1,6 @@
 REPOSITORY:
-  REST_ENDPOINT: http://repository:8080/rest
-  REPO_EXTERNAL_URL: http://fcrepo-local:8080/rest
+  REST_ENDPOINT: http://repository:8080/fcrepo/rest
+  REPO_EXTERNAL_URL: http://fcrepo-local:8080/fcrepo/rest
   RELPATH: /pcdm
   JWT_SECRET: <REPLACE WITH JWT_SECRET FROM umd-fcrepo>
   LOG_DIR: /var/log/plastron


### PR DESCRIPTION
Configured the "docker-plastron.yml" file to use the "/fcrepo/rest"
endpoint that is now used for the Docker setup.

https://issues.umd.edu/browse/LIBFCREPO-1041