### PR TITLE
LIBFCREPO-1048. Updates to support Archelon import job workflow.

### DIFF
--- a/docs/messages.md
+++ b/docs/messages.md
@@ -1,17 +1,16 @@
 # Message Formats
 
-The Plastron Daemon emits both incremental progress messages
-as well as a final job completion message. The headers of
-these messages are standardized across commands, but the bodies
-have command-specific formats.
+The Plastron Daemon emits both incremental progress messages, and a final job
+completion message. The headers of these messages are standardized across
+commands, but the bodies have command-specific formats.
 
 ## Headers
 
 | Header            | Message Type       | Usage |
 |-------------------|--------------------|-------|
 |`PlastronJobId`    |progress, completion|URI that identifies the job|
-|`PlastronJobStatus`|completion          |Final job status; one of `Done` or `Failed`|
-|`PlastronJobError` |completion          |Reason for failure if the status is `Failed`|
+|`PlastronJobState` |completion          |Job state as of the end of this run|
+|`PlastronJobError` |completion          |Error message, if the job had a fatal exception|
 
 ## Bodies
 
@@ -38,8 +37,11 @@ All message bodies are JSON-formatted.
 
 #### Completion message
 
+The `PlastronJobState` header is copied from the `"type"` field in the message body.
+
 ```
 {
+    "type": "export_complete" | "partial_export",
     "content_type": /* MIME type of the export file: text/turtle, text/csv, or application/zip */,
     "file_extension": /* file extension of the export output file: .ttl, .csv, or .zip */,
     "download_uri": /* repository URI of the export file */
@@ -86,8 +88,11 @@ counted during the import processing.
 
 #### Completion message
 
+The `PlastronJobState` header is copied from the `"type"` field in the message body.
+
 ```
 {
+    "type": "validate_success" | "validate_failed" | "import_complete" | "import_incomplete",
     "count": {
         "total": /* total number of resources to import */,
         "updated": /* number of resources with changes that were updated */,

--- a/plastron/commands/export.py
+++ b/plastron/commands/export.py
@@ -247,6 +247,7 @@ class Command(BaseCommand):
         compress_bag(bag, destination, root)
 
         self.result = {
+            'type': 'export_complete' if count == total else 'partial_export',
             'content_type': serializer.content_type,
             'file_extension': serializer.file_extension,
             'count': {

--- a/plastron/commands/importcommand.py
+++ b/plastron/commands/importcommand.py
@@ -553,29 +553,21 @@ class Command(BaseCommand):
         if args.validate_only:
             # validate phase
             if metadata.invalid == 0:
-                self.result = {
-                    'type': 'validate_success',
-                    'validation': metadata.validation_reports,
-                    'count': metadata.stats()
-                }
+                result_type = 'validate_success'
             else:
-                self.result = {
-                    'type': 'validate_failed',
-                    'validation': metadata.validation_reports,
-                    'count': metadata.stats()
-                }
+                result_type = 'validate_failed'
         else:
             # import phase
             if len(job.completed_log) == metadata.total:
-                self.result = {
-                    'type': 'import_complete',
-                    'count': metadata.stats()
-                }
+                result_type = 'import_complete'
             else:
-                self.result = {
-                    'type': 'import_incomplete',
-                    'count': metadata.stats()
-                }
+                result_type = 'import_incomplete'
+
+        self.result = {
+            'type': result_type,
+            'validation': metadata.validation_reports,
+            'count': metadata.stats()
+        }
 
     def create_repo_changeset(self, args, repo, metadata, row):
         """

--- a/plastron/commands/update.py
+++ b/plastron/commands/update.py
@@ -140,6 +140,7 @@ class Command(BaseCommand):
             traverse=parse_predicate_list(args.recursive),
             use_transaction=args.use_transactions
         )
+        self.result = {}
 
     def update_item(self, resource, graph):
         if self.resources.completed and resource.uri in self.resources.completed:

--- a/plastron/rdf.py
+++ b/plastron/rdf.py
@@ -113,6 +113,8 @@ class RDFObjectProperty(RDFProperty):
             return URIRef(value.uri)
         elif isinstance(value, URIRef):
             return value
+        elif isinstance(value, str):
+            return URIRef(value)
         else:
             raise ValueError('Expecting a URIRef or an object with a uri attribute')
 

--- a/plastron/stomp/handlers.py
+++ b/plastron/stomp/handlers.py
@@ -17,7 +17,6 @@ class AsynchronousResponseHandler:
             self.listener.status_queue.send(
                 headers={
                     'PlastronJobId': self.message.job_id,
-                    'PlastronJobStatus': 'Error',
                     'PlastronJobError': str(e),
                     'persistent': 'true'
                 }
@@ -54,7 +53,6 @@ class SynchronousResponseHandler:
             self.reply_to.send(
                 headers={
                     'PlastronJobId': self.message.job_id,
-                    'PlastronJobStatus': 'Error',
                     'PlastronJobError': str(e),
                     'persistent': 'true'
                 }

--- a/plastron/stomp/listeners.py
+++ b/plastron/stomp/listeners.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 from concurrent.futures import ThreadPoolExecutor
-from importlib import import_module
+
 from plastron import version
 from plastron.commands import get_command_class
 from plastron.exceptions import FailureException
@@ -149,7 +149,7 @@ class MessageProcessor:
         return Message(
             headers={
                 'PlastronJobId': message.job_id,
-                'PlastronJobStatus': 'Done',
+                'PlastronJobState': command.result.get('type', ''),
                 'persistent': 'true'
             },
             body=json.dumps(command.result)


### PR DESCRIPTION
- return the PlastronJobState as the "type" key in the result dictionary for the import and export commands
- removed the PlastronJobStatus STOMP message header; an error message can be determined by checking for the presence of a PlastronJobError header
- set result value for the update command
- wrap string values of RDFObjectProperty in a URIRef

https://issues.umd.edu/browse/LIBFCREPO-1048