### PR TITLE
LIBFCREPO-1075. Run only one daemon (STOMP or HTTP) in plastrond.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ VOLUME /var/opt/plastron/jobs
 
 EXPOSE 5000
 
-CMD ["plastrond", "-c", "/etc/plastrond.yml"]
+ENTRYPOINT ["plastrond", "-c", "/etc/plastrond.yml"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 version: "3.7"
 services:
-  plastrond:
+  plastrond-stomp:
     image: docker.lib.umd.edu/plastrond
+    command: ["stomp"]
     configs:
       - source: plastrond
         target: /etc/plastrond.yml
@@ -11,8 +12,19 @@ services:
     volumes:
       - plastrond-jobs:/var/opt/plastron/jobs
       - plastrond-messages:/var/opt/plastron/msg
+  plastrond-http:
+    image: docker.lib.umd.edu/plastrond
+    command: ["http"]
+    configs:
+      - source: plastrond
+        target: /etc/plastrond.yml
+      - source: archelon_id
+        target: /etc/plastron/auth/archelon_id
+        mode: 0400
+    volumes:
+      - plastrond-jobs:/var/opt/plastron/jobs
     ports:
-      - 5000:5000
+      - "5000:5000"
 configs:
   plastrond:
     file: docker-plastron.yml

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -1,17 +1,27 @@
 # Plastron Server
 
 The Plastron server (a.k.a., "plastrond") is implemented by the
-[plastron.daemon](../plastron/daemon.py) module, and there is a
-*plastrond* entry point provided by [setup.py](../setup.py).
+[plastron.daemon](../plastron/daemon.py) module, and there is a *plastrond*
+entry point provided by [setup.py](../setup.py).
 
 ## Running with Python
 
-```
+```bash
+# Install dependencies
 pip install -e .
-plastrond -c <config_file>
 ```
 
-## Running with Docker
+The Plastron Daemon itself can run in one of two modes:
+
+* As a STOMP client: `plastrond -c <config file> stomp`
+* An HTTP server: `plastrond -c <config file> http`
+
+## Running with Docker Swarm
+
+This repository contains a [docker-compose.yml](../docker-compose.yml) file 
+that defines a Docker stack that can be run alongside the [umd-fcrepo-docker]
+stack. This stack runs two containers, `plastrond-stomp` and `plastrond-http`,
+each running the Plastron Daemon in their respective mode.
 
 ```
 # if you are not already running in swarm mode
@@ -25,6 +35,10 @@ docker build -t plastrond .
 # PLASTRON_PUBLIC_KEY
 ssh-keygen -q -t rsa -N '' -f archelon_id
 
+# Copy the docker-plastron-template.yml and edit the configuration
+cp docker-plastron-template.yml docker-plastron.yml
+vim docker-plastron.yml
+
 # deploy the stack
 docker stack deploy -c docker-compose.yml plastrond
 ```
@@ -32,15 +46,19 @@ docker stack deploy -c docker-compose.yml plastrond
 To watch the logs:
 
 ```
-docker logs -f plastrond_plastrond.1.<generated_id>
+# STOMP
+docker service logs -f plastrond_plastrond-stomp
+
+# HTTP
+docker service logs -f plastrond_plastrond-http
 ```
 
 ## Configuration
 
 See [Configuration](configuration.md).
 
-See [docker-plastron.yml](../docker-plastron.yml) for an example
-of the config file.
+See [docker-plastron-template.yml](../docker-plastron-template.yml) for an 
+example of the config file.
 
 ## STOMP Message Headers
 
@@ -60,3 +78,5 @@ all commands:
 
 See the [messages documentation](messages.md) for details on the headers and bodies
 of the messages the Plastron Daemon emits.
+
+[umd-fcrepo-docker]: https://github.com/umd-lib/umd-fcrepo-docker

--- a/plastron/daemon.py
+++ b/plastron/daemon.py
@@ -1,97 +1,34 @@
-#!/usr/bin/env python3
-import argparse
 import logging
 import logging.config
-import os
-import signal
 import sys
+from argparse import ArgumentParser, FileType
+from datetime import datetime
 from pathlib import Path
-from threading import Thread
+from threading import Event, Thread
+from typing import Any, Mapping, Tuple, Type
 
 import waitress
 import yaml
 
-from datetime import datetime
 from plastron import version
 from plastron.logging import DEFAULT_LOGGING_OPTIONS
 from plastron.stomp import Broker
-from plastron.stomp.listeners import ReconnectListener, CommandListener
+from plastron.stomp.listeners import CommandListener, ReconnectListener
 from plastron.util import envsubst
 from plastron.web import create_app
 
 logger = logging.getLogger(__name__)
-now = datetime.utcnow().strftime('%Y%m%d%H%M%S')
-
-
-def main():
-    parser = argparse.ArgumentParser(
-        prog='plastron',
-        description='Batch operations daemon for Fedora 4.'
-    )
-    parser.add_argument(
-        '-c', '--config',
-        help='Path to configuration file.',
-        action='store',
-        required=True
-    )
-    parser.add_argument(
-        '-v', '--verbose',
-        help='increase the verbosity of the status output',
-        action='store_true'
-    )
-
-    # parse command line args
-    args = parser.parse_args()
-
-    with open(args.config, 'r') as config_file:
-        config = envsubst(yaml.safe_load(config_file))
-
-    repo_config = config['REPOSITORY']
-
-    logging_options = DEFAULT_LOGGING_OPTIONS
-
-    # log file configuration
-    log_dirname = repo_config.get('LOG_DIR')
-    if not os.path.isdir(log_dirname):
-        os.makedirs(log_dirname)
-    log_filename = f'plastron.daemon.{now}.log'
-    logfile = os.path.join(log_dirname, log_filename)
-    logging_options['handlers']['file']['filename'] = logfile
-
-    # manipulate console verbosity
-    if args.verbose:
-        logging_options['handlers']['console']['level'] = 'DEBUG'
-
-    # configure logging
-    logging.config.dictConfig(logging_options)
-
-    logger.info(f'plastrond {version}')
-
-    threads = [
-        STOMPDaemon(config=config),
-        HTTPDaemon(config=config)
-    ]
-
-    try:
-        # start all daemons
-        for thread in threads:
-            thread.start()
-        # block until all threads have exited
-        for thread in threads:
-            thread.join()
-    except KeyboardInterrupt:
-        # exit on Ctrl+C
-        sys.exit()
 
 
 class STOMPDaemon(Thread):
     def __init__(self, config=None, **kwargs):
-        super().__init__(daemon=True, **kwargs)
+        super().__init__(**kwargs)
         if config is None:
             config = {}
         self.repo_config = config['REPOSITORY']
         self.broker_config = config['MESSAGE_BROKER']
         self.command_config = config.get('COMMANDS', {})
+        self.running = Event()
 
     def run(self):
         # configure STOMP message broker
@@ -105,8 +42,11 @@ class STOMPDaemon(Thread):
 
         # connect and listen indefinitely
         broker.connect()
-        while True:
-            signal.pause()
+        self.running.set()
+        while self.running.is_set():
+            self.running.wait(1)
+
+        broker.disconnect()
 
 
 class HTTPDaemon(Thread):
@@ -121,6 +61,91 @@ class HTTPDaemon(Thread):
         app = create_app({'JOBS_DIR': Path(self.jobs_dir)})
         logger.info(f'HTTP server listening on {self.host}:{self.port}')
         waitress.serve(app, host=self.host, port=self.port)
+
+
+INTERFACES = {
+    'stomp': STOMPDaemon,
+    'http': HTTPDaemon
+}
+
+
+def configure_logging(log_filename_base: str, log_dir: str = 'logs', verbose: bool = False) -> None:
+    logging_options = DEFAULT_LOGGING_OPTIONS
+
+    # log file configuration
+    log_dirname = Path(log_dir)
+    log_dirname.mkdir(parents=True, exist_ok=True)
+    now = datetime.utcnow().strftime('%Y%m%d%H%M%S')
+    log_filename = '.'.join((log_filename_base, now, 'log'))
+    logfile = log_dirname / log_filename
+    logging_options['handlers']['file']['filename'] = str(logfile)
+
+    # manipulate console verbosity
+    if verbose:
+        logging_options['handlers']['console']['level'] = 'DEBUG'
+
+    # configure logging
+    logging.config.dictConfig(logging_options)
+
+
+def get_daemon_config() -> Tuple[Type[Any], Mapping[str, Any]]:
+    parser = ArgumentParser(
+        prog='plastrond',
+        description='Batch operations daemon for Fedora 4.'
+    )
+    parser.add_argument(
+        '-c', '--config',
+        dest='config_file',
+        help='path to configuration file',
+        type=FileType(),
+        action='store',
+        required=True
+    )
+    parser.add_argument(
+        '-v', '--verbose',
+        help='increase the verbosity of the status output',
+        action='store_true'
+    )
+    parser.add_argument(
+        'interface',
+        help='interface to run',
+        choices=INTERFACES.keys()
+    )
+
+    # parse command line args
+    args = parser.parse_args()
+
+    config = envsubst(yaml.safe_load(args.config_file))
+
+    configure_logging(
+        log_filename_base='plastron.daemon',
+        log_dir=config.get('REPOSITORY', {}).get('LOG_DIR', 'logs'),
+        verbose=args.verbose
+    )
+
+    return INTERFACES[args.interface], config
+
+
+def main():
+    daemon_class, config = get_daemon_config()
+    daemon_description = f'plastrond/{version} ({daemon_class.__name__})'
+
+    logger.info(f'Starting {daemon_description}')
+
+    thread = daemon_class(config=config)
+
+    try:
+        thread.start()
+        while thread.is_alive():
+            thread.join(1)
+    except KeyboardInterrupt:
+        logger.warning(f'Shutting down {daemon_description}')
+        if hasattr(thread, 'running'):
+            thread.running.clear()
+        thread.join(1)
+
+    logger.info(f'Exiting {daemon_description}')
+    sys.exit()
 
 
 if __name__ == "__main__":

--- a/plastron/web.py
+++ b/plastron/web.py
@@ -3,7 +3,7 @@ import urllib.parse
 from pathlib import Path
 
 from flask import Flask, url_for
-from werkzeug.exceptions import InternalServerError, NotFound
+from werkzeug.exceptions import NotFound
 
 from plastron.jobs import ConfigMissingError, ImportJob, JobError
 
@@ -57,7 +57,7 @@ def create_app(config):
         job = get_job(job_id)
         try:
             job.load_config()
-        except ConfigMissingError as e:
+        except ConfigMissingError:
             logger.warning(f'Cannot open config file {job.config_filename} for job {job}')
             # TODO: more complete information in the response body?
             raise NotFound


### PR DESCRIPTION
- plastron.daemon only executes a single child thread, based on the command-line argument (stomp or http)
- changed CMD to ENTRYPOINT in the Docker image so that the daemon mode is easily selectable at docker run-time
- changed the plastrond stack to have two containers, plastrond-stomp and plastrond-http
- updated documentation

https://issues.umd.edu/browse/LIBFCREPO-1075