### PR TITLE
LIBFCREPO-1093. Use requests to read remote vocabularies directly.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,6 +100,7 @@ pipeline {
           python -m pip install virtualenv
           virtualenv venv
           . venv/bin/activate
+          pip install --force-reinstall 'setuptools<58.0.0'
 
           pip install -e .[test]
         '''

--- a/plastron/validation/vocabularies/__init__.py
+++ b/plastron/validation/vocabularies/__init__.py
@@ -36,7 +36,7 @@ def get_vocabulary(vocab_uri: str) -> Graph:
     # does not support "308 Permanent Redirect" responses as redirection and
     # instead treats them as errors. This is fixed in rdflib 6.0.0, but that
     # requires Python > 3.7, and Plastron currently uses 3.6
-    response = requests.get(vocab_uri)
+    response = requests.get(vocab_uri, headers={'Accept': 'application/ld+json, text/turtle'})
     if not response.ok:
         raise ValidationError(f'Unable to retrieve vocabulary from {vocab_uri}: {response}')
     graph.parse(data=response.text, format=response.headers['Content-Type'])

--- a/plastron/validation/vocabularies/__init__.py
+++ b/plastron/validation/vocabularies/__init__.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import List
 from urllib.error import HTTPError
 
+import requests
 from rdflib import Graph
 
 from plastron.validation import ValidationError
@@ -32,10 +33,14 @@ def get_vocabulary(vocab_uri: str) -> Graph:
             logger.info('Falling back to remote retrieval')
 
     # otherwise, fall back to remote retrieval
-    try:
-        graph.parse(location=vocab_uri)
-    except HTTPError as e:
-        raise ValidationError(f'Unable to retrieve vocabulary from {vocab_uri}: {e}') from e
+    # LIBFCREPO-1093: use requests to fetch the vocab_uri, since rdflib < 6.0.0
+    # does not support "308 Permanent Redirect" responses as redirection and
+    # instead treats them as errors. This is fixed in rdflib 6.0.0, but that
+    # requires Python > 3.7, and Plastron currently uses 3.6
+    response = requests.get(vocab_uri)
+    if not response.ok:
+        raise ValidationError(f'Unable to retrieve vocabulary from {vocab_uri}: {response}')
+    graph.parse(data=response.text, format=response.headers['Content-Type'])
 
     return graph
 

--- a/plastron/validation/vocabularies/__init__.py
+++ b/plastron/validation/vocabularies/__init__.py
@@ -3,7 +3,6 @@ from functools import lru_cache
 from os.path import abspath, dirname
 from pathlib import Path
 from typing import List
-from urllib.error import HTTPError
 
 import requests
 from rdflib import Graph

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ PyYAML==5.4.1
 rdflib==5.0.0
 rdflib-jsonld==0.5.0
 requests==2.26.0
+setuptools==57.4.0
 six==1.16.0
 soupsieve==2.2.1
 stomp.py==6.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ Deprecated==1.2.12
 docopt==0.6.2
 edtf-validate==2.0.0
 Flask==2.0.1
+httpretty==1.1.4
 idna==3.2
 importlib-metadata==4.6.1
 iso639==0.1.4
@@ -28,6 +29,8 @@ Pillow==8.3.2
 pycparser==2.20
 PyNaCl==1.4.0
 pyparsing==2.4.7
+pytest==6.2.4
+pytest-datadir==1.3.1
 pytz==2021.1
 PyYAML==5.4.1
 rdflib==5.0.0

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
         'pyparsing',
         'PyYAML>3.12',
         'rdflib',
-        'rdflib-jsonld',
+        'rdflib-jsonld==0.5.0',
         'requests',
         'setuptools',
         'stomp.py==6.1.0',

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ setup(
     # projects.
     extras_require={  # Optional
         'dev': ['pycodestyle'],
-        'test': ['pytest', 'freezegun', 'http-server-mock'],
+        'test': ['pytest', 'pytest-datadir', 'freezegun', 'http-server-mock', 'httpretty'],
     },
 
     # TODO: config/templates/*.yml?

--- a/setup.py
+++ b/setup.py
@@ -83,10 +83,10 @@ setup(
         'Pillow>=6.2.2',
         'pyparsing',
         'PyYAML>3.12',
-        'rdflib',
+        'rdflib<6.0.0',
         'rdflib-jsonld==0.5.0',
         'requests',
-        'setuptools',
+        'setuptools<58.0.0',
         'stomp.py==6.1.0',
         'waitress',
         'watchdog==0.10.3'

--- a/tests/data/form.json
+++ b/tests/data/form.json
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "dc": "http://purl.org/dc/elements/1.1/"
+  },
+  "@graph": [
+    {
+      "@id": "http://vocab.lib.umd.edu/form#slides_photographs",
+      "dc:identifier": "slides_photographs",
+      "rdfs:label": "Slides (photographs)",
+      "owl:sameAs": {
+        "@id": "http://vocab.getty.edu/page/aat/300128371"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
rdflib < 6.0.0 does not support "308 Permanent Redirect" responses as redirection and instead treats them as errors. This is fixed in rdflib 6.0.0, but that requires Python > 3.7, and Plastron currently uses 3.6.

This PR adds the `httpretty` and `pytest-datadir` libraries as test dependencies, to facilitate testing of specific HTTP request/response chains and to make creating reusable data file fixtures easier.

https://issues.umd.edu/browse/LIBFCREPO-1093