### PR TITLE
LIBFCREPO-1076. Updated Plastron "stub" command to support Plant Patents ingest

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,7 +2,7 @@
 
 ## Common Options
 
-```
+```text
 $ plastron --help
 usage: plastron [-h] (-r REPO | -c CONFIG_FILE | -V) [-v] [-q]
                 [--on-behalf-of DELEGATED_USER]
@@ -28,7 +28,7 @@ commands:
 
 ### Check version
 
-```
+```bash
 $ plastron --version
 3.5.0
 ```
@@ -41,7 +41,7 @@ All commands require you to specify a configuration file using either the
 
 ### Annotate (annotate)
 
-```
+```text
 $ plastron annotate --help
 usage: plastron annotate [-h] [uris [uris ...]]
 
@@ -56,7 +56,7 @@ optional arguments:
 
 ### Create (create)
 
-```
+```text
 $ plastron create -h
 usage: plastron create [-h] [-D PREDICATE VALUE] [-O PREDICATE VALUE]
                        [-T TYPE] [--collection NAME] [--container PATH]
@@ -91,7 +91,7 @@ optional arguments:
 
 **DEPRECATED:** Use `plastron create --collection` instead.
 
-```
+```text
 $ plastron mkcol --help
 usage: plastron mkcol [-h] -n NAME [-b BATCH] [--notransactions]
 
@@ -111,7 +111,7 @@ See [Delete Command](delete.md)
 
 ### Echo (echo)
 
-```
+```text
 $ plastron echo --help
 usage: plastron echo [-h] [-e ECHO_DELAY] -b BODY
 
@@ -127,7 +127,7 @@ optional arguments:
 
 ### Export (export)
 
-```
+```text
 $ plastron export --help
 usage: plastron export [-h] -o OUTPUT_DEST [--key KEY] -f
                        {text/turtle,turtle,ttl,text/csv,csv}
@@ -158,7 +158,7 @@ optional arguments:
 
 ### Extract OCR (extractocr)
 
-```
+```text
 $ plastron extractocr --help
 usage: plastron extractocr [-h] [--ignore IGNORE]
 
@@ -172,7 +172,7 @@ optional arguments:
 
 ### Image Size (imgsize)
 
-```
+```text
 $ plastron imgsize --help
 usage: plastron imgsize [-h] [uris [uris ...]]
 
@@ -191,7 +191,7 @@ See [Import Command](import.md)
 
 ### List (list, ls)
 
-```
+```text
 $ plastron list --help
 usage: plastron list [-h] [-l] [-R RECURSIVE] [uris [uris ...]]
 
@@ -210,7 +210,7 @@ optional arguments:
 
 ### Load (load)
 
-```
+```text
 $ plastron load --help
 usage: plastron load [-h] -b BATCH [-d] [-n] [-l LIMIT] [-% PERCENT]
                      [--no-annotations] [--no-transactions] [--ignore IGNORE]
@@ -241,7 +241,7 @@ required arguments:
 
 ### Ping (ping)
 
-```
+```text
 $ plastron ping --help
 usage: plastron ping [-h]
 
@@ -253,7 +253,7 @@ optional arguments:
 
 ### Reindex (reindex)
 
-```
+```text
 $ plastron reindex --help
 usage: plastron reindex [-h] [-R RECURSIVE] [uris [uris ...]]
 
@@ -269,9 +269,53 @@ optional arguments:
                         given predicate(s)
 ```
 
+### Stub (stub)
+
+```text
+$ plastron stub --help
+usage: plastron stub [-h] --identifier-column IDENTIFIER_COLUMN
+                     --binary-column BINARY_COLUMN
+                     [--rename-binary-column RENAME_BINARY_COLUMN]
+                     [--member-of MEMBER_OF] [--access ACCESS]
+                     [--container CONTAINER_PATH] [-o OUTPUT_FILE]
+                     source_file
+
+create stub resources with just an identifier and binary
+
+positional arguments:
+  source_file           name of the CSV file to create stubs from; use "-" to
+                        read from STDIN
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --identifier-column IDENTIFIER_COLUMN
+                        column in the source CSV file with a unique identifier
+                        for each item
+  --binary-column BINARY_COLUMN
+                        column in the source CSV file with the location of the
+                        binary to load. Supports http: and https: (must begin
+                        with "http:" or "https:"), and file resources
+                        (relative or absolute file path). Relative file paths
+                        are relative to where the command is run.
+  --rename-binary-column RENAME_BINARY_COLUMN
+                        Renames the binary column in the CSV output to the
+                        provided name.
+  --member-of MEMBER_OF
+                        URI of the object that new items are PCDM members of
+  --access ACCESS       URI or CURIE of the access class to apply to new items
+  --container CONTAINER_PATH
+                        parent container for new items; defaults to the
+                        RELPATH in the repo configuration file
+  -o OUTPUT_FILE, --output-file OUTPUT_FILE
+                        destination for a copy of the source CSV file with the
+                        binary-column value replaced with the newly created
+                        repository URI for the binary; defaults to STDOUT if
+                        not given
+```
+
 ### Update (update)
 
-```
+```text
 $ plastron update --help
 usage: plastron update [-h] -u UPDATE_FILE [-R RECURSIVE] [-d]
                        [--no-transactions] [--validate] [-m MODEL]
@@ -308,7 +352,6 @@ optional arguments:
 
 The repository connection is configured in a YAML file and passed to `plastron`
 with the `-r` or `--repo` option. These are the recognized configuration keys:
-
 
 ### Batch Configuration
 

--- a/plastron/commands/stub.py
+++ b/plastron/commands/stub.py
@@ -1,17 +1,17 @@
 import csv
 import logging
 import sys
-from argparse import FileType, Namespace
 
+from argparse import FileType, Namespace
 from plastron.commands import BaseCommand
 from plastron.exceptions import FailureException, RESTAPIException
-from plastron.files import HTTPFileSource, LocalFileSource
-from plastron.http import Transaction
+from plastron.files import BinarySource, HTTPFileSource, LocalFileSource
+from plastron.http import Repository, Transaction
 from plastron.models import Item
 from plastron.pcdm import File
 from plastron.util import uri_or_curie
 from rdflib import URIRef
-
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -89,39 +89,39 @@ def configure_cli(subparsers):
 
 
 class Command(BaseCommand):
-    @staticmethod
-    def get_source(binary_column_value):
+    def get_source(self, binary_column_value: str) -> Optional[BinarySource]:
         """
         Returns the approriate BinarySource implementation to use, based on the
         value in the binary column, or None if an appropriate BinarySource
         implementation cannot be determined.
         """
+        source: Optional[BinarySource] = None
         if binary_column_value.startswith("http:") or binary_column_value.startswith("https:"):
             source = HTTPFileSource(binary_column_value)
         elif binary_column_value is not None:
             source = LocalFileSource(binary_column_value)
-        else:
-            source = None
         return source
 
-    @staticmethod
-    def write_csv_header(csv_file: csv.DictReader, args: Namespace, csv_writer: csv.DictWriter) -> None:
+    def write_csv_header(self, csv_file: csv.DictReader, args: Namespace, csv_writer: csv.DictWriter) -> None:
         """
         Writes the CSV header line to the output, possibly replacing the
-        binary_column header with a different value.
+        binary_column header with a renamed header.
 
         This is needed because the binary_column in the output will always
         be a URL, while the binary_column in the input may be a filepath
         (and thus have a column name that is not descriptive of the output).
         """
-        csv_header_dict = dict(zip(csv_file.fieldnames, csv_file.fieldnames))
-        if args.rename_binary_column is not None:
-            csv_header_dict[args.binary_column] = args.rename_binary_column
-        # csv_writer.writeheader()
-        csv_writer.writerow(csv_header_dict)
+        if csv_file.fieldnames is not None:
+            csv_header_dict = dict(zip(csv_file.fieldnames, csv_file.fieldnames))
+            if args.rename_binary_column is not None:
+                csv_header_dict[args.binary_column] = args.rename_binary_column
+            csv_writer.writerow(csv_header_dict)
 
-    def __call__(self, repo, args):
+    def __call__(self, repo: Repository, args: Namespace) -> None:
         csv_file = csv.DictReader(args.source_file)
+        if csv_file.fieldnames is None:
+            logger.error(f'No fields found in {csv_file}. Exiting.')
+            sys.exit(1)
 
         if args.output_file is not None:
             output_file = open(args.output_file, 'w')
@@ -129,11 +129,11 @@ class Command(BaseCommand):
             output_file = sys.stdout
         csv_writer = csv.DictWriter(output_file, fieldnames=csv_file.fieldnames)
 
-        Command.write_csv_header(csv_file, args, csv_writer)
+        self.write_csv_header(csv_file, args, csv_writer)
 
         for n, row in enumerate(csv_file, start=1):
             id = row[args.identifier_column]
-            source = Command.get_source(row[args.binary_column])
+            source = self.get_source(row[args.binary_column])
             if not source:
                 logger.warning(f'No source found for {id}; skipping')
                 csv_writer.writerow(row)

--- a/plastron/commands/stub.py
+++ b/plastron/commands/stub.py
@@ -107,7 +107,7 @@ class Command(BaseCommand):
                 with Transaction(repo) as txn:
                     try:
                         item.create(repo, container_path=args.container_path)
-                        item.recursive_update(repo)
+                        item.update(repo)
                         # update the CSV with the new URI
                         row[args.binary_column] = file.uri
                         csv_writer.writerow(row)


### PR DESCRIPTION
Modified the "stub" command to accept local (relative or absolute) file paths
in the "binary_column" read from the CSV file by adding a "get_source" method
returns the appropriate BinarySource (either "HTTPFileSource", "LocalFileSource",
or None), based on the format of the value in the "binary_column" for the row.

Modified the "stub" command to take a "--rename-binary-column" optional
argument, that changes the binary_column name in the CSV output.

This is needed because the binary_column in the output will always
be a URL, while the binary_column in the input may be a filepath
(and thus have a column name that is not descriptive of the output).

https://issues.umd.edu/browse/LIBFCREPO-1076