### PR TITLE
 LIBFCREPO-1218: Updating Modeling in Annotate Command

### DIFF
--- a/plastron-repo/src/plastron/jobs/importjob.py
+++ b/plastron-repo/src/plastron/jobs/importjob.py
@@ -486,7 +486,7 @@ class ImportRow:
                                             with previous_proxy_resource.describe(Proxy) as previous_proxy:
                                                 previous_proxy.next = proxy
                                                 proxy.prev = previous_proxy
-                                                previous_proxy.save()
+                                                previous_proxy_resource.save()
                                                 obj.last = proxy
                                     proxy_resource.save()
                                     previous_proxy_resource = proxy_resource


### PR DESCRIPTION
Using new models in Annotate Command to update the PCDM page resource.

Also fixing a naming bug found in the importjob when importing the whpool reports locally.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1218
