### PR TITLE
LIBFCREPO-1121. Set the model class each time update is executed.

### DIFF
--- a/plastron/commands/update.py
+++ b/plastron/commands/update.py
@@ -82,7 +82,7 @@ class Command(BaseCommand):
         self.resources = None
         self.validate = False
         self.model = None
-        self._model_class = None
+        self.model_class = None
         self.stats = {
             'updated': [],
             'invalid': defaultdict(list),
@@ -92,22 +92,18 @@ class Command(BaseCommand):
     def __call__(self, fcrepo, args):
         self.execute(fcrepo, args)
 
-    @property
-    def model_class(self):
-        if self._model_class is None:
-            # Retrieve the model to use for validation
-            try:
-                self._model_class = getattr(importlib.import_module("plastron.models"), self.model)
-            except AttributeError as e:
-                raise FailureException(f'Unable to load model "{self.model}"') from e
-        return self._model_class
-
     def execute(self, fcrepo, args):
         self.repository = fcrepo
         self.repository.test_connection()
         self.dry_run = args.dry_run
         self.validate = args.validate
         self.model = args.model
+        # Retrieve the model to use for validation
+        logger.debug(f'Loading model class "{self.model}"')
+        try:
+            self.model_class = getattr(importlib.import_module("plastron.models"), self.model)
+        except AttributeError as e:
+            raise FailureException(f'Unable to load model "{self.model}"') from e
         self.stats = {
             'updated': [],
             'invalid': defaultdict(list),

--- a/plastron/commands/update.py
+++ b/plastron/commands/update.py
@@ -98,12 +98,6 @@ class Command(BaseCommand):
         self.dry_run = args.dry_run
         self.validate = args.validate
         self.model = args.model
-        # Retrieve the model to use for validation
-        logger.debug(f'Loading model class "{self.model}"')
-        try:
-            self.model_class = getattr(importlib.import_module("plastron.models"), self.model)
-        except AttributeError as e:
-            raise FailureException(f'Unable to load model "{self.model}"') from e
         self.stats = {
             'updated': [],
             'invalid': defaultdict(list),
@@ -112,6 +106,14 @@ class Command(BaseCommand):
 
         if self.validate and not self.model:
             raise FailureException("Model must be provided when performing validation")
+
+        if self.model:
+            # Retrieve the model to use for validation
+            logger.debug(f'Loading model class "{self.model}"')
+            try:
+                self.model_class = getattr(importlib.import_module("plastron.models"), self.model)
+            except AttributeError as e:
+                raise FailureException(f'Unable to load model "{self.model}"') from e
 
         self.sparql_update = args.update_file.read().encode('utf-8')
 


### PR DESCRIPTION
This addresses the issue where the first model to be used got "stuck", and future updates used that same model, regardless of what the request message headers were set to.

https://issues.umd.edu/browse/LIBFCREPO-1121