### PR TITLE
LIBFCREPO-1166: Removing the "exactly" key

### DIFF
--- a/plastron/models/letter.py
+++ b/plastron/models/letter.py
@@ -128,7 +128,7 @@ class Letter(pcdm.Object):
         },
         'handle': {
             'required': False,
-            'exactly': 1,
+            # 'exactly': 1,
             'function': is_handle
         },
     }

--- a/plastron/models/newspaper.py
+++ b/plastron/models/newspaper.py
@@ -50,7 +50,7 @@ class Issue(pcdm.Object):
         },
         'handle': {
             'required': False,
-            'exactly': 1,
+            # 'exactly': 1,
             'function': is_handle
         },
     }

--- a/plastron/models/poster.py
+++ b/plastron/models/poster.py
@@ -118,7 +118,7 @@ class Poster(pcdm.Object):
         },
         'handle': {
             'required': False,
-            'exactly': 1,
+            # 'exactly': 1,
             'function': is_handle
         },
     }

--- a/plastron/models/umd.py
+++ b/plastron/models/umd.py
@@ -107,7 +107,7 @@ class Item(pcdm.Object):
         },
         'handle': {
             'required': False,
-            'exactly': 1,
+            # 'exactly': 1,
             'function': is_handle
         },
     }

--- a/plastron/validation/__init__.py
+++ b/plastron/validation/__init__.py
@@ -36,6 +36,9 @@ def is_valid_iso639_code(value):
 
 
 def is_handle(value: str) -> bool:
+    # Allow blank values
+    if str(value).strip() == "":
+        return True
     return bool(re.match('hdl:[^/]+/.*', value))
 
 

--- a/plastron/validation/__init__.py
+++ b/plastron/validation/__init__.py
@@ -36,9 +36,6 @@ def is_valid_iso639_code(value):
 
 
 def is_handle(value: str) -> bool:
-    # Allow blank values
-    if str(value).strip() == "":
-        return True
     return bool(re.match('hdl:[^/]+/.*', value))
 
 


### PR DESCRIPTION
Plastron import may be erroring with blank handles because of this key in the models

https://umd-dit.atlassian.net/browse/LIBFCREPO-1166