### PR TITLE
LIBFCREPO-1104. Bump Python version in docker image to 3.7.15 to support arm64 builds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # docker build -t docker.lib.umd.edu/plastrond:<VERSION> -f Dockerfile .
 #
 # where <VERSION> is the Docker image version to create.
-FROM python:3.6.12-slim
+FROM python:3.7.15-slim
 
 RUN mkdir -p /opt/plastron
 COPY . /opt/plastron

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,14 +21,15 @@ Jinja2==3.0.1
 jwcrypto==0.9.1
 lxml==4.9.1
 MarkupSafe==2.0.1
-numpy==1.19.5;python_version<"3.10"
+numpy==1.19.5;python_version<"3.8"
+numpy==1.20.0;python_version=="3.8" or python_version=="3.9"
 numpy==1.22.0;python_version>="3.10"
 paramiko==2.10.1
 pathtools==0.1.2
 Pillow==8.3.2;python_version<"3.7"
 Pillow==9.0.1;python_version>="3.7"
 pycparser==2.20
-PyNaCl==1.4.0
+PyNaCl==1.5.0
 pyparsing==2.4.7
 pytz==2021.1
 PyYAML==5.4.1


### PR DESCRIPTION
Also bumped PyNaCl version to 1.5.0, and added finer granularity to numpy versions.

https://issues.umd.edu/browse/LIBFCREPO-1104