### PR TITLE
LIBFCREPO 1136: Allow import of binaries at the item level

### DIFF
--- a/plastron/commands/importcommand.py
+++ b/plastron/commands/importcommand.py
@@ -554,7 +554,7 @@ class Command(BaseCommand):
                 raise FailureException()
             logger.info(f'Writing template for the {job.model_class.__name__} model to {args.template_file.name}')
             writer = csv.writer(args.template_file)
-            writer.writerow(list(job.model_class.HEADER_MAP.values()) + ['FILES'])
+            writer.writerow(list(job.model_class.HEADER_MAP.values()) + ['FILES', 'ITEM_FILES'])
             return
 
         if args.import_file is None and not args.resume:
@@ -723,6 +723,15 @@ class Command(BaseCommand):
                     base_location=job.binaries_location,
                     access=job.access,
                     create_pages=create_pages
+                )
+
+            if row.has_item_files:
+                self.add_files(
+                    item,
+                    build_file_groups(row['ITEM_FILES']),
+                    base_location=job.binaries_location,
+                    access=job.access,
+                    create_pages=False
                 )
 
             if args.extract_text_types is not None:

--- a/plastron/jobs.py
+++ b/plastron/jobs.py
@@ -531,6 +531,10 @@ class Row:
     @property
     def has_files(self):
         return 'FILES' in self.data and self.data['FILES'].strip() != ''
+    
+    @property
+    def has_item_files(self):
+        return 'ITEM_FILES' in self.data and self.data['ITEM_FILES'].strip() != ''
 
     @property
     def filenames(self):

--- a/plastron/jobs.py
+++ b/plastron/jobs.py
@@ -531,7 +531,7 @@ class Row:
     @property
     def has_files(self):
         return 'FILES' in self.data and self.data['FILES'].strip() != ''
-    
+
     @property
     def has_item_files(self):
         return 'ITEM_FILES' in self.data and self.data['ITEM_FILES'].strip() != ''

--- a/plastron/serializers.py
+++ b/plastron/serializers.py
@@ -103,7 +103,7 @@ def write_csv_file(row_info, file):
 
 
 class CSVSerializer:
-    SYSTEM_HEADERS = ['URI', 'PUBLIC URI', 'CREATED', 'MODIFIED', 'INDEX', 'FILES']
+    SYSTEM_HEADERS = ['URI', 'PUBLIC URI', 'CREATED', 'MODIFIED', 'INDEX', 'FILES', 'ITEM_FILES']
 
     def __init__(self, directory=None, public_uri_template=None):
         self.directory_name = directory or os.path.curdir


### PR DESCRIPTION
- Templates generated will now have the ITEM_FILES column in the csv file
- Files in the ITEM_FILES column will now have resources without a page created
- Old files without the ITEM_FILES column will still work

https://umd-dit.atlassian.net/browse/LIBFCREPO-1136