### PR TITLE
LIBFCREPO-1027: Fixing Solr indexing using plastron create

### DIFF
--- a/plastron/cli.py
+++ b/plastron/cli.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from importlib import import_module
 from pkgutil import iter_modules
 from plastron import commands, version
-from plastron.exceptions import FailureException
+from plastron.exceptions import FailureException, ConfigError
 from plastron.logging import DEFAULT_LOGGING_OPTIONS
 from plastron.http import Repository
 from plastron.stomp import Broker
@@ -89,6 +89,14 @@ def main():
         action='store'
     )
 
+    parser.add_argument(
+        '--batch-mode', '-bm',
+        help='specifies the use of batch user for interaction with fcrepo',
+        dest='batch_mode',
+        action='store',
+        default=False
+    )
+
     subparsers = parser.add_subparsers(title='commands')
 
     command_modules = load_commands(subparsers)
@@ -114,9 +122,13 @@ def main():
         broker_config = None
         command_config = {}
 
-    fcrepo = Repository(
-        repo_config, ua_string=f'plastron/{version}', on_behalf_of=args.delegated_user
-    )
+    try:
+        fcrepo = Repository(
+            repo_config, ua_string=f'plastron/{version}', on_behalf_of=args.delegated_user, batch_mode=args.batch_mode
+        )
+    except ConfigError as e:
+        logger.error(str(e))
+        sys.exit(1)
 
     if broker_config is not None:
         broker = Broker(broker_config)

--- a/plastron/http.py
+++ b/plastron/http.py
@@ -91,7 +91,7 @@ class HierarchicalCreator:
 
 
 class Repository:
-    def __init__(self, config, ua_string=None, on_behalf_of=None):
+    def __init__(self, config, ua_string=None, on_behalf_of=None, batch_mode=False):
         # repo root
         self.endpoint = config['REST_ENDPOINT'].rstrip('/')
 
@@ -110,6 +110,7 @@ class Repository:
             [p.strip('/') for p in (self.endpoint, self.relpath)]
         )
         self.session = requests.Session()
+        self.session.batch_mode = batch_mode
         self.jwt_secret = None
         self.transaction = None
         self.load_binaries = True

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -8,6 +8,7 @@ from freezegun import freeze_time
 from jwcrypto.jwk import JWK
 from jwcrypto.jwt import JWT
 from requests import Session
+from plastron.exceptions import ConfigError
 
 from plastron.auth import AuthFactory, ProvidedJwtTokenAuth, JwtSecretAuth, ClientCertAuth, FedoraUserAuth
 
@@ -24,16 +25,40 @@ def test_auth_factory_bad_config():
         auth = AuthFactory.create(config)
 
 
-def test_auth_factory_provided_jwt():
+def test_auth_factory_provided_jwt_default_credentials():
     config = {'AUTH_TOKEN': 'abcd-1234'}
     auth = AuthFactory.create(config)
     assert isinstance(auth, ProvidedJwtTokenAuth)
 
     session = Session()
+    session.batch_mode = False
     auth.configure_session(session)
 
     assert session.headers.get('Authorization')
     assert session.headers['Authorization'] == 'Bearer abcd-1234'
+
+
+def test_auth_factory_provided_jwt_batch_credentials():
+    config = {'AUTH_TOKEN': 'abcd-1234', 'BATCH_MODE': {'PLASTRON_BATCH': 'batch-abcd-1234'}}
+    auth = AuthFactory.create(config)
+    session = Session()
+    session.batch_mode = True
+    auth.configure_session(session)
+
+    assert session.headers.get('Authorization')
+    assert session.headers['Authorization'] == 'Bearer batch-abcd-1234'
+
+
+def test_auth_factory_provided_jwt_no_batch_credentials():
+    config = {'AUTH_TOKEN': 'abcd-1234'}
+    auth = AuthFactory.create(config)
+    session = Session()
+    session.batch_mode = True
+
+    try:
+        auth.configure_session(session)
+    except ConfigError:
+        pass
 
 
 def test_auth_factory_jwt_secret():


### PR DESCRIPTION
A --batch-mode was added to the plastron command that will look for an alternative set of fcrepo credentials, and will use those instead. This means that we can seperate the batch uploads from the single uploads, and the single uploads won't cause a reindexing in Solr

https://umd-dit.atlassian.net/browse/LIBFCREPO-1027