### PR TITLE
LIBFCREPO-1035. Record invalid import items separately from valid but dropped items

### DIFF
--- a/docs/import.md
+++ b/docs/import.md
@@ -101,10 +101,32 @@ The `completed.log.csv` has the following columns:
 You may specify a job ID on the command line using the `--job-id` argument. If
 you do not provide one, Plastron will generate one using the current timestamp.
 
-If, during a run, an item cannot be loaded for any reason, that item is recorded
-to a dropped item log for that run, along with the reason for the failure.
+### Import Failures
 
-Dropped item logs have the following columns:
+Items that cannot be imported during a run are categorized as either
+"invalid" or "failed".
+
+#### Invalid Items
+
+Invalid items are items that fail metadata validation, and are recorded in
+the "dropped-invalid" log for that run, along with the reason for the failure.
+
+Invalid items will likely require changes to the source CSV file, or some other
+action on the part of the user (such as adding missing files).
+
+#### Failed Items
+
+Failed items are items that could not be imported due to problems adding
+records to the repository, and are recorded in the "dropped-failed" log for that
+run, along with the reason for the failure.
+
+Some failures may occcur due to transient network issues. In those cases,
+resuming the import should allow those items to tbe added.
+
+### Dropped Item Logs
+
+Both the "dropped-invalid" and "dropped-failed" item logs have the following
+columns:
 
 | Name      | Purpose |
 |-----------|---------|
@@ -146,8 +168,10 @@ plastron -c repo.yml import \
     --resume
 ```
 
-Any dropped items from a particular run will be recorded in
-`{JOBS_DIR}/import-foo-1/dropped-{run_timestamp}.csv`.
+Any dropped items from a particular run will be recorded in:
+
+* `{JOBS_DIR}/import-foo-1/dropped-failed-{run_timestamp}.csv`
+* `{JOBS_DIR}/import-foo-1/dropped-invalid-{run_timestamp}.csv`
 
 ## Percentage Imports
 

--- a/plastron/commands/importcommand.py
+++ b/plastron/commands/importcommand.py
@@ -459,8 +459,6 @@ class Command(BaseCommand):
         for row in metadata:
             repo_changeset = self.create_repo_changeset(args, repo, metadata, row)
             item = repo_changeset.item
-            delete_graph = repo_changeset.delete_graph
-            insert_graph = repo_changeset.insert_graph
 
             # count the number of files referenced in this row
             metadata.files += len(row.filenames)
@@ -505,9 +503,8 @@ class Command(BaseCommand):
                 continue
 
             try:
-                self.update_repo(args, job, repo, metadata, row, item,
-                                 insert_graph, delete_graph, created_uris,
-                                 updated_uris)
+                self.update_repo(args, job, repo, metadata, row, repo_changeset,
+                                 created_uris, updated_uris)
             except FailureException as e:
                 metadata.errors += 1
                 logger.error(f'{item} import failed: {e}')
@@ -649,7 +646,11 @@ class Command(BaseCommand):
 
         return RepoChangeset(item, insert_graph, delete_graph)
 
-    def update_repo(self, args, job, repo, metadata, row, item, insert_graph, delete_graph, created_uris, updated_uris):
+    def update_repo(self, args, job, repo, metadata, row, repo_changeset, created_uris, updated_uris):
+        item = repo_changeset.item
+        delete_graph = repo_changeset.delete_graph
+        insert_graph = repo_changeset.insert_graph
+
         if not item.created:
             # if an item is new, don't construct a SPARQL Update query
             # instead, just create and update normally

--- a/plastron/commands/importcommand.py
+++ b/plastron/commands/importcommand.py
@@ -504,7 +504,7 @@ class Command(BaseCommand):
                 reasons = [' '.join(str(f) for f in outcome) for outcome in report.failed()]
                 if len(missing_files) > 0:
                     reasons.extend(f'Missing file: {f}' for f in missing_files)
-                job.drop_failed(
+                job.drop_invalid(
                     item=item,
                     line_reference=row.line_reference,
                     reason=f'Validation failures: {"; ".join(reasons)}'
@@ -536,7 +536,8 @@ class Command(BaseCommand):
 
         logger.info(f'Skipped {metadata.skipped} items')
         logger.info(f'Completed {len(job.completed_log) - initial_completed_item_count} items')
-        logger.info(f'Dropped {len(job.dropped_failed_log)} items')
+        logger.info(f'Dropped {len(job.dropped_invalid_log)} invalid items')
+        logger.info(f'Dropped {len(job.dropped_failed_log)} failed items')
 
         logger.info(f"Found {metadata.valid} valid items")
         logger.info(f"Found {metadata.invalid} invalid items")

--- a/plastron/commands/importcommand.py
+++ b/plastron/commands/importcommand.py
@@ -504,7 +504,7 @@ class Command(BaseCommand):
                 reasons = [' '.join(str(f) for f in outcome) for outcome in report.failed()]
                 if len(missing_files) > 0:
                     reasons.extend(f'Missing file: {f}' for f in missing_files)
-                job.drop(
+                job.drop_failed(
                     item=item,
                     line_reference=row.line_reference,
                     reason=f'Validation failures: {"; ".join(reasons)}'
@@ -521,7 +521,7 @@ class Command(BaseCommand):
             except FailureException as e:
                 metadata.errors += 1
                 logger.error(f'{item} import failed: {e}')
-                job.drop(item, row.line_reference, reason=str(e))
+                job.drop_failed(item, row.line_reference, reason=str(e))
 
             # update the status
             now = datetime.now().timestamp()
@@ -536,7 +536,7 @@ class Command(BaseCommand):
 
         logger.info(f'Skipped {metadata.skipped} items')
         logger.info(f'Completed {len(job.completed_log) - initial_completed_item_count} items')
-        logger.info(f'Dropped {len(job.dropped_log)} items')
+        logger.info(f'Dropped {len(job.dropped_failed_log)} items')
 
         logger.info(f"Found {metadata.valid} valid items")
         logger.info(f"Found {metadata.invalid} invalid items")

--- a/plastron/commands/importcommand.py
+++ b/plastron/commands/importcommand.py
@@ -383,9 +383,22 @@ class Command(BaseCommand):
 
     @staticmethod
     def create_import_job(job_id, jobs_dir):
+        """
+        Returns an ImportJob with the given parameters
+
+        :param job_id: the job id for the import job
+        :param jobs_dir: the base directory where job information is stored
+        :return: An ImportJob with the given parameters
+        """
         return ImportJob(job_id, jobs_dir=jobs_dir)
 
     def execute(self, repo, args):
+        """
+        Performs the import
+
+        :param repo: the repository configuration
+        :param args: the command-line arguments
+        """
         start_time = datetime.now().timestamp()
 
         if args.resume and args.job_id is None:
@@ -542,6 +555,18 @@ class Command(BaseCommand):
         }
 
     def create_repo_changeset(self, args, repo, metadata, row):
+        """
+        Returns a RepoChangeset of the changes to make to the repository
+
+        :param args: the arguments from the command-line
+        :param repo: the repository configuration
+        :param metadata: A plastron.jobs.MetadataRows object representing the
+                          CSV file for the import
+        :param row: A single plastron.jobs.Row object representing the row
+                     to import
+        :return: A RepoChangeSet encapsulating the changes to make to the
+                repository.
+        """
         if args.validate_only:
             # create an empty object to validate without fetching from the repo
             item = metadata.model_class(uri=row.uri)
@@ -647,6 +672,23 @@ class Command(BaseCommand):
         return RepoChangeset(item, insert_graph, delete_graph)
 
     def update_repo(self, args, job, repo, metadata, row, repo_changeset, created_uris, updated_uris):
+        """
+        Updates the repository with the given RepoChangeSet
+
+        :param args: the arguments from the command-line
+        :param job: The ImportJob
+        :param repo: the repository configuration
+        :param metadata: A plastron.jobs.MetadataRows object representing the
+                          CSV file being imported
+        :param row: A single plastron.jobs.Row object representing the row
+                     being imported
+        :param repo_changeset: The RepoChangeSet object describing the changes
+                                 to make to the repository.
+        :param created_uris: Accumulator storing a list of created URIS. This
+                              variable is MODIFIED by this method.
+        :param updated_uris: Accumulator storing a list of updated URIS. This
+                              variable is MODIFIED by this method.
+        """
         item = repo_changeset.item
         delete_graph = repo_changeset.delete_graph
         insert_graph = repo_changeset.insert_graph
@@ -713,6 +755,15 @@ class Command(BaseCommand):
 
 
 class RepoChangeset:
+    """
+    Data object encapsulating the set of changes that need to be made to
+    the repository for a single import
+
+    :param item: a repository model object (i.e. from plastron.models) from
+                 the repository (or an empty object if validation only)
+    :param insert_graph: an RDF Graph object to insert into the repository
+    :param delete_graph: an RDF Graph object to delete from the repository
+    """
     def __init__(self, item, insert_graph, delete_graph):
         self._item = item
         self._insert_graph = insert_graph

--- a/plastron/commands/importcommand.py
+++ b/plastron/commands/importcommand.py
@@ -352,7 +352,6 @@ class Command(BaseCommand):
 
         return count
 
-
     @staticmethod
     def parse_message(message):
         access = message.args.get('access')
@@ -729,6 +728,7 @@ class RepoChangeset:
     @property
     def delete_graph(self):
         return self._delete_graph
+
 
 @rdf.object_property('derived_from', prov.wasDerivedFrom)
 class FullTextAnnotation(Annotation):

--- a/plastron/commands/importcommand.py
+++ b/plastron/commands/importcommand.py
@@ -352,6 +352,7 @@ class Command(BaseCommand):
 
         return count
 
+
     @staticmethod
     def parse_message(message):
         access = message.args.get('access')
@@ -381,6 +382,10 @@ class Command(BaseCommand):
             relpath=message.args.get('relpath', None)
         )
 
+    @staticmethod
+    def create_import_job(job_id, jobs_dir):
+        return ImportJob(job_id, jobs_dir=jobs_dir)
+
     def execute(self, repo, args):
         start_time = datetime.now().timestamp()
 
@@ -391,7 +396,7 @@ class Command(BaseCommand):
             # TODO: generate a more unique id? add in user and hostname?
             args.job_id = f"import-{datetimestamp()}"
 
-        job = ImportJob(args.job_id, jobs_dir=self.jobs_dir)
+        job = Command.create_import_job(args.job_id, jobs_dir=self.jobs_dir)
         logger.debug(f'Job directory is {job.dir}')
 
         if args.resume and not job.dir_exists:

--- a/plastron/jobs.py
+++ b/plastron/jobs.py
@@ -140,8 +140,14 @@ class ImportJob:
         completed_fieldnames = ['id', 'timestamp', 'title', 'uri']
         self.completed_log = ItemLog(os.path.join(self.dir, 'completed.log.csv'), completed_fieldnames, 'id')
 
+        # record of items that failed metadata validation
+        dropped_invalid_basename = f'dropped-invalid-{self.run_timestamp}'
+        dropped_invalid_log_filename = os.path.join(self.dir, f'{dropped_invalid_basename}.log.csv')
+        dropped_invalid_fieldnames = ['id', 'timestamp', 'title', 'uri', 'reason']
+        self.dropped_invalid_log = ItemLog(dropped_invalid_log_filename, dropped_invalid_fieldnames, 'id')
+
         # record of items that failed when loading into the repository during this import run
-        dropped_failed_basename = f'dropped-{self.run_timestamp}'
+        dropped_failed_basename = f'dropped-failed-{self.run_timestamp}'
         dropped_failed_log_filename = os.path.join(self.dir, f'{dropped_failed_basename}.log.csv')
         dropped_failed_fieldnames = ['id', 'timestamp', 'title', 'uri', 'reason']
         self.dropped_failed_log = ItemLog(dropped_failed_log_filename, dropped_failed_fieldnames, 'id')
@@ -192,6 +198,18 @@ class ImportJob:
             f'Dropping failed {line_reference} from import job "{self.id}" run {self.run_timestamp}: {reason}'
         )
         self.dropped_failed_log.append({
+            'id': getattr(item, 'identifier', line_reference),
+            'timestamp': datetimestamp(digits_only=False),
+            'title': getattr(item, 'title', ''),
+            'uri': getattr(item, 'uri', ''),
+            'reason': reason
+        })
+
+    def drop_invalid(self, item, line_reference, reason=''):
+        logger.warning(
+            f'Dropping invalid {line_reference} from import job "{self.id}" run {self.run_timestamp}: {reason}'
+        )
+        self.dropped_invalid_log.append({
             'id': getattr(item, 'identifier', line_reference),
             'timestamp': datetimestamp(digits_only=False),
             'title': getattr(item, 'title', ''),
@@ -332,7 +350,7 @@ class MetadataRows:
                     'is_valid': False,
                     'error': f'Line {line_reference} has the wrong number of columns'
                 })
-                self.job.drop_failed(item=None, line_reference=line_reference, reason='Wrong number of columns')
+                self.job.drop_invalid(item=None, line_reference=line_reference, reason='Wrong number of columns')
                 continue
 
             row = Row(line_reference, row_number, line, self.identifier_column)

--- a/tests/commands/test_get_command_class.py
+++ b/tests/commands/test_get_command_class.py
@@ -19,4 +19,3 @@ def test_get_import_command_class():
 def test_non_existent_command_class():
     with pytest.raises(FailureException):
         _cls = get_command_class('foo')
-

--- a/tests/commands/test_importcommand.py
+++ b/tests/commands/test_importcommand.py
@@ -155,14 +155,14 @@ def test_invalid_item_added_to_drop_log():
 
     command.create_repo_changeset = MagicMock(return_value=repo_changeset)
     command.update_repo = MagicMock()
-    mock_job.drop = MagicMock()
+    mock_job.drop_failed = MagicMock()
 
     for _ in command.execute(repo, args):
         pass
 
     command.create_repo_changeset.assert_called_once()
     command.update_repo.assert_not_called()
-    mock_job.drop.assert_called_once()
+    mock_job.drop_failed.assert_called_once()
 
 
 def test_failed_item_added_to_drop_log():
@@ -184,14 +184,14 @@ def test_failed_item_added_to_drop_log():
     command.get_source.exists = MagicMock(return_value=True)
     command.update_repo = MagicMock(side_effect=FailureException)
 
-    mock_job.drop = MagicMock()
+    mock_job.drop_failed = MagicMock()
 
     for _ in command.execute(repo, args):
         pass
 
     command.create_repo_changeset.assert_called_once()
     command.update_repo.assert_called_once()
-    mock_job.drop.assert_called_once()
+    mock_job.drop_failed.assert_called_once()
 
 
 def create_args(job_id):

--- a/tests/commands/test_importcommand.py
+++ b/tests/commands/test_importcommand.py
@@ -2,8 +2,26 @@ import argparse
 import os
 import pytest
 import tempfile
-from plastron.exceptions import FailureException
-from plastron.commands.importcommand import Command
+from collections import OrderedDict
+from plastron.commands.importcommand import Command, RepoChangeset
+from plastron.exceptions import FailureException, NoValidationRulesetException
+from plastron.jobs import Row
+from plastron.models.umd import Item
+from plastron.validation import ResourceValidationResult
+from rdflib.graph import Graph
+from unittest.mock import MagicMock
+
+
+def test_create_import_job():
+    # Verifies "create_import_job" method creates an InputJob with the expected
+    # value
+    job_id = 'test_job_id'
+    jobs_dir = '/test_jobs_dir'
+
+    import_job = Command.create_import_job(job_id, jobs_dir)
+    assert import_job.id == job_id
+    assert import_job.safe_id == job_id
+    assert import_job.dir == os.path.join(jobs_dir, job_id)
 
 
 def test_cannot_resume_without_job_id():
@@ -26,7 +44,8 @@ def test_cannot_resume_without_job_directory():
     jobs_dir = '/nonexistent_directory'
     config = {'JOBS_DIR': jobs_dir}
     command = Command(config)
-    args = argparse.Namespace(resume=True, job_id='test_job_id')
+    args = create_args('test_job_id')
+    args.resume = True
     repo = None
 
     with pytest.raises(FailureException) as excinfo:
@@ -40,7 +59,8 @@ def test_cannot_resume_without_config_file():
     # Verifies that the import command throws FailureException when resuming a
     # job and a config file is not found
     job_id = 'test_id'
-    args = argparse.Namespace(resume=True, job_id=job_id)
+    args = create_args(job_id)
+    args.resume = True
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         config = {'JOBS_DIR': tmpdirname}
@@ -63,7 +83,8 @@ def test_model_is_required_unless_resuming():
     # Verifies that the import command throws FailureException if model
     # is not provided when not resuming
     job_id = 'test_id'
-    args = argparse.Namespace(resume=False, job_id=job_id, model=None)
+    args = create_args(job_id)
+    args.model = None
     config = {}
 
     command = Command(config)
@@ -79,14 +100,8 @@ def test_import_file_is_required_unless_resuming():
     # Verifies that the import command throws FailureException if an import_file
     # is not provided when not resuming
     job_id = 'test_id'
-    args = argparse.Namespace(
-        resume=False, job_id=job_id, model='Item', access=None,
-        member_of="test",
-        container="test_container",
-        binaries_location="test_binaries_location",
-        template_file=None,
-        import_file=None
-    )
+    args = create_args(job_id)
+    args.import_file = None
     config = {}
 
     command = Command(config)
@@ -96,3 +111,147 @@ def test_import_file_is_required_unless_resuming():
             pass
 
     assert "An import file is required unless resuming an existing job" in str(excinfo.value)
+
+
+def test_exception_when_no_validation_ruleset():
+    # Verifies that the import command throws FailureException if item
+    # validation throws a NoValidationRulesetException
+    mock_job = create_mock_job()
+    args = create_args(mock_job.id)
+    config = {}
+
+    Command.create_import_job = MagicMock(return_value=mock_job)
+
+    command = Command(config)
+    repo = None
+
+    item = MagicMock(Item)
+    item.validate = MagicMock(side_effect=NoValidationRulesetException("test"))
+    repo_changeset = RepoChangeset(item, None, None)
+
+    command.create_repo_changeset = MagicMock(return_value=repo_changeset)
+
+    with pytest.raises(FailureException) as excinfo:
+        for _ in command.execute(repo, args):
+            pass
+
+    assert "Unable to run validation" in str(excinfo.value)
+
+
+def test_invalid_item_added_to_drop_log():
+    # Verifies that the import command adds an invalid item to the drop log
+    mock_job = create_mock_job()
+    args = create_args(mock_job.id)
+
+    invalid_item = create_mock_item(is_valid=False)
+
+    Command.create_import_job = MagicMock(return_value=mock_job)
+    config = {}
+
+    command = Command(config)
+    repo = None
+
+    repo_changeset = RepoChangeset(invalid_item, None, None)
+
+    command.create_repo_changeset = MagicMock(return_value=repo_changeset)
+    command.update_repo = MagicMock()
+    mock_job.drop = MagicMock()
+
+    for _ in command.execute(repo, args):
+        pass
+
+    command.create_repo_changeset.assert_called_once()
+    command.update_repo.assert_not_called()
+    mock_job.drop.assert_called_once()
+
+
+def test_failed_item_added_to_drop_log():
+    # Verifies that the import command adds a failed item to the drop log
+    mock_job = create_mock_job()
+    args = create_args(mock_job.id)
+    failed_item = create_mock_item(is_valid=True)
+
+    Command.create_import_job = MagicMock(return_value=mock_job)
+    config = {}
+
+    command = Command(config)
+    repo = None
+
+    repo_changeset = RepoChangeset(failed_item, Graph(), Graph())
+
+    command.create_repo_changeset = MagicMock(return_value=repo_changeset)
+    command.get_source = MagicMock()
+    command.get_source.exists = MagicMock(return_value=True)
+    command.update_repo = MagicMock(side_effect=FailureException)
+
+    mock_job.drop = MagicMock()
+
+    for _ in command.execute(repo, args):
+        pass
+
+    command.create_repo_changeset.assert_called_once()
+    command.update_repo.assert_called_once()
+    mock_job.drop.assert_called_once()
+
+
+def create_args(job_id):
+    """
+    Returns an argparse.Namespace object suitable for use in testing.
+
+    Individual tests should override attributes as needed to support
+    their scenario.
+
+    :param job_id: the job id to use
+    :return: a configured argparse.Namespace object
+    """
+    return argparse.Namespace(
+        resume=False, job_id=job_id,
+        model='Item',
+        access=None,
+        member_of="test",
+        container="test_container",
+        binaries_location="test_binaries_location",
+        template_file=None,
+        import_file='test_import_file',
+        percentage=None,
+        validate_only=False,
+        limit=None,
+    )
+
+
+def create_mock_job():
+    """
+    Returns an ImportJob with a single row of mock metadata.
+
+    :return: an ImportJob with mock metadata
+    """
+
+    job_id = 'test_id'
+    mock_job = Command.create_import_job(job_id, 'test_jobs_dir')
+    mock_job.save_config = MagicMock()
+    mock_job.store_metadata_file = MagicMock()
+    mock_metadata = MagicMock()
+    row = Row(line_reference='line_reference', row_number=1,
+              data=OrderedDict([{'FILES', 'test_file'}, {'Identifier', 'test-1'}]),
+              identifier_column='Identifier')
+    mock_metadata.__iter__.return_value = [row]
+
+    mock_job.metadata = MagicMock(return_value=mock_metadata)
+    mock_job.binaries_location = 'test_binaries_location'
+    return mock_job
+
+
+def create_mock_item(is_valid=True):
+    """
+    Returns a mock Item object
+
+    :param is_valid: True if the item is valid, false otherwise.
+                     Defaults to True
+    :return: a mock Item object
+    """
+    mock_item = MagicMock(Item)
+    mock_validation_result = MagicMock(ResourceValidationResult)
+    mock_validation_result.__bool__ = MagicMock(return_value=is_valid)
+    mock_validation_result.is_valid = MagicMock(return_value=is_valid)
+    mock_item.validate = MagicMock(return_value=mock_validation_result)
+    return mock_item

--- a/tests/commands/test_importcommand.py
+++ b/tests/commands/test_importcommand.py
@@ -138,8 +138,9 @@ def test_exception_when_no_validation_ruleset():
     assert "Unable to run validation" in str(excinfo.value)
 
 
-def test_invalid_item_added_to_drop_log():
-    # Verifies that the import command adds an invalid item to the drop log
+def test_invalid_item_added_to_drop_invalid_log():
+    # Verifies that the import command adds an invalid item to the
+    # drop-invalid log
     mock_job = create_mock_job()
     args = create_args(mock_job.id)
 
@@ -155,18 +156,19 @@ def test_invalid_item_added_to_drop_log():
 
     command.create_repo_changeset = MagicMock(return_value=repo_changeset)
     command.update_repo = MagicMock()
-    mock_job.drop_failed = MagicMock()
+    mock_job.drop_invalid = MagicMock()
 
     for _ in command.execute(repo, args):
         pass
 
     command.create_repo_changeset.assert_called_once()
     command.update_repo.assert_not_called()
-    mock_job.drop_failed.assert_called_once()
+    mock_job.drop_invalid.assert_called_once()
 
 
-def test_failed_item_added_to_drop_log():
-    # Verifies that the import command adds a failed item to the drop log
+def test_failed_item_added_to_drop_failed_log():
+    # Verifies that the import command adds a failed item to the
+    # drop-failed log
     mock_job = create_mock_job()
     args = create_args(mock_job.id)
     failed_item = create_mock_item(is_valid=True)

--- a/tests/commands/test_importcommand.py
+++ b/tests/commands/test_importcommand.py
@@ -1,0 +1,98 @@
+import argparse
+import os
+import pytest
+import tempfile
+from plastron.exceptions import FailureException
+from plastron.commands.importcommand import Command
+
+
+def test_cannot_resume_without_job_id():
+    # Verifies that the import command throws FailureException when resuming a
+    # job and the job id is not provided
+    command = Command()
+    args = argparse.Namespace(resume=True, job_id=None)
+    repo = None
+
+    with pytest.raises(FailureException) as excinfo:
+        for _ in command.execute(repo, args):
+            pass
+
+    assert "Resuming a job requires a job id" in str(excinfo.value)
+
+
+def test_cannot_resume_without_job_directory():
+    # Verifies that the import command throws FailureException when resuming a
+    # job and the directory associated with job id is not found
+    jobs_dir = '/nonexistent_directory'
+    config = {'JOBS_DIR': jobs_dir}
+    command = Command(config)
+    args = argparse.Namespace(resume=True, job_id='test_job_id')
+    repo = None
+
+    with pytest.raises(FailureException) as excinfo:
+        for _ in command.execute(repo, args):
+            pass
+
+    assert "no such job directory found" in str(excinfo.value)
+
+
+def test_cannot_resume_without_config_file():
+    # Verifies that the import command throws FailureException when resuming a
+    # job and a config file is not found
+    job_id = 'test_id'
+    args = argparse.Namespace(resume=True, job_id=job_id)
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        config = {'JOBS_DIR': tmpdirname}
+
+        # Make subdirectory in tmpdirname for job
+        job_dir = os.path.join(tmpdirname, job_id)
+        os.mkdir(job_dir)
+
+        command = Command(config)
+        repo = None
+
+        with pytest.raises(FailureException) as excinfo:
+            for _ in command.execute(repo, args):
+                pass
+
+        assert "no config.yml found" in str(excinfo.value)
+
+
+def test_model_is_required_unless_resuming():
+    # Verifies that the import command throws FailureException if model
+    # is not provided when not resuming
+    job_id = 'test_id'
+    args = argparse.Namespace(resume=False, job_id=job_id, model=None)
+    config = {}
+
+    command = Command(config)
+    repo = None
+    with pytest.raises(FailureException) as excinfo:
+        for _ in command.execute(repo, args):
+            pass
+
+    assert "A model is required unless resuming an existing job" in str(excinfo.value)
+
+
+def test_import_file_is_required_unless_resuming():
+    # Verifies that the import command throws FailureException if an import_file
+    # is not provided when not resuming
+    job_id = 'test_id'
+    args = argparse.Namespace(
+        resume=False, job_id=job_id, model='Item', access=None,
+        member_of="test",
+        container="test_container",
+        binaries_location="test_binaries_location",
+        template_file=None,
+        import_file=None
+    )
+    config = {}
+
+    command = Command(config)
+    repo = None
+    with pytest.raises(FailureException) as excinfo:
+        for _ in command.execute(repo, args):
+            pass
+
+    assert "An import file is required unless resuming an existing job" in str(excinfo.value)


### PR DESCRIPTION
1) Refactored the following methods out of the "execute" method in plastron.commands.importcommand.Command to facilitate creating mocks for testing:

* create_repo_changeset
* create_import_job
* update_repo

2) Added a "RepoChangeset" data object to hold the results from the "create_repo_changeset" method

3) Modified plastron.jobs.ImportJob:

* Renamed "drop" method to "drop_failed"
* Added a "drop_invalid" method

4) Modified importcommand.Command to use "drop_invalid" method failures occur during validation, and "drop_failed" method when failures occur when communicating with the repository

5) Added unit tests

The "dropped-<timestamp>.log.csv" file was renamed to "dropped-failed-<timestamp>.log.csv". This enables consistent naming for the "invalid" items, which are placed in a "dropped-invalid-<timestamp>.log.csv" file.

The ImportJob will now create the following files in the "jobs" directory:

* config.yml - Holds in the import job configuration
* dropped-failed-<timestamp>.log.csv - Holds items that failed when communicating with the repository
* dropped-invalid-<timestamp>.log.csv - Holds items that did not pass metadata validation
* source.csv - The CSV metadata file

https://issues.umd.edu/browse/LIBFCREPO-1035