### PR TITLE
LIBFCREPO-1084. Modified "stub" command to accept URL for "access" flag

### DIFF
--- a/plastron/commands/stub.py
+++ b/plastron/commands/stub.py
@@ -148,8 +148,9 @@ class Command(BaseCommand):
             if args.member_of is not None:
                 item.member_of = URIRef(args.member_of)
             if args.access is not None:
-                item.rdf_types.add(args.access)
-                file.rdf_types.add(args.access)
+                term = uri_or_curie(args.access)
+                item.rdf_types.add(term)
+                file.rdf_types.add(term)
             try:
                 with Transaction(repo) as txn:
                     try:

--- a/plastron/util.py
+++ b/plastron/util.py
@@ -35,7 +35,10 @@ def parse_predicate_list(string, delimiter=','):
     return [from_n3(p, nsm=manager) for p in string.split(delimiter)]
 
 
-def uri_or_curie(arg):
+def uri_or_curie(arg: str):
+    if arg and (arg.startswith('http://') or arg.startswith('https://')):
+        # looks like an absolute HTTP URI
+        return URIRef(arg)
     try:
         term = from_n3(arg, nsm=namespaces.get_manager())
     except KeyError:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,32 @@
+import pytest
+
+from argparse import ArgumentTypeError
+from plastron.util import uri_or_curie
+from rdflib.term import URIRef
+
+
+class TestUriOrCurie:
+    # Tests for the "uri_or_curie" function
+
+    def test_given_None__raises_ArgumentTypeError(self):
+        with pytest.raises(ArgumentTypeError):
+            uri_or_curie(None)
+
+    def test_given_empty_string__raises_ArgumentTypeError(self):
+        with pytest.raises(ArgumentTypeError):
+            uri_or_curie('')
+
+    def test_given_invalid_curie__raises_ArgumentTypeError(self):
+        with pytest.raises(ArgumentTypeError):
+            uri_or_curie('not_in_namespace:Foo')
+
+    def test_given_valid_curie__returns_term(self):
+        assert uri_or_curie('umdaccess:Public') == URIRef('http://vocab.lib.umd.edu/access#Public')
+
+    def test_given_valid_N3_URI__returns_term(self):
+        assert uri_or_curie('<http://vocab.lib.umd.edu/access#Public>') == \
+            URIRef('http://vocab.lib.umd.edu/access#Public')
+
+    def test_given_valid_simple_URI__returns_term(self):
+        assert uri_or_curie('http://vocab.lib.umd.edu/access#Public') == \
+            URIRef('http://vocab.lib.umd.edu/access#Public')


### PR DESCRIPTION
Modified the "uri_or_curie" function in "plastron/util.py" to return
a URIRef if a simple URL is provided as an argument. This enables a
simple URL to be provided to the "access" flag of the "stub" command.

Modified the "plastron/commands/stub.py" file, so that the term returned
by by the "uri_or_curie" function is actually used to populate the
RDF type of the item being added, instead of simply using the bare
string provided in the arguments.

https://issues.umd.edu/browse/LIBFCREPO-1084