### PR TITLE
LIBFCREPO-1236. Created separate Dockerfile for plastron-web.

### DIFF
--- a/plastron-cli/src/plastron/cli/commands/importcommand.py
+++ b/plastron-cli/src/plastron/cli/commands/importcommand.py
@@ -166,17 +166,6 @@ class Command(BaseCommand):
 
         return result_config
 
-    @staticmethod
-    def create_import_job(job_id, jobs_dir):
-        """
-        Returns an ImportJob with the given parameters
-
-        :param job_id: the job id for the import job
-        :param jobs_dir: the base directory where job information is stored
-        :return: An ImportJob with the given parameters
-        """
-        return ImportJob(job_id, jobs_dir=jobs_dir)
-
     def __call__(self, client: Client, args: Namespace):
         """
         Performs the import

--- a/plastron-cli/tests/commands/test_importcommand.py
+++ b/plastron-cli/tests/commands/test_importcommand.py
@@ -22,18 +22,6 @@ def client():
     return Client(endpoint=Endpoint(url='http://localhost:8080/fcrepo/rest'))
 
 
-def test_create_import_job():
-    # Verifies "create_import_job" method creates an InputJob with the expected
-    # value
-    job_id = 'test_job_id'
-    jobs_dir = '/test_jobs_dir'
-
-    import_job = Command.create_import_job(job_id, jobs_dir)
-    assert import_job.id == job_id
-    assert import_job.safe_id == job_id
-    assert str(import_job.dir) == os.path.join(jobs_dir, job_id)
-
-
 def test_cannot_resume_without_job_id(client):
     # Verifies that the import command throws RuntimeError when resuming a
     # job and the job id is not provided

--- a/plastron-client/tests/test_client.py
+++ b/plastron-client/tests/test_client.py
@@ -339,3 +339,18 @@ def test_get_graph_not_found(monkeypatch, client):
     monkeypatch.setattr(requests.Session, 'request', mock_request(MockNotFoundResponse()))
     with pytest.raises(ClientError):
         client.get_graph('http://localhost:9999/fcrepo/rest/123')
+
+
+@pytest.mark.parametrize(
+    ('url', 'external_url', 'forwarded_host', 'forwarded_protocol'),
+    [
+        ('http://localhost:8080', 'http://fcrepo-local', 'fcrepo-local', 'http'),
+        ('http://localhost:8080', 'https://fcrepo-local', 'fcrepo-local', 'https'),
+        ('http://localhost:8080', 'http://fcrepo-local:8080', 'fcrepo-local:8080', 'http'),
+    ]
+)
+def test_forwarded_headers(url, external_url, forwarded_host, forwarded_protocol):
+    endpoint = Endpoint(url=url, external_url=external_url)
+    client = Client(endpoint=endpoint)
+    assert client.forwarded_host == forwarded_host
+    assert client.forwarded_protocol == forwarded_protocol

--- a/plastron-client/tests/test_client_error.py
+++ b/plastron-client/tests/test_client_error.py
@@ -1,0 +1,11 @@
+from unittest.mock import MagicMock
+
+from requests import Response
+
+from plastron.client import ClientError
+
+
+def test_client_error_str():
+    response = MagicMock(spec=Response, status_code=404, reason='Not Found')
+    error = ClientError(response)
+    assert str(error) == '404 Not Found'

--- a/plastron-client/tests/test_endpoint.py
+++ b/plastron-client/tests/test_endpoint.py
@@ -26,3 +26,12 @@ def test_contains_with_external_url():
 
     assert 'https://repo.example.net/123' in endpoint
     assert 'http://localhost:8080/fcrepo/rest/123' in endpoint
+
+
+def test_default_path_adds_slash():
+    endpoint = Endpoint(url='http://localhost:8080/fcrepo/rest', default_path='foo')
+    assert endpoint.relpath == '/foo'
+
+
+def test_transaction_endpoint(endpoint):
+    assert endpoint.transaction_endpoint == 'http://localhost:8080/fcrepo/rest/fcr:tx'

--- a/plastron-client/tests/test_functions.py
+++ b/plastron-client/tests/test_functions.py
@@ -1,7 +1,23 @@
+import re
 from pathlib import Path
 from unittest.mock import MagicMock
 
-from plastron.client import Client, paths_to_create
+import pytest
+from rdflib import Graph, URIRef, Literal
+
+from plastron.client import Client, paths_to_create, build_sparql_update
+
+
+@pytest.fixture
+def empty_graph():
+    return Graph()
+
+
+@pytest.fixture
+def non_empty_graph():
+    graph = Graph()
+    graph.add((URIRef('http://example.com/subject'), URIRef('http://purl.org/dc/terms/title'), Literal('Moonpig')))
+    return graph
 
 
 def test_paths_to_create():
@@ -9,3 +25,19 @@ def test_paths_to_create():
     mock_client.path_exists.return_value = True
 
     assert paths_to_create(mock_client, Path('/foo')) == []
+
+
+def test_build_sparql_update(empty_graph, non_empty_graph):
+    assert build_sparql_update(delete_graph=empty_graph, insert_graph=empty_graph) == ''
+    assert re.match(
+        r'^DELETE DATA {.*}$',
+        build_sparql_update(delete_graph=non_empty_graph, insert_graph=empty_graph),
+    )
+    assert re.match(
+        r'^INSERT DATA {.*}',
+        build_sparql_update(delete_graph=empty_graph, insert_graph=non_empty_graph),
+    )
+    assert re.match(
+        r'^DELETE {.*} INSERT {.*} WHERE {}$',
+        build_sparql_update(delete_graph=non_empty_graph, insert_graph=non_empty_graph),
+    )

--- a/plastron-client/tests/test_session_header_attribute.py
+++ b/plastron-client/tests/test_session_header_attribute.py
@@ -26,3 +26,15 @@ def test_session_header_attribute():
     # remove the header
     del foo.x_test_header
     assert 'X-Header' not in foo.session.headers
+
+
+def test_delete_nonexistent_session_header():
+    foo = Foo()
+    del foo.x_test_header
+
+
+def test_get_session_header():
+    foo = Foo()
+    foo.x_test_header = 'ABC'
+    assert foo.x_test_header == 'ABC'
+

--- a/plastron-repo/pyproject.toml
+++ b/plastron-repo/pyproject.toml
@@ -4,6 +4,7 @@ version = "4.0.0-dev"
 requires-python = ">= 3.8"
 dependencies = [
     "bagit",
+    "beautifulsoup4",
     "paramiko",
     "PyYAML",
     "rdflib",

--- a/plastron-stomp/README.md
+++ b/plastron-stomp/README.md
@@ -39,11 +39,12 @@ docker build -t docker.lib.umd.edu/plastrond-stomp:latest \
 
 ### Running with Docker Swarm
 
-This repository contains a [docker-compose.yml](../docker-compose.yml) file
-that defines a Docker stack that can be run alongside the [umd-fcrepo-docker]
-stack. This stack adds a `plastrond-stomp` container.
+This repository contains a [compose.yml](compose.yml) file that defines 
+part of a `plastrond` Docker stack intended to be run alongside the 
+[umd-fcrepo-docker] stack. This repository's configuration adds a 
+`plastrond-stomp` container.
 
-```
+```bash
 # if you are not already running in swarm mode
 docker swarm init
 
@@ -60,14 +61,20 @@ ssh-keygen -q -t rsa -N '' -f archelon_id
 cp docker-plastron.template.yml docker-plastron.yml
 vim docker-plastron.yml
 
-# deploy the stack
-docker stack deploy -c docker-compose.yml plastrond
+# deploy the stack to run the STOMP application
+docker stack deploy -c plastron-stomp/compose.yml plastrond
 ```
 
 To watch the logs:
 
+```bash
+docker service logs -f plastrond_stomp
 ```
-docker service logs -f plastrond_plastrond-stomp
+
+To stop the STOMP service:
+
+```bash
+docker service rm plastrond_stomp
 ```
 
 ## Configuration

--- a/plastron-stomp/compose.yml
+++ b/plastron-stomp/compose.yml
@@ -1,6 +1,6 @@
 version: "3.7"
 services:
-  plastrond-stomp:
+  stomp:
     image: docker.lib.umd.edu/plastrond-stomp
     configs:
       - source: plastrond
@@ -13,11 +13,11 @@ services:
       - plastrond-messages:/var/opt/plastron/msg
 configs:
   plastrond:
-    file: docker-plastron.yml
+    file: ../docker-plastron.yml
   archelon_id:
     # Private key for archelon SFTP
     # The corresponding public key should be added to Archelon
-    file: archelon_id
+    file: ../archelon_id
 volumes:
   plastrond-jobs:
   plastrond-messages:

--- a/plastron-web/Dockerfile
+++ b/plastron-web/Dockerfile
@@ -1,8 +1,8 @@
-# Dockerfile for the generating the Docker image for the Plastron STOMP Daemon (plastrond-stomp)
+# Dockerfile for the generating the Docker image for the Plastron HTTP Daemon (plastrond-http)
 #
 # To build, from the main plastron project directory, run:
 #
-# docker build -t docker.lib.umd.edu/plastrond-stomp:<VERSION> -f plastron-stomp/Dockerfile .
+# docker build -t docker.lib.umd.edu/plastrond-http:<VERSION> -f plastron-web/Dockerfile .
 #
 # where <VERSION> is the Docker image version to create.
 
@@ -14,8 +14,8 @@ COPY plastron-client /opt/plastron/plastron-client
 COPY plastron-models /opt/plastron/plastron-models
 COPY plastron-rdf /opt/plastron/plastron-rdf
 COPY plastron-repo /opt/plastron/plastron-repo
-COPY plastron-stomp /opt/plastron/plastron-stomp
 COPY plastron-utils /opt/plastron/plastron-utils
+COPY plastron-web /opt/plastron/plastron-web
 
 WORKDIR /opt/plastron
 RUN pip install \
@@ -24,10 +24,12 @@ RUN pip install \
     './plastron-rdf' \
     './plastron-models' \
     './plastron-repo' \
-    './plastron-stomp'
+    './plastron-web'
 
 ENV PYTHONUNBUFFERED=1
 VOLUME /var/opt/plastron/msg
 VOLUME /var/opt/plastron/jobs
 
-ENTRYPOINT ["plastrond-stomp", "-c", "/etc/plastrond.yml", "-v"]
+EXPOSE 5000
+
+ENTRYPOINT ["plastrond-http"]

--- a/plastron-web/README.md
+++ b/plastron-web/README.md
@@ -1,3 +1,83 @@
 # plastron-web
 
 HTTP server for synchronous remote operations
+
+## Running with Python
+
+As a Flask application: 
+
+```bash
+flask --app plastron.web:create_app run
+```
+
+To enable debugging, for hot code reloading, set `FLASK_DEBUG=1` either on 
+the command line or in a `.env` file:
+
+```bash
+FLASK_DEBUG=1 flask --app plastron.web:create_app run
+```
+
+Using the console script entrypoint, which runs the application with the 
+[Waitress] WSGI server:
+
+```bash
+plastrond-http
+```
+
+## Docker Image
+
+The plastron-stomp package contains a [Dockerfile](Dockerfile) for
+building the `plastrond-http` Docker image.
+
+### Building
+
+**Important:** This image **MUST** be built from the main _plastron_
+project directory, in order to include the other plastron packages in the
+build context.
+
+```bash
+docker build -t docker.lib.umd.edu/plastrond-http:latest \
+    -f plastron-web/Dockerfile .
+```
+
+### Running with Docker Swarm
+
+This repository contains a [compose.yml](compose.yml) file that defines 
+part of a `plastrond` Docker stack intended to be run alongside the
+[umd-fcrepo-docker] stack. This repository's configuration adds a
+`plastrond-http` container.
+
+```bash
+# if you are not already running in swarm mode
+docker swarm init
+
+# build the image
+docker build -t docker.lib.umd.edu/plastrond-http:latest \
+    -f plastron-web/Dockerfile .
+
+# deploy the stack to run the HTTP webapp
+docker stack deploy -c plastron-web/compose.yml plastrond
+```
+
+To watch the logs:
+
+```bash
+docker service logs -f plastrond_http
+```
+
+To stop the HTTP service:
+
+```bash
+docker service rm plastrond_http
+```
+
+## Configuration
+
+The application is configured through environment variables.
+
+| Name       | Value                                      | Default |
+|------------|--------------------------------------------|---------|
+| `JOBS_DIR` | Root directory for storing job information | `jobs`  |
+
+[umd-fcrepo-docker]: https://github.com/umd-lib/umd-fcrepo-docker
+[Waitress]: https://pypi.org/project/waitress/

--- a/plastron-web/compose.yml
+++ b/plastron-web/compose.yml
@@ -1,0 +1,17 @@
+version: "3.7"
+services:
+  http:
+    image: docker.lib.umd.edu/plastrond-http
+    volumes:
+      - plastrond-jobs:/var/opt/plastron/jobs
+    environment:
+      - JOBS_DIR=/var/opt/plastron/jobs
+    ports:
+      - "5000:5000"
+volumes:
+  plastrond-jobs:
+  plastrond-messages:
+networks:
+  default:
+    external: true
+    name: umd-fcrepo_default


### PR DESCRIPTION
- builds the docker.lib.umd.edu/plastrond-http image
- split the single docker-compose into two files (one for stomp, one for http)
- removed create_import_job class method
- propagate any errors within a transaction upwards after rolling back
- added a create_page_sequence method to PCDMObjectResource
- added a create_sequence method to AggregationResource
- fix forwarded host to work with ports
- add BeautifulSoup to the plastron-repo requirements
- updated tests and documentation

https://umd-dit.atlassian.net/browse/LIBFCREPO-1236