### PR TITLE
LIBFCREPO-1045. Fix Plastron CLI "reindex" command when run via Docker

### DIFF
--- a/plastron/commands/reindex.py
+++ b/plastron/commands/reindex.py
@@ -53,7 +53,7 @@ class Command(BaseCommand):
             destination=self.reindexing_queue,
             headers={
                 'CamelFcrepoUri': resource.uri,
-                'CamelFcrepoPath': resource.uri.replace(self.repo.endpoint, ''),
+                'CamelFcrepoPath': self.repo.repo_path(resource.uri),
                 'CamelFcrepoResourceType': types,
                 'CamelFcrepoUser': self.username,
                 'persistent': 'true'

--- a/plastron/http.py
+++ b/plastron/http.py
@@ -118,12 +118,12 @@ class Repository:
         self.ua_string = ua_string
         self.delegated_user = on_behalf_of
 
-        repo_external_url = config.get('REPO_EXTERNAL_URL')
+        self.repo_external_url = config.get('REPO_EXTERNAL_URL')
         self.forwarded_host = None
         self.forwarded_proto = None
         self.forwarded_endpoint = None
-        if repo_external_url is not None:
-            parsed_repo_external_url = urlsplit(repo_external_url)
+        if self.repo_external_url is not None:
+            parsed_repo_external_url = urlsplit(self.repo_external_url)
             proto = parsed_repo_external_url.scheme
             host = parsed_repo_external_url.netloc
             if (proto != endpoint_proto) or (host != endpoint_host):
@@ -158,6 +158,17 @@ class Repository:
         self._path_stack.append(self.relpath)
         self.relpath = relpath
         return self
+
+    def contains(self, uri):
+        """
+        Returns True if the given URI string is contained within this
+        repository, False otherwise
+        """
+        try:
+            return uri.startswith(self.endpoint) or \
+                uri.startswith(self.repo_external_url)
+        except Exception:
+            return False
 
     def __enter__(self):
         pass

--- a/plastron/http.py
+++ b/plastron/http.py
@@ -170,6 +170,20 @@ class Repository:
         except Exception:
             return False
 
+    def repo_path(self, resource_uri):
+        """
+        Returns the repository path for the given resource URI, i.e. the
+        path with either the "REST_ENDPOINT" or "REPO_EXTERNAL_URL"
+        removed.
+        """
+        if resource_uri is None:
+            return None
+
+        repo_path = resource_uri.replace(self.endpoint, '')
+        if self.repo_external_url:
+            repo_path = repo_path.replace(self.repo_external_url, '')
+        return repo_path
+
     def __enter__(self):
         pass
 

--- a/plastron/util.py
+++ b/plastron/util.py
@@ -146,7 +146,7 @@ class ResourceList:
 
     def get_resources(self, traverse=None):
         for uri in self.get_uris():
-            if not uri.startswith(self.repository.endpoint):
+            if not self.repository.contains(uri):
                 logger.warning(f'Resource {uri} is not contained within the repository {self.repository.endpoint}')
                 continue
             for resource, graph in self.repository.recursive_get(uri, traverse=traverse):

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -243,3 +243,27 @@ def test_repository_contains_uri_without_repo_external_url(repo_base_config):
 
     in_repo_uri = repository.endpoint + '/foo/bar'
     assert repository.contains(in_repo_uri) is True
+
+
+def test_repository_repo_path(repo_base_config):
+    # Without REPO_EXTERNAL_URL
+    repository = Repository(repo_base_config)
+
+    assert repository.repo_path(None) is None
+    assert '' == repository.repo_path('')
+
+    # URLs not in repository are returned unchanged (shouldn't happen)
+    assert 'http://example.com/foo/bar' == repository.repo_path('http://example.com/foo/bar')
+
+    # URLs starting with REST endpoint should be have endpoint prefix removed
+    rest_endpoint = repo_base_config['REST_ENDPOINT']
+    resource_uri = rest_endpoint + '/foo/bar'
+    assert '/foo/bar' == repository.repo_path(resource_uri)
+
+    # With REPO_EXTERNAL_URL
+    repo_external_url = 'http://external-host.com:8080/fcrepo/rest'
+    repo_base_config['REPO_EXTERNAL_URL'] = repo_external_url
+    repository = Repository(repo_base_config)
+
+    external_resource_uri = repo_external_url + '/baz/quuz'
+    assert '/baz/quuz' == repository.repo_path(external_resource_uri)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -210,3 +210,36 @@ def test_repository_auth(repo_base_config):
     session = repository.session
     assert session.headers.get('Authorization')
     assert session.headers['Authorization'] == 'Bearer abcd-1234'
+
+
+def test_repository_contains_uri(repo_base_config):
+    repo_base_config['REPO_EXTERNAL_URL'] = 'http://external-host.com:8080/fcrepo/rest'
+    repository = Repository(repo_base_config)
+
+    assert repository.contains(None) is False
+    assert repository.contains('') is False
+    assert repository.contains('/not_in_repo') is False
+
+    assert repository.contains(repository.endpoint) is True
+
+    in_repo_uri = repository.endpoint + '/foo/bar'
+    assert repository.contains(in_repo_uri) is True
+
+    external_repo_uri = repo_base_config['REPO_EXTERNAL_URL']
+    assert repository.contains(external_repo_uri) is True
+
+    in_external_repo_uri = external_repo_uri + '/foo/bar'
+    assert repository.contains(in_external_repo_uri) is True
+
+
+def test_repository_contains_uri_without_repo_external_url(repo_base_config):
+    repository = Repository(repo_base_config)
+
+    assert repository.contains(None) is False
+    assert repository.contains('') is False
+    assert repository.contains('/not_in_repo') is False
+
+    assert repository.contains(repository.endpoint) is True
+
+    in_repo_uri = repository.endpoint + '/foo/bar'
+    assert repository.contains(in_repo_uri) is True


### PR DESCRIPTION
Added a "contains" method to the plastron.http.Repository class that
returns True if the given URI string is contained within the repository,
False otherwise. When running in Docker, the method accepts URIs
starting with either the "internal" Kubernetes URL, or the "external"
repository URL.

Modified the "get_resources" method in plastron.util.ResourceList to
use the "contains" method to determine if the resource URI is in the
repository.

Added an "repo_path" method to the plastron.http.Repository class so
that the resource subpath could be retrieved from a resource URI,
regardless of whether the resource URI was an internal Kubernetes URI
or an external URI.

This was necessary so that the "CamelFcrepoPath" passed to the Solr
reindex command would have the correct path regardless of the initial
resource URI.


https://issues.umd.edu/browse/LIBFCREPO-1045