### PR TITLE
LIBFCREPO-1252. Added "umd:" to "http://vocab.lib.umd.edu/model#" namespace mapping.

### DIFF
--- a/plastron-utils/src/plastron/namespaces/__init__.py
+++ b/plastron-utils/src/plastron/namespaces/__init__.py
@@ -93,6 +93,9 @@ sc = Namespace('http://www.shared-canvas.org/ns/')
 skos = Namespace('http://www.w3.org/2004/02/skos/core#')
 """[Simple Knowledge Organization System (SKOS)](https://www.w3.org/TR/skos-reference/)"""
 
+umd = Namespace('http://vocab.lib.umd.edu/model#')
+"""[UMD Content Models Vocabulary](http://vocab.lib.umd.edu/model)"""
+
 umdaccess = Namespace('http://vocab.lib.umd.edu/access#')
 """[UMD Access Classes Vocabulary](http://vocab.lib.umd.edu/access)"""
 


### PR DESCRIPTION
https://umd-dit.atlassian.net/browse/LIBFCREPO-1252