### PR TITLE
LIBFCREPO-1165: Fixing spelling issue with identifier

### DIFF
--- a/plastron/models/letter.py
+++ b/plastron/models/letter.py
@@ -49,7 +49,7 @@ class Collection(LabeledThing):
 @rdf.data_property('bibliographic_citation', dcterms.bibliographicCitation)
 @rdf.data_property('extent', dcterms.extent)
 @rdf.data_property('rights_holder', dcterms.rightsHolder)
-@rdf.data_property('handle', dcterms.identifer, datatype=umdtype.handle)
+@rdf.data_property('handle', dcterms.identifier, datatype=umdtype.handle)
 @rdf.rdf_class(bibo.Letter)
 class Letter(pcdm.Object):
     HEADER_MAP = {

--- a/plastron/models/newspaper.py
+++ b/plastron/models/newspaper.py
@@ -14,7 +14,7 @@ umdtype = Namespace('http://vocab.lib.umd.edu/datatype#')
 @rdf.data_property('volume', bibo.volume)
 @rdf.data_property('issue', bibo.issue)
 @rdf.data_property('edition', bibo.edition)
-@rdf.data_property('handle', dcterms.identifer, datatype=umdtype.handle)
+@rdf.data_property('handle', dcterms.identifier, datatype=umdtype.handle)
 @rdf.rdf_class(bibo.Issue)
 class Issue(pcdm.Object):
     """Newspaper issue"""

--- a/plastron/models/poster.py
+++ b/plastron/models/poster.py
@@ -26,7 +26,7 @@ umdtype = Namespace('http://vocab.lib.umd.edu/datatype#')
 @rdf.data_property('part_of', dcterms.isPartOf)
 @rdf.data_property('publisher', dc.publisher)
 @rdf.data_property('alternative', dcterms.alternative)
-@rdf.data_property('handle', dcterms.identifer, datatype=umdtype.handle)
+@rdf.data_property('handle', dcterms.identifier, datatype=umdtype.handle)
 @rdf.rdf_class(bibo.Image)
 class Poster(pcdm.Object):
     HEADER_MAP = {

--- a/plastron/models/umd.py
+++ b/plastron/models/umd.py
@@ -29,7 +29,7 @@ umdform = Namespace('http://vocab.lib.umd.edu/form#')
 @rdf.object_property('rights_holder', dcterms.rightsHolder, embed=True, obj_class=LabeledThing)
 @rdf.data_property('bibliographic_citation', dcterms.bibliographicCitation)
 @rdf.data_property('accession_number', dcterms.identifier, datatype=umdtype.accessionNumber)
-@rdf.data_property('handle', dcterms.identifer, datatype=umdtype.handle)
+@rdf.data_property('handle', dcterms.identifier, datatype=umdtype.handle)
 class Item(pcdm.Object):
     HEADER_MAP = {
         'object_type': 'Object Type',


### PR DESCRIPTION
The handles should be under identifier now rather than identifer

https://umd-dit.atlassian.net/browse/LIBFCREPO-1165