### PR TITLE
LIBFCREPO-1067. Created split_escaped() function.

### DIFF
--- a/tests/test_split_escaped.py
+++ b/tests/test_split_escaped.py
@@ -1,0 +1,17 @@
+import pytest
+
+from plastron.commands.importcommand import split_escaped
+
+
+@pytest.mark.parametrize(
+    ('string', 'separator', 'expected'),
+    [
+        ('foo', '|', ['foo']),
+        ('foo|', '|', ['foo', '']),
+        ('foo|bar|baz\\|flip', '|', ['foo', 'bar', 'baz|flip']),
+        ('foo|bar|baz\\|flip;a;b\\;c', ';', ['foo|bar|baz|flip', 'a', 'b;c']),
+        ('\\\\foo|bar|baz\\|flip;a;b\\;c', ';', ['\\foo|bar|baz|flip', 'a', 'b;c']),
+    ]
+)
+def test_split_escaped(string, separator, expected):
+    assert split_escaped(string, separator) == expected


### PR DESCRIPTION
Honors the presence of a backslash escape character and treats the following character as not a delimiter character.

https://issues.umd.edu/browse/LIBFCREPO-1067