### PR TITLE
LIBFCREPO-1063. Return a stats dictionary from updates.

### DIFF
--- a/plastron/commands/importcommand.py
+++ b/plastron/commands/importcommand.py
@@ -24,7 +24,7 @@ from plastron.oa import Annotation, TextualBody
 from plastron.pcdm import File, PreservationMasterFile
 from plastron.rdf import RDFDataProperty
 from plastron.util import datetimestamp, uri_or_curie
-from plastron.validation import ValidationError
+from plastron.validation import ValidationError, validate
 
 nsm = get_manager()
 logger = logging.getLogger(__name__)
@@ -146,23 +146,6 @@ def get_property_type(model_class: rdf.Resource, attrs):
         return get_property_type(model_class.name_to_prop[first].obj_class, rest)
     else:
         return model_class.name_to_prop[attrs]
-
-
-def validate(item):
-    result = item.validate()
-
-    if result.is_valid():
-        logger.info(f'"{item}" passed metadata validation')
-        for outcome in result.passed():
-            logger.debug(f'  ✓ {outcome}')
-    else:
-        logger.warning(f'"{item}" failed metadata validation')
-        for outcome in result.failed():
-            logger.warning(f'  ✗ {outcome}')
-        for outcome in result.passed():
-            logger.debug(f'  ✓ {outcome}')
-
-    return result
 
 
 def build_file_groups(filenames_string):

--- a/plastron/validation/__init__.py
+++ b/plastron/validation/__init__.py
@@ -1,5 +1,26 @@
+import logging
+
 from edtf_validate.valid_edtf import is_valid as is_valid_edtf
 from iso639 import is_valid639_1, is_valid639_2
+
+logger = logging.getLogger(__name__)
+
+
+def validate(item):
+    result = item.validate()
+
+    if result.is_valid():
+        logger.info(f'"{item}" passed metadata validation')
+        for outcome in result.passed():
+            logger.debug(f'  ✓ {outcome}')
+    else:
+        logger.warning(f'"{item}" failed metadata validation')
+        for outcome in result.failed():
+            logger.warning(f'  ✗ {outcome}')
+        for outcome in result.passed():
+            logger.debug(f'  ✓ {outcome}')
+
+    return result
 
 
 def is_edtf_formatted(value):

--- a/tests/test_update_command.py
+++ b/tests/test_update_command.py
@@ -6,7 +6,7 @@ from pytest import raises
 
 
 def test_parse_message():
-    message_body = '{\"uri\": [\"test\"], \"sparql_update\": \"\" }'
+    message_body = '{\"uris\": [\"test\"], \"sparql_update\": \"\" }'
 
     headers = {
         'PlastronJobId': 'test',


### PR DESCRIPTION
Tracks the successful, invalid, and error updates. Also moved the validate() convenience function (with logging) into a common location to be shared by the import and update commands.

https://issues.umd.edu/browse/LIBFCREPO-1063