### PR TITLE
LIBFCREPO-1109. Implemented "find" command.

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,7 +6,7 @@
 $ plastron --help
 usage: plastron [-h] (-r REPO | -c CONFIG_FILE | -V) [-v] [-q]
                 [--on-behalf-of DELEGATED_USER]
-                {annotate,create,delete,del,rm,echo,export,extractocr,imgsize,import,list,ls,load,mkcol,ping,reindex,stub,update}
+                {annotate,create,delete,del,rm,echo,export,extractocr,find,imgsize,import,list,ls,load,mkcol,ping,reindex,stub,update}
                 ...
 
 Batch operation tool for Fedora 4.
@@ -23,7 +23,7 @@ optional arguments:
                         delegate repository operations to this username
 
 commands:
-  {annotate,create,delete,del,rm,echo,export,extractocr,imgsize,import,list,ls,load,mkcol,ping,reindex,stub,update}
+  {annotate,create,delete,del,rm,echo,export,extractocr,find,imgsize,import,list,ls,load,mkcol,ping,reindex,stub,update}
 ```
 
 ### Check version
@@ -89,7 +89,7 @@ optional arguments:
 
 ### Create Collection (mkcol)
 
-**DEPRECATED:** Use `plastron create --collection` instead.
+**DEPRECATED:** Use [`plastron create --collection`](#create-create) instead.
 
 ```text
 $ plastron mkcol --help
@@ -168,6 +168,40 @@ optional arguments:
   -h, --help            show this help message and exit
   --ignore IGNORE, -i IGNORE
                         file listing items to ignore
+```
+
+### Find (find)
+
+```text
+$ plastron find --help
+usage: plastron find [-h] [-R RECURSIVE] [-D PREDICATE VALUE]
+                     [-O PREDICATE VALUE] [-T TYPE]
+                     [--match-all | --match-any]
+                     [URI [URI ...]]
+
+Find objects in the repository
+
+positional arguments:
+  URI                   search at this URI in the repository
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -R RECURSIVE, --recursive RECURSIVE
+                        search additional objects found by traversing the
+                        given predicate(s)
+  -D PREDICATE VALUE, --data-property PREDICATE VALUE
+                        an RDF data property to match; VALUE is treated as a
+                        Literal; repeatable
+  -O PREDICATE VALUE, --object-property PREDICATE VALUE
+                        an RDF object property to match; VALUE is treated as a
+                        CURIE or URIRef; repeatable
+  -T TYPE, --rdf-type TYPE
+                        RDF type to match; equivalent to "-O rdf:type TYPE";
+                        TYPE is treated as a CURIE or URIRef; repeatable
+  --match-all           require all properties to match to include a resource
+                        in the result list; this is the default behavior
+  --match-any           require at least one property to match to include a
+                        resource in the result list
 ```
 
 ### Image Size (imgsize)

--- a/plastron/commands/find.py
+++ b/plastron/commands/find.py
@@ -1,6 +1,6 @@
-from typing import List, Tuple, Union, Literal
+from typing import List, Tuple, Union
 
-from rdflib import URIRef
+from rdflib import URIRef, Literal
 
 import logging
 from plastron.commands import BaseCommand

--- a/plastron/commands/find.py
+++ b/plastron/commands/find.py
@@ -1,0 +1,129 @@
+from typing import List, Tuple, Union, Literal
+
+from rdflib import URIRef
+
+import logging
+from plastron.commands import BaseCommand
+from plastron.namespaces import get_manager, rdf
+from plastron.util import ResourceList, parse_predicate_list, uri_or_curie, parse_data_property, parse_object_property
+
+logger = logging.getLogger(__name__)
+manager = get_manager()
+
+
+def configure_cli(subparsers):
+    parser = subparsers.add_parser(
+        name='find',
+        description='Find objects in the repository'
+    )
+    parser.add_argument(
+        '-R', '--recursive',
+        help='search additional objects found by traversing the given predicate(s)',
+        action='store'
+    )
+    parser.add_argument(
+        '-D', '--data-property',
+        help=(
+            'an RDF data property to match; '
+            'VALUE is treated as a Literal; repeatable'
+        ),
+        action='append',
+        nargs=2,
+        dest='data_properties',
+        metavar=('PREDICATE', 'VALUE'),
+        default=[]
+    )
+    parser.add_argument(
+        '-O', '--object-property',
+        help=(
+            'an RDF object property to match; '
+            'VALUE is treated as a CURIE or URIRef; repeatable'
+        ),
+        action='append',
+        nargs=2,
+        dest='object_properties',
+        metavar=('PREDICATE', 'VALUE'),
+        default=[]
+    )
+    parser.add_argument(
+        '-T', '--rdf-type',
+        help=(
+            'RDF type to match; equivalent to "-O rdf:type TYPE"; '
+            'TYPE is treated as a CURIE or URIRef; repeatable'
+        ),
+        action='append',
+        dest='types',
+        metavar='TYPE',
+        default=[]
+    )
+    any_or_all = parser.add_mutually_exclusive_group()
+    any_or_all.add_argument(
+        '--match-all',
+        help=(
+            'require all properties to match to include a resource in the result list; '
+            'this is the default behavior'
+        ),
+        default=False,
+        action='store_true'
+    )
+    any_or_all.add_argument(
+        '--match-any',
+        help='require at least one property to match to include a resource in the result list',
+        default=False,
+        action='store_true'
+    )
+    parser.add_argument(
+        'uris', nargs='*',
+        metavar='URI',
+        help='search at this URI in the repository'
+    )
+    parser.set_defaults(cmd_name='find')
+
+
+class Command(BaseCommand):
+    def __call__(self, fcrepo, args):
+        self.properties: List[Tuple[URIRef, Union[Literal, URIRef]]] = [
+            *(parse_data_property(p, o) for p, o in args.data_properties),
+            *(parse_object_property(p, o) for p, o in args.object_properties)
+        ]
+
+        for rdf_type in args.types:
+            self.properties.append((rdf.type, uri_or_curie(rdf_type)))
+
+        if args.match_any:
+            self.match = any
+        elif args.match_all:
+            self.match = all
+        else:
+            self.match = all
+
+        logger.info(f'Matching {self.match.__name__} of these properties:')
+        for p, o in self.properties:
+            logger.info(f'  {p.n3(namespace_manager=manager)} {o.n3(namespace_manager=manager)}')
+
+        self.resource_count = 0
+
+        resources = ResourceList(
+            repository=fcrepo,
+            uri_list=args.uris
+        )
+
+        resources.process(
+            method=self.find,
+            traverse=parse_predicate_list(args.recursive),
+            use_transaction=False
+        )
+
+        logger.info(f'Found {self.resource_count} resource(s)')
+
+    def find(self, resource, graph):
+        if len(self.properties) > 0:
+            subject = URIRef(resource.uri)
+            if self.match((subject, p, o) in graph for p, o in self.properties):
+                self.resource_count += 1
+                print(resource)
+        else:
+            # with no filters specified, list all resources found
+            # this mimics the behavior of the Linux "find" command
+            self.resource_count += 1
+            print(resource)

--- a/tests/commands/test_find.py
+++ b/tests/commands/test_find.py
@@ -1,0 +1,40 @@
+import pytest
+from rdflib import Graph, Literal
+
+from plastron.commands.find import Command
+from plastron.http import ResourceURI
+from plastron.namespaces import rdf, pcdm, dcterms
+
+
+@pytest.fixture
+def resources(datadir):
+    source_graph = Graph()
+    with open(datadir / 'graph.ttl', 'r') as fh:
+        source_graph.load(fh, format='turtle')
+
+    resource_graphs = []
+    for subject in set(source_graph.subjects()):
+        graph = Graph()
+        for triple in source_graph.triples((subject, None, None)):
+            graph.add(triple)
+        resource_graphs.append((ResourceURI(subject, subject), graph))
+    return resource_graphs
+
+
+@pytest.mark.parametrize(
+    ['match_condition', 'property_filter', 'expected_count'],
+    [
+        (all, [], 2),
+        (all, [(rdf.type, pcdm.Object)], 1),
+        (all, [(rdf.type, pcdm.Object), (dcterms.title, Literal('Moonpig'))], 0),
+        (any, [(rdf.type, pcdm.Object), (dcterms.title, Literal('Moonpig'))], 2),
+    ]
+)
+def test_find(resources, match_condition, property_filter, expected_count):
+    cmd = Command()
+    cmd.resource_count = 0
+    cmd.properties = property_filter
+    cmd.match = match_condition
+    for resource, graph in resources:
+        cmd.find(resource, graph)
+    assert cmd.resource_count == expected_count

--- a/tests/commands/test_find/graph.ttl
+++ b/tests/commands/test_find/graph.ttl
@@ -1,0 +1,6 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix pcdm: <http://pcdm.org/models#> .
+
+<http://example.com/test_find/1> a pcdm:Object; dcterms:title "Foobar" .
+
+<http://example.com/test_find/2> dcterms:title "Moonpig" .

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,67 +1,86 @@
 import pytest
 
 from argparse import ArgumentParser, ArgumentTypeError
-from plastron.util import uri_or_curie
-from rdflib.term import URIRef
+
+from plastron.namespaces import dcterms, rdf, pcdm
+from plastron.util import uri_or_curie, parse_data_property, parse_object_property
+from rdflib.term import URIRef, Literal
+
+INVALID_URI_OR_CURIE_ARGS = [
+    # None
+    None,
+    # empty string
+    '',
+    # unrecognized namespace
+    'not_in_namespace:Foo'
+]
+VALID_URI_OR_CURIE_ARGS = [
+    # CURIE
+    'umdaccess:Public',
+    # N3-formatted URI
+    '<http://vocab.lib.umd.edu/access#Public>',
+    # plain string HTTP URI
+    'http://vocab.lib.umd.edu/access#Public'
+]
+EXPECTED_TERM = URIRef('http://vocab.lib.umd.edu/access#Public')
 
 
 # Tests for the "uri_or_curie" function
 
-def test_given_None__raises_ArgumentTypeError():
+@pytest.mark.parametrize(
+    'arg_value', INVALID_URI_OR_CURIE_ARGS
+)
+def test_given_invalid_uri_or_curie__raises_error(arg_value):
     with pytest.raises(ArgumentTypeError):
-        uri_or_curie(None)
-
-
-def test_given_empty_string__raises_ArgumentTypeError():
-    with pytest.raises(ArgumentTypeError):
-        uri_or_curie('')
-
-
-def test_given_invalid_curie__raises_ArgumentTypeError():
-    with pytest.raises(ArgumentTypeError):
-        uri_or_curie('not_in_namespace:Foo')
-
-
-def test_given_valid_curie__returns_term():
-    assert uri_or_curie('umdaccess:Public') == URIRef('http://vocab.lib.umd.edu/access#Public')
-
-
-def test_given_valid_N3_URI__returns_term():
-    assert uri_or_curie('<http://vocab.lib.umd.edu/access#Public>') == \
-        URIRef('http://vocab.lib.umd.edu/access#Public')
-
-
-def test_given_valid_simple_URI__returns_term():
-    assert uri_or_curie('http://vocab.lib.umd.edu/access#Public') == \
-        URIRef('http://vocab.lib.umd.edu/access#Public')
+        uri_or_curie(arg_value)
 
 
 @pytest.mark.parametrize(
-    'arg_value', [
-        # CURIE
-        'umdaccess:Public',
-        # N3-formatted URI
-        '<http://vocab.lib.umd.edu/access#Public>',
-        # plain string HTTP URI
-        'http://vocab.lib.umd.edu/access#Public'
-    ]
+    'arg_value', VALID_URI_OR_CURIE_ARGS
+)
+def test_given_valid_uri_or_curie__returns_term(arg_value):
+    assert uri_or_curie(arg_value) == EXPECTED_TERM
+
+
+@pytest.mark.parametrize(
+    'arg_value', VALID_URI_OR_CURIE_ARGS
 )
 def test_given_valid_uri_or_curie_type__parse_args_returns_uriref(arg_value):
     parser = ArgumentParser()
     parser.add_argument('--access', type=uri_or_curie)
     args = parser.parse_args(('--access', arg_value))
     assert isinstance(args.access, URIRef)
+    assert args.access == EXPECTED_TERM
 
 
 @pytest.mark.parametrize(
-    'arg_value', [
-        None,
-        '',
-        'not_in_namespace:Foo'
-    ]
+    'arg_value', INVALID_URI_OR_CURIE_ARGS
 )
 def test_given_invalid_uri_or_curie_type__parse_args_exits(arg_value):
     parser = ArgumentParser()
     parser.add_argument('--access', type=uri_or_curie)
     with pytest.raises(SystemExit):
         parser.parse_args(('--access', arg_value))
+
+
+@pytest.mark.parametrize(
+    ('p', 'o', 'expected'),
+    [
+        ('dcterms:title', 'Foobar', (dcterms.title, Literal('Foobar'))),
+        ('dcterms:title', '"der Hund"@de', (dcterms.title, Literal('der Hund', lang='de')))
+    ]
+)
+def test_parse_data_property(p, o, expected):
+    assert parse_data_property(p, o) == expected
+
+
+@pytest.mark.parametrize(
+    ('p', 'o', 'expected'),
+    [
+        ('rdf:type', 'pcdm:Object', (rdf.type, pcdm.Object)),
+        ('dcterms:creator', 'https://www.lib.umd.edu/', (dcterms.creator, URIRef('https://www.lib.umd.edu/'))),
+        ('dcterms:creator', '<https://www.lib.umd.edu/>', (dcterms.creator, URIRef('https://www.lib.umd.edu/')))
+    ]
+)
+def test_parse_object_property(p, o, expected):
+    assert parse_object_property(p, o) == expected


### PR DESCRIPTION
* searches a list of URIs for one's whose graph matches all (or any) of the RDF properties given on the command line
* default to match all (--match-all); use "--match-any" flag to change
* provides a count of the number of resources found
* allows recursive search with the '--recursive/-R' flag
* moved parse_data_property and parse_object_property into plastron.util
* updated tests

https://issues.umd.edu/browse/LIBFCREPO-1109