### PR TITLE
LIBFCREPO-1220: Updating imgsize command to use new models

### DIFF
--- a/plastron-models/src/plastron/models/umd.py
+++ b/plastron-models/src/plastron/models/umd.py
@@ -63,6 +63,10 @@ class PCDMFile(RDFResource):
     def __str__(self):
         return str(self.title or self.uri)
 
+class PCDMImageFile(PCDMFile):
+    height = DataProperty(ebucore.height)
+    width = DataProperty(ebucore.width)
+
 
 class Item(PCDMObject):
     object_type = ObjectProperty(


### PR DESCRIPTION
Updating the imgsize command to use the new transaction models

Also created a new PCDMImageFile class for images. It's a subclass of PCDMFile, with a width and height DataProperty.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1220