### PR TITLE
LIBFCREPO-1135: Fixing retrieving the URI and Titles

### DIFF
--- a/plastron/commands/load.py
+++ b/plastron/commands/load.py
@@ -183,8 +183,8 @@ class Command(BaseCommand):
                        'timestamp': getattr(
                            item, 'creation_timestamp', str(datetime.utcnow())
                        ),
-                       'title': getattr(item, 'title', 'N/A'),
-                       'uri': getattr(item, 'uri', 'N/A')
+                       'title': getattr(item.issue, 'title', 'N/A'),
+                       'uri': getattr(item.issue, 'uri', 'N/A')
                        }
 
                 # write item details to relevant summary CSV


### PR DESCRIPTION
In https://umd-dit.atlassian.net/browse/LIBFCREPO-672 the class hierarchy was changed, which caused the BatchItem to no longer inherit the rdf.Resource class. Instead, the item's issue variable was inheriting the rdf.Resource, so that's how we're able to obtain the uri and title.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1135