### PR TITLE
LIBFCREPO-1065. Modify AsynchronousResponseHandler to clean up msg boxes

### DIFF
--- a/plastron/stomp/handlers.py
+++ b/plastron/stomp/handlers.py
@@ -16,24 +16,24 @@ class AsynchronousResponseHandler:
         e = future.exception()
         if e:
             logger.error(f"Job {self.message.job_id} failed: {e}")
-            self.reply_queue.send(PlastronErrorMessage(job_id=self.message.job_id, error=str(e)))
+            response = PlastronErrorMessage(job_id=self.message.job_id, error=str(e))
         else:
             # assume no errors, return the response
             response = future.result()
 
-            # save a copy of the response message in the outbox
-            job_id = response.job_id
-            self.listener.outbox.add(job_id, response)
+        # save a copy of the response message in the outbox
+        job_id = response.job_id
+        self.listener.outbox.add(job_id, response)
 
-            # remove the message from the inbox now that processing has completed
-            self.listener.inbox.remove(self.message.id)
+        # remove the message from the inbox now that processing has completed
+        self.listener.inbox.remove(self.message.id)
 
-            # send the job completed message
-            self.reply_queue.send(response)
-            logger.debug(f'Response message sent to {self.reply_queue} with headers: {response.headers}')
+        # send the job completed message
+        self.reply_queue.send(response)
+        logger.debug(f'Response message sent to {self.reply_queue} with headers: {response.headers}')
 
-            # remove the message from the outbox now that sending has completed
-            self.listener.outbox.remove(job_id)
+        # remove the message from the outbox now that sending has completed
+        self.listener.outbox.remove(job_id)
 
 
 class SynchronousResponseHandler:

--- a/tests/stomp/test_handlers.py
+++ b/tests/stomp/test_handlers.py
@@ -1,0 +1,69 @@
+from typing import cast, Dict, Type
+from unittest import TestCase
+from unittest.mock import Mock
+from concurrent.futures import Future
+
+from plastron.stomp import Destination
+from plastron.stomp.handlers import AsynchronousResponseHandler
+from plastron.stomp.listeners import CommandListener
+from plastron.stomp.messages import MessageBox, PlastronCommandMessage, PlastronErrorMessage, PlastronMessage
+
+
+def test_asynchronous_response_handler_successful_call_removes_inbox_and_outbox_entries():
+    # Set up mocks
+    job_id = 'test_asynchronous_response_handler_successful_call-123'
+
+    # This future represents a successful call
+    future_response = PlastronMessage(headers={'PlastronJobId': job_id}, body="Success!")
+    future_mock_attrs = {'exception.return_value': None, 'result.return_value': future_response}
+    future = Mock(Future, **future_mock_attrs)
+
+    listener = Mock(CommandListener, inbox=Mock(MessageBox), outbox=Mock(MessageBox), status_queue=Mock(Destination))
+    incoming_message = Mock(PlastronCommandMessage, id='incoming_test_message', job_id=job_id)
+
+    # Handle the incoming message
+    handler = AsynchronousResponseHandler(listener, incoming_message)
+    handler(future)
+
+    # Verify outbox/inbox handling and message sending
+    listener.outbox.add.assert_called_once_with(job_id, future_response)
+    listener.inbox.remove.assert_called_once_with(incoming_message.id)
+    listener.status_queue.send.assert_called_once_with(future_response)
+    listener.outbox.remove.assert_called_once_with(job_id)
+
+
+def test_asynchronous_response_handler_call_with_exception_removes_inbox_and_outbox_entries():
+    # Set up mocks
+    job_id = 'test_asynchronous_response_handler_call_with_exception-123'
+
+    # This future throw an exception, representing a failed call
+    future_response = PlastronErrorMessage(headers={'PlastronJobId': job_id})
+    exception_message = 'An error occurred'
+    future_mock_attrs = {'exception.return_value': Exception(exception_message), 'result.return_value': future_response}
+    future = Mock(Future, **future_mock_attrs)
+
+    listener = Mock(CommandListener, inbox=Mock(MessageBox), outbox=Mock(MessageBox), status_queue=Mock(Destination))
+    incoming_message = Mock(PlastronCommandMessage, id='incoming_test_message', job_id=job_id)
+
+    # Handle the incoming message
+    handler = AsynchronousResponseHandler(listener, incoming_message)
+    handler(future)
+
+    # Verify outbox/inbox handling and message sending
+    listener.outbox.add.assert_called_once()
+    listener.inbox.remove.assert_called_once_with(incoming_message.id)
+
+    listener.status_queue.send.assert_called_once()
+    expected_msg_headers = {'PlastronJobId': job_id, 'PlastronJobError': exception_message, 'persistent': 'true'}
+    assert_sent_message(listener.status_queue, PlastronErrorMessage, expected_msg_headers, '')
+
+    listener.outbox.remove.assert_called_once_with(job_id)
+
+
+def assert_sent_message(queue: Destination, message_class: Type,
+                        expected_message_headers: Dict[str, str], expected_body: str):
+    status_queue_send_args = cast(Mock, queue).send.call_args[0]  # using cast, so mypy doesn't complain
+    sent_message = status_queue_send_args[0]
+    assert isinstance(sent_message, message_class)
+    TestCase().assertDictEqual(sent_message.headers, expected_message_headers)
+    assert sent_message.body == expected_body


### PR DESCRIPTION
Changed AsynchronousResponseHandler so that inbox/outbox processing
still occurs when a job throws an exception.

In particular, the original message in the "inbox" should be removed,
even when an exception has occurred during the job, so that the job
is not inadvertently repeated (because it was not removed from the
inbox).

https://issues.umd.edu/browse/LIBFCREPO-1065