### PR TITLE
LIBFCREPO-1058. Support storing local copies of validation vocabularies.

### DIFF
--- a/plastron/commands/importcommand.py
+++ b/plastron/commands/importcommand.py
@@ -15,7 +15,7 @@ from rdflib import Graph, Literal, URIRef
 
 from plastron import rdf
 from plastron.commands import BaseCommand
-from plastron.exceptions import ConfigError, FailureException, NoValidationRulesetException, RESTAPIException
+from plastron.exceptions import ConfigError, FailureException, RESTAPIException
 from plastron.files import HTTPFileSource, LocalFileSource, RemoteFileSource, ZipFileSource
 from plastron.http import Transaction
 from plastron.jobs import ImportJob, ImportedItemStatus, JobError, ModelClassNotFoundError, build_lookup_index
@@ -24,6 +24,7 @@ from plastron.oa import Annotation, TextualBody
 from plastron.pcdm import File, PreservationMasterFile
 from plastron.rdf import RDFDataProperty
 from plastron.util import datetimestamp, uri_or_curie
+from plastron.validation import ValidationError
 
 nsm = get_manager()
 logger = logging.getLogger(__name__)
@@ -600,7 +601,7 @@ class Command(BaseCommand):
 
             try:
                 report = validate(item)
-            except NoValidationRulesetException as e:
+            except ValidationError as e:
                 raise FailureException(f'Unable to run validation: {e}') from e
 
             metadata.validation_reports.append({

--- a/plastron/exceptions.py
+++ b/plastron/exceptions.py
@@ -26,14 +26,6 @@ class FailureException(Exception):
     pass
 
 
-class NoValidationRulesetException(Exception):
-    def __init__(self, message):
-        self.message = message
-
-    def __str__(self):
-        return self.message
-
-
 class BinarySourceError(Exception):
     pass
 

--- a/plastron/rdf.py
+++ b/plastron/rdf.py
@@ -1,8 +1,7 @@
 import plastron.validation.rules
 import sys
-from plastron.exceptions import NoValidationRulesetException
 from plastron.namespaces import rdf
-from plastron.validation import ResourceValidationResult
+from plastron.validation import ResourceValidationResult, ValidationError
 from rdflib import Graph, URIRef, Literal
 
 # alias the rdflib Namespace
@@ -278,7 +277,7 @@ class Resource(metaclass=Meta):
             try:
                 ruleset = self.VALIDATION_RULESET
             except AttributeError:
-                raise NoValidationRulesetException(f'No ruleset given, and "{self}" does not have a default ruleset')
+                raise ValidationError(f'No ruleset given, and "{self}" does not have a default ruleset')
         result = ResourceValidationResult(self)
         for field, rules in ruleset.items():
             for rule_name, arg in rules.items():

--- a/plastron/validation/__init__.py
+++ b/plastron/validation/__init__.py
@@ -41,3 +41,7 @@ class ResourceValidationResult:
             if status != 'failed':
                 continue
             yield prop.name, status, rule.__name__, getattr(expected, '__name__', expected)
+
+
+class ValidationError(Exception):
+    pass

--- a/plastron/validation/rules.py
+++ b/plastron/validation/rules.py
@@ -1,8 +1,7 @@
 import re
-
-from functools import lru_cache
-from rdflib import Graph
 from typing import Callable
+
+from plastron.validation.vocabularies import get_subjects
 
 
 def non_empty(values):
@@ -27,12 +26,6 @@ def exactly(prop, length):
 
 def allowed_values(prop, values):
     return not any(True for v in prop.values if str(v) not in values)
-
-
-@lru_cache()
-def get_subjects(vocab_uri):
-    graph = Graph().parse(vocab_uri)
-    return [str(s) for s in set(graph.subjects())]
 
 
 def from_vocabulary(prop, vocab_uri):

--- a/plastron/validation/vocabularies/__init__.py
+++ b/plastron/validation/vocabularies/__init__.py
@@ -1,0 +1,45 @@
+import logging
+from functools import lru_cache
+from os.path import abspath, dirname
+from pathlib import Path
+from typing import List
+from urllib.error import HTTPError
+
+from rdflib import Graph
+
+from plastron.validation import ValidationError
+
+logger = logging.getLogger(__name__)
+
+VOCABULARIES_DIR = Path(dirname(abspath(__file__)))
+VOCABULARIES = {
+    'http://purl.org/dc/dcmitype/': 'dcmitype.ttl',
+}
+
+
+def get_vocabulary(vocab_uri: str) -> Graph:
+    graph = Graph()
+    # first check locally available vocabularies
+    if vocab_uri in VOCABULARIES:
+        try:
+            graph.parse(
+                location=str(VOCABULARIES_DIR / VOCABULARIES[vocab_uri]),
+                format='turtle'
+            )
+            return graph
+        except FileNotFoundError as e:
+            logger.warning(f'Local version of {vocab_uri} not found: {e}')
+            logger.info('Falling back to remote retrieval')
+
+    # otherwise, fall back to remote retrieval
+    try:
+        graph.parse(location=vocab_uri)
+    except HTTPError as e:
+        raise ValidationError(f'Unable to retrieve vocabulary from {vocab_uri}: {e}') from e
+
+    return graph
+
+
+@lru_cache()
+def get_subjects(vocab_uri: str) -> List[str]:
+    return [str(s) for s in set(get_vocabulary(vocab_uri).subjects())]

--- a/plastron/validation/vocabularies/dcmitype.ttl
+++ b/plastron/validation/vocabularies/dcmitype.ttl
@@ -1,0 +1,123 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix dcam: <http://purl.org/dc/dcam/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://purl.org/dc/dcmitype/>
+    dcterms:modified "2012-06-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:publisher <http://purl.org/dc/aboutdcmi#DCMI> ;
+    dcterms:title "DCMI Type Vocabulary"@en .
+
+<http://purl.org/dc/dcmitype/Collection>
+    dcam:memberOf dcterms:DCMIType ;
+    dcterms:description "A collection is described as a group; its parts may also be separately described."@en ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "An aggregation of resources."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/dcmitype/> ;
+    rdfs:label "Collection"@en .
+
+<http://purl.org/dc/dcmitype/Dataset>
+    dcam:memberOf dcterms:DCMIType ;
+    dcterms:description "Examples include lists, tables, and databases.  A dataset may be useful for direct machine processing."@en ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "Data encoded in a defined structure."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/dcmitype/> ;
+    rdfs:label "Dataset"@en .
+
+<http://purl.org/dc/dcmitype/Event>
+    dcam:memberOf dcterms:DCMIType ;
+    dcterms:description "Metadata for an event provides descriptive information that is the basis for discovery of the purpose, location, duration, and responsible agents associated with an event. Examples include an exhibition, webcast, conference, workshop, open day, performance, battle, trial, wedding, tea party, conflagration."@en ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A non-persistent, time-based occurrence."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/dcmitype/> ;
+    rdfs:label "Event"@en .
+
+<http://purl.org/dc/dcmitype/Image>
+    dcam:memberOf dcterms:DCMIType ;
+    dcterms:description "Examples include images and photographs of physical objects, paintings, prints, drawings, other images and graphics, animations and moving pictures, film, diagrams, maps, musical notation.  Note that Image may include both electronic and physical representations."@en ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A visual representation other than text."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/dcmitype/> ;
+    rdfs:label "Image"@en .
+
+<http://purl.org/dc/dcmitype/InteractiveResource>
+    dcam:memberOf dcterms:DCMIType ;
+    dcterms:description "Examples include forms on Web pages, applets, multimedia learning objects, chat services, or virtual reality environments."@en ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A resource requiring interaction from the user to be understood, executed, or experienced."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/dcmitype/> ;
+    rdfs:label "Interactive Resource"@en .
+
+<http://purl.org/dc/dcmitype/MovingImage>
+    dcam:memberOf dcterms:DCMIType ;
+    dcterms:description "Examples include animations, movies, television programs, videos, zoetropes, or visual output from a simulation.  Instances of the type Moving Image must also be describable as instances of the broader type Image."@en ;
+    dcterms:issued "2003-11-18"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A series of visual representations imparting an impression of motion when shown in succession."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/dcmitype/> ;
+    rdfs:label "Moving Image"@en ;
+    rdfs:subClassOf <http://purl.org/dc/dcmitype/Image> .
+
+<http://purl.org/dc/dcmitype/PhysicalObject>
+    dcam:memberOf dcterms:DCMIType ;
+    dcterms:description "Note that digital representations of, or surrogates for, these objects should use Image, Text or one of the other types."@en ;
+    dcterms:issued "2002-07-13"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "An inanimate, three-dimensional object or substance."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/dcmitype/> ;
+    rdfs:label "Physical Object"@en .
+
+<http://purl.org/dc/dcmitype/Service>
+    dcam:memberOf dcterms:DCMIType ;
+    dcterms:description "Examples include a photocopying service, a banking service, an authentication service, interlibrary loans, a Z39.50 or Web server."@en ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A system that provides one or more functions."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/dcmitype/> ;
+    rdfs:label "Service"@en .
+
+<http://purl.org/dc/dcmitype/Software>
+    dcam:memberOf dcterms:DCMIType ;
+    dcterms:description "Examples include a C source file, MS-Windows .exe executable, or Perl script."@en ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A computer program in source or compiled form."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/dcmitype/> ;
+    rdfs:label "Software"@en .
+
+<http://purl.org/dc/dcmitype/Sound>
+    dcam:memberOf dcterms:DCMIType ;
+    dcterms:description "Examples include a music playback file format, an audio compact disc, and recorded speech or sounds."@en ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A resource primarily intended to be heard."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/dcmitype/> ;
+    rdfs:label "Sound"@en .
+
+<http://purl.org/dc/dcmitype/StillImage>
+    dcam:memberOf dcterms:DCMIType ;
+    dcterms:description "Examples include paintings, drawings, graphic designs, plans and maps. Recommended best practice is to assign the type Text to images of textual materials. Instances of the type Still Image must also be describable as instances of the broader type Image."@en ;
+    dcterms:issued "2003-11-18"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A static visual representation."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/dcmitype/> ;
+    rdfs:label "Still Image"@en ;
+    rdfs:subClassOf <http://purl.org/dc/dcmitype/Image> .
+
+<http://purl.org/dc/dcmitype/Text>
+    dcam:memberOf dcterms:DCMIType ;
+    dcterms:description "Examples include books, letters, dissertations, poems, newspapers, articles, archives of mailing lists. Note that facsimiles or images of texts are still of the genre Text."@en ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A resource consisting primarily of words for reading."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/dcmitype/> ;
+    rdfs:label "Text"@en .
+
+

--- a/tests/commands/test_importcommand.py
+++ b/tests/commands/test_importcommand.py
@@ -6,10 +6,10 @@ from collections import OrderedDict
 
 import plastron
 from plastron.commands.importcommand import Command, RepoChangeset
-from plastron.exceptions import FailureException, NoValidationRulesetException
+from plastron.exceptions import FailureException
 from plastron.jobs import ConfigMissingError, Row
 from plastron.models.umd import Item
-from plastron.validation import ResourceValidationResult
+from plastron.validation import ResourceValidationResult, ValidationError
 from rdflib.graph import Graph
 from unittest.mock import MagicMock
 
@@ -128,7 +128,7 @@ def test_exception_when_no_validation_ruleset():
     repo = None
 
     item = MagicMock(Item)
-    item.validate = MagicMock(side_effect=NoValidationRulesetException("test"))
+    item.validate = MagicMock(side_effect=ValidationError("test"))
     repo_changeset = RepoChangeset(item, None, None)
 
     plastron.commands.importcommand.create_repo_changeset = MagicMock(return_value=repo_changeset)


### PR DESCRIPTION
- Created a plastron.validation.vocabularies package
- Added the dcmitype vocabulary
- Created ValidationError class for all validation processing exceptions

https://issues.umd.edu/browse/LIBFCREPO-1058