### PR TITLE
LIBFCREPO-1256. Added publish and unpublish commands.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
     "python.testing.pytestArgs": [
+        "--cov",
+        "--cov-report", "xml",
         "."
     ],
     "python.testing.pytestEnabled": true,

--- a/plastron-cli/README.md
+++ b/plastron-cli/README.md
@@ -487,6 +487,7 @@ objects, configured using the current config file and arguments:
 | `client`        | plastron.client.Client               |
 | `repo`          | plastron.repo.Repository             |
 | `broker`        | plastron.stomp.broker.Broker         |
+| `handle_client` | plastron.handles.HandleServiceClient |
 
 Any `RuntimeError` exceptions are caught by the `plastron` script and 
 cause it to exit with a status code of 1. Any `KeyboardInterrupt` 

--- a/plastron-cli/README.md
+++ b/plastron-cli/README.md
@@ -265,6 +265,29 @@ required arguments:
                         path to batch configuration file
 ```
 
+#### Batch Configuration
+
+##### Required
+
+| Option       | Description                                                        |
+|--------------|--------------------------------------------------------------------|
+| `BATCH_FILE` | The "main" file of the batch                                       |
+| `COLLECTION` | URI of the repository collection that the objects will be added to |
+| `HANDLER`    | The handler to use                                                 |
+
+##### Optional
+
+| Option            | Description                                                                                             | Default                                               |
+|-------------------|---------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
+| `ROOT_DIR`        |                                                                                                         | The directory containing the batch configuration file |
+| `DATA_DIR`        | Where to find the data files for the batch; relative paths are relative to `ROOT_DIR`                   | `data`                                                |
+| `LOG_DIR`         | Where to write the mapfile, skipfile, and other logging info; relative paths are relative to `ROOT_DIR` | `logs`                                                |
+| `MAPFILE`         | Where to store the record of completed items in this batch; relative paths are relative to `LOG_DIR`    | `mapfile.csv`                                         |
+| `HANDLER_OPTIONS` | Any additional options required by the handler                                                          |                                                       |
+
+**Note:** The `plastron.load.*.log` files are currently written to the
+repository log directory, *not* to batch log directory.
+
 ### Ping (ping)
 
 ```text
@@ -385,36 +408,6 @@ optional arguments:
   -l LOG, --log LOG  completed log file from an import job
 ```
 
-## Configuration
-
-### Repository Configuration
-
-The repository connection is configured in a YAML file and passed to `plastron`
-with the `-r` or `--repo` option. These are the recognized configuration keys:
-
-### Batch Configuration
-
-#### Required
-
-| Option       | Description                                                        |
-|--------------|--------------------------------------------------------------------|
-| `BATCH_FILE` | The "main" file of the batch                                       |
-| `COLLECTION` | URI of the repository collection that the objects will be added to |
-| `HANDLER`    | The handler to use                                                 |
-
-#### Optional
-
-| Option            | Description                                                                                             | Default                                               |
-|-------------------|---------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
-| `ROOT_DIR`        |                                                                                                         | The directory containing the batch configuration file |
-| `DATA_DIR`        | Where to find the data files for the batch; relative paths are relative to `ROOT_DIR`                   | `data`                                                |
-| `LOG_DIR`         | Where to write the mapfile, skipfile, and other logging info; relative paths are relative to `ROOT_DIR` | `logs`                                                |
-| `MAPFILE`         | Where to store the record of completed items in this batch; relative paths are relative to `LOG_DIR`    | `mapfile.csv`                                         |
-| `HANDLER_OPTIONS` | Any additional options required by the handler                                                          |                                                       |
-
-**Note:** The `plastron.load.*.log` files are currently written to the 
-repository log directory, *not* to batch log directory.
-
 ## Extending
 
 ### Adding Commands
@@ -428,38 +421,78 @@ creates and configures a subparser to handle its specific command-line
 arguments.
 
 The `Command` class should inherit from `plastron.cli.BaseCommand`, and must
-have a `__call__` method that takes a `plastron.client.Client` object and an
-[argparse.Namespace] object, and executes the actual command.
+have a `__call__` method that takes an [argparse.Namespace] object, and
+executes the actual command.
 
-For a simple example, see the `ping` command, as implemented in
-[`plastron.cli.commands.ping`](src/plastron/cli/commands/ping.py):
+For a simple example, see the `list` command, as implemented in
+[`plastron.cli.commands.list`](src/plastron/cli/commands/list.py):
 
 ```python
-from requests.exceptions import ConnectionError
+import logging
+from argparse import Namespace
 
 from plastron.cli.commands import BaseCommand
+from plastron.models.umd import PCDMFile
+from plastron.namespaces import ldp
+
+logger = logging.getLogger(__name__)
 
 
 def configure_cli(subparsers):
-    parser_ping = subparsers.add_parser(
-        name='ping',
-        description='Check connection to the repository'
+    parser = subparsers.add_parser(
+        name='list',
+        aliases=['ls'],
+        description='List objects in the repository'
     )
-    parser_ping.set_defaults(cmd_name='ping')
+    # long mode to print more than just the URIs (name modeled after ls -l)
+    parser.add_argument(
+        '-l', '--long',
+        help='Display additional information besides the URI',
+        action='store_true'
+    )
+    parser.add_argument(
+        'uris', nargs='*',
+        help='URIs of repository objects to list'
+    )
+    parser.set_defaults(cmd_name='list')
 
 
 class Command(BaseCommand):
-    def __call__(self, fcrepo, args):
-        try:
-            fcrepo.test_connection()
-        except ConnectionError as e:
-            raise RuntimeError(str(e)) from e
+    def __call__(self, args: Namespace):
+        self.long = args.long
+
+        for uri in args.uris:
+            resource = self.context.repo[uri].read()
+
+            if resource.is_binary:
+                print(uri)
+                continue
+
+            for child_resource in resource.walk(min_depth=1, max_depth=1, traverse=[ldp.contains]):
+                if self.long:
+                    description = child_resource.describe(PCDMFile)
+                    title = str(description.title)
+                    print(f'{child_resource.url} {title}')
+                else:
+                    print(child_resource.url)
 ```
 
-The `RuntimeError` is caught by the `plastron` script and causes it to exit
-with a status code of 1. Any `KeyboardInterrupt` exceptions (for instance, 
-due to the user pressing <kbd>Ctrl+C</kbd>) are also caught by the 
-`plastron` script and cause it to exit with a status code of 2.
+The `Command` class has a `context` attribute that contains a 
+`PlastronContext` object. This context object provides the following 
+objects, configured using the current config file and arguments:
+
+| Attribute       | Type                                 |
+|-----------------|--------------------------------------|
+| `endpoint`      | plastron.client.Endpoint             |
+| `client`        | plastron.client.Client               |
+| `repo`          | plastron.repo.Repository             |
+| `broker`        | plastron.stomp.broker.Broker         |
+
+Any `RuntimeError` exceptions are caught by the `plastron` script and 
+cause it to exit with a status code of 1. Any `KeyboardInterrupt` 
+exceptions (for instance, due to the user pressing <kbd>Ctrl+C</kbd>) are 
+also caught by the `plastron` script and cause it to exit with a status 
+code of 2.
 
 [argparse subparsers object]: https://docs.python.org/3/library/argparse.html#sub-commands
 [argparse.Namespace]: https://docs.python.org/3/library/argparse.html#the-namespace-object

--- a/plastron-cli/src/plastron/cli/commands/__init__.py
+++ b/plastron-cli/src/plastron/cli/commands/__init__.py
@@ -1,26 +1,20 @@
 from importlib import import_module
-from typing import Optional, Generator
+from typing import Generator, Dict, Any
 
-from plastron.repo import Repository
+from plastron.cli.context import PlastronContext
 
 
 class BaseCommand:
-    def __init__(self, config=None):
-        if config is None:
-            config = {}
-        self.config = config
-        self.repo: Optional[Repository] = None
+    def __init__(self, context: PlastronContext = None):
+        self.context = context
         self.result = None
 
-    def repo_config(self, repo_config, args=None):
-        """
-        Enable default repository config dictionary to be overridden by the
-        command before actually creating the repository.
-
-        The default implementation of this method simply returns the provided
-        repo_config dictionary without change
-        """
-        return repo_config
+    @property
+    def config(self) -> Dict[str, Any]:
+        name = self.__module__.split('.')[-1]
+        if name == 'importcommand':
+            name = 'import'
+        return self.context.config.get('COMMANDS').get(name.upper(), {})
 
     def _run(self, command: Generator):
         # delegating generator; each progress step is passed to the calling

--- a/plastron-cli/src/plastron/cli/commands/annotate.py
+++ b/plastron-cli/src/plastron/cli/commands/annotate.py
@@ -29,16 +29,12 @@ def configure_cli(subparsers):
 
 
 class Command(BaseCommand):
-    def __init__(self, config=None):
-        super().__init__(config)
-        self.result = None
-
-    def __call__(self, client: Client, args: Namespace):
+    def __call__(self, args: Namespace):
         uris = get_uris(args)
-        client.test_connection()
+        self.context.client.test_connection()
         for uri in uris:
-            with context(repo=self.repo):
-                obj = self.repo[uri:PCDMPageResource]
+            with context(repo=self.context.repo):
+                obj = self.context.repo[uri:PCDMPageResource]
                 for file_resource in obj.read().get_files(mime_type='text/html'):
                     with file_resource.open() as stream:
                         text = BeautifulSoup(stream, features='lxml').get_text()

--- a/plastron-cli/src/plastron/cli/commands/create.py
+++ b/plastron-cli/src/plastron/cli/commands/create.py
@@ -5,7 +5,6 @@ from typing import List, Tuple, Union
 
 from rdflib import Graph, Literal, URIRef
 
-from plastron.client import Client
 from plastron.cli.commands import BaseCommand
 from plastron.namespaces import dcterms, get_manager, pcdm, rdf
 from plastron.rdf import parse_data_property, parse_object_property, uri_or_curie
@@ -83,9 +82,7 @@ def configure_cli(subparsers):
 
 
 class Command(BaseCommand):
-    def __call__(self, client: Client, args: Namespace):
-        self.client = client
-
+    def __call__(self, args: Namespace):
         properties: List[Tuple[URIRef, Union[Literal, URIRef]]] = [
             *(parse_data_property(p, o) for p, o in args.data_properties),
             *(parse_object_property(p, o) for p, o in args.object_properties)
@@ -103,6 +100,6 @@ class Command(BaseCommand):
             graph.add((URIRef(''), p, o))
 
         if args.path is not None:
-            self.client.create_at_path(Path(args.path), graph)
+            self.context.client.create_at_path(Path(args.path), graph)
         elif args.container is not None:
-            self.client.create_in_container(Path(args.container), graph)
+            self.context.client.create_in_container(Path(args.container), graph)

--- a/plastron-cli/src/plastron/cli/commands/delete.py
+++ b/plastron-cli/src/plastron/cli/commands/delete.py
@@ -1,5 +1,5 @@
-import argparse
 import logging
+from argparse import FileType, Namespace
 from datetime import datetime
 
 from plastron.cli import get_uris
@@ -44,7 +44,7 @@ def configure_cli(subparsers):
     parser.add_argument(
         '-f', '--file',
         dest='uris_file',
-        type=argparse.FileType(mode='r'),
+        type=FileType(mode='r'),
         help='File containing a list of URIs to delete',
         action='store'
     )
@@ -56,8 +56,8 @@ def configure_cli(subparsers):
 
 
 class Command(BaseCommand):
-    def __call__(self, client, args):
-        client.test_connection()
+    def __call__(self, args: Namespace):
+        self.context.client.test_connection()
         if args.completed:
             completed_log = ItemLog(args.completed, ['uri', 'title', 'timestamp'], 'uri')
         else:
@@ -75,9 +75,9 @@ class Command(BaseCommand):
         uris = get_uris(args)
 
         for uri in uris:
-            with context(repo=self.repo, use_transactions=args.use_transactions, dry_run=args.dry_run):
+            with context(repo=self.context.repo, use_transactions=args.use_transactions, dry_run=args.dry_run):
                 try:
-                    for resource in self.repo[uri].walk(traverse=traverse):
+                    for resource in self.context.repo[uri].walk(traverse=traverse):
                         obj = resource.describe(PCDMObject)
                         title = obj.title
                         if args.dry_run:

--- a/plastron-cli/src/plastron/cli/commands/echo.py
+++ b/plastron-cli/src/plastron/cli/commands/echo.py
@@ -32,11 +32,6 @@ def configure_cli(subparsers):
 
 
 class Command(BaseCommand):
-    def __init__(self, config=None):
-        super().__init__(config=config)
-        self.result = None
-        self.ssh_private_key = self.config.get('SSH_PRIVATE_KEY')
-
     def __call__(self, *args, **kwargs):
         self.execute(*args, **kwargs)
         print(self.result)

--- a/plastron-cli/src/plastron/cli/commands/export.py
+++ b/plastron-cli/src/plastron/cli/commands/export.py
@@ -3,7 +3,6 @@ from argparse import Namespace
 
 from plastron.cli.commands import BaseCommand
 from plastron.jobs.exportjob import ExportJob
-from plastron.repo import Repository
 from plastron.serializers import SERIALIZER_CLASSES
 
 logger = logging.getLogger(__name__)
@@ -56,14 +55,9 @@ def configure_cli(subparsers):
 
 
 class Command(BaseCommand):
-    def __init__(self, config=None):
-        super().__init__(config=config)
-        self.ssh_private_key = self.config.get('SSH_PRIVATE_KEY')
-        self.result = None
-
-    def __call__(self, repo: Repository, args: Namespace):
+    def __call__(self, args: Namespace):
         export_job = ExportJob(
-            repo=self.repo,
+            repo=self.context.repo,
             export_binaries=args.export_binaries,
             binary_types=args.binary_types,
             uris=args.uris,

--- a/plastron-cli/src/plastron/cli/commands/extractocr.py
+++ b/plastron-cli/src/plastron/cli/commands/extractocr.py
@@ -1,5 +1,5 @@
-import argparse
 import logging
+from argparse import FileType, Namespace
 from datetime import datetime
 
 from lxml import etree
@@ -7,7 +7,6 @@ from lxml import etree
 from plastron.cli import get_uris
 from plastron.repo.utils import context
 from plastron.cli.commands import BaseCommand
-from plastron.client import Client
 from plastron.models.annotations import TextblockOnPage
 from plastron.namespaces import pcdmuse
 from plastron.rdf.ocr import ALTOResource
@@ -42,7 +41,7 @@ def configure_cli(subparsers):
     parser.add_argument(
         '-f', '--file',
         dest='uris_file',
-        type=argparse.FileType(mode='r'),
+        type=FileType(mode='r'),
         help='File containing a list of URIs',
         action='store'
     )
@@ -54,7 +53,7 @@ def configure_cli(subparsers):
 
 
 class Command(BaseCommand):
-    def __call__(self, client: Client, args):
+    def __call__(self, args: Namespace):
         # TODO: create an ExtractOCRJob
 
         fieldnames = ['uri', 'timestamp']
@@ -82,8 +81,8 @@ class Command(BaseCommand):
                 logger.info(f'Ignoring {uri}')
                 continue
 
-            with context(repo=self.repo, use_transactions=args.use_transactions):
-                page_resource = self.repo[uri:PCDMPageResource].read()
+            with context(repo=self.context.repo, use_transactions=args.use_transactions):
+                page_resource = self.context.repo[uri:PCDMPageResource].read()
                 extracted_text_file = page_resource.get_file(rdf_type=pcdmuse.ExtractedText)
                 if extracted_text_file is None:
                     logger.error(f'Resource {page_resource.url} has no OCR file; skipping')

--- a/plastron-cli/src/plastron/cli/commands/find.py
+++ b/plastron-cli/src/plastron/cli/commands/find.py
@@ -5,7 +5,6 @@ from typing import List, Tuple, Union, Iterator, Callable, Iterable
 from rdflib import URIRef, Literal
 
 from plastron.cli.commands import BaseCommand
-from plastron.client import Client
 from plastron.namespaces import get_manager, rdf
 from plastron.rdf import parse_predicate_list, parse_data_property, parse_object_property, uri_or_curie
 from plastron.repo import RepositoryResource
@@ -84,7 +83,7 @@ def configure_cli(subparsers):
 
 
 class Command(BaseCommand):
-    def __call__(self, client: Client, args: Namespace):
+    def __call__(self, args: Namespace):
         self.properties: List[Tuple[URIRef, Union[Literal, URIRef]]] = [
             *(parse_data_property(p, o) for p, o in args.data_properties),
             *(parse_object_property(p, o) for p, o in args.object_properties)
@@ -109,7 +108,7 @@ class Command(BaseCommand):
         traverse = parse_predicate_list(args.recursive) if args.recursive else []
         for uri in args.uris:
             for resource in find(
-                start_resource=self.repo[uri],
+                start_resource=self.context.repo[uri],
                 matcher=self.match,
                 traverse=traverse,
                 properties=self.properties,

--- a/plastron-cli/src/plastron/cli/commands/imgsize.py
+++ b/plastron-cli/src/plastron/cli/commands/imgsize.py
@@ -1,13 +1,12 @@
 import logging
-from PIL import Image
 from argparse import Namespace
 
+from PIL import Image
+
 from plastron.cli.commands import BaseCommand
-from plastron.client import Client
 from plastron.models.umd import PCDMImageFile
 from plastron.repo import BinaryResource
 from plastron.repo.utils import context
-
 
 Image.MAX_IMAGE_PIXELS = None
 
@@ -28,15 +27,15 @@ def configure_cli(subparsers):
 
 
 class Command(BaseCommand):
-    def __call__(self, client: Client, args: Namespace):
+    def __call__(self, args: Namespace):
         for uri in args.uris:
 
-            file_resource: BinaryResource = self.repo[uri:BinaryResource].read()
+            file_resource: BinaryResource = self.context.repo[uri:BinaryResource].read()
             file = file_resource.describe(PCDMImageFile)
 
             # source = RepositoryFileSource(client, uri)
-            if file.mime_type.value.startswith('image/'): # ?
-                with context(repo=self.repo):
+            if file.mime_type.value.startswith('image/'):  # ?
+                with context(repo=self.context.repo):
                     logger.info(f'Reading image data from {uri}')
 
                     with file_resource.open() as file_contents:

--- a/plastron-cli/src/plastron/cli/commands/list.py
+++ b/plastron-cli/src/plastron/cli/commands/list.py
@@ -1,7 +1,6 @@
 import logging
 from argparse import Namespace
 
-from plastron.cli import Client
 from plastron.cli.commands import BaseCommand
 from plastron.models.umd import PCDMFile
 from plastron.namespaces import ldp
@@ -29,11 +28,11 @@ def configure_cli(subparsers):
 
 
 class Command(BaseCommand):
-    def __call__(self, client: Client, args: Namespace):
+    def __call__(self, args: Namespace):
         self.long = args.long
 
         for uri in args.uris:
-            resource = self.repo[uri].read()
+            resource = self.context.repo[uri].read()
 
             if resource.is_binary:
                 print(uri)

--- a/plastron-cli/src/plastron/cli/commands/ping.py
+++ b/plastron-cli/src/plastron/cli/commands/ping.py
@@ -12,8 +12,8 @@ def configure_cli(subparsers):
 
 
 class Command(BaseCommand):
-    def __call__(self, fcrepo, args):
+    def __call__(self, *args, **kwargs):
         try:
-            fcrepo.test_connection()
+            self.context.client.test_connection()
         except ConnectionError as e:
             raise RuntimeError(str(e)) from e

--- a/plastron-cli/src/plastron/cli/commands/publish.py
+++ b/plastron-cli/src/plastron/cli/commands/publish.py
@@ -1,0 +1,118 @@
+import logging
+from argparse import FileType, Namespace
+from typing import Iterable
+from plastron.cli import get_uris
+
+from plastron.cli.commands import BaseCommand
+from plastron.handles import HandleBearingResource
+from plastron.namespaces import umdaccess
+from plastron.rdfmapping.resources import RDFResource
+from plastron.repo import RepositoryError, RepositoryResource
+
+logger = logging.getLogger(__name__)
+
+
+def get_publication_status(obj: RDFResource) -> str:
+    if umdaccess.Published in obj.rdf_type.values:
+        if umdaccess.Hidden in obj.rdf_type.values:
+            return 'PublishedHidden'
+        else:
+            return 'Published'
+    else:
+        if umdaccess.Hidden in obj.rdf_type.values:
+            return 'UnpublishedHidden'
+        else:
+            return 'Unpublished'
+
+
+def configure_cli(subparsers):
+    parser = subparsers.add_parser(
+        name='publish',
+        description='Publish digital objects',
+    )
+    hide_or_show = parser.add_mutually_exclusive_group()
+    hide_or_show.add_argument(
+        '--hidden',
+        action='store_true',
+        help='set the "Hidden" state on these objects',
+    )
+    hide_or_show.add_argument(
+        '--visible',
+        action='store_true',
+        help='remove the "Hidden" state from these objects',
+    )
+    parser.add_argument(
+        '-f', '--uris-file',
+        action='store',
+        type=FileType(),
+        help='file containing URIs of objects to publish'
+    )
+    parser.add_argument(
+        'uris',
+        nargs='*',
+    )
+    parser.set_defaults(cmd_name='publish')
+
+
+class Command(BaseCommand):
+    def __call__(self, args: Namespace):
+        # mimicking a click.Context object to bridge between argparse and click commands
+        ctx = Namespace(obj=self.context)
+        return publish(ctx, uris=get_uris(args), force_hidden=args.hidden, force_visible=args.visible)
+
+
+def publish(ctx, uris: Iterable[str], force_hidden: bool = False, force_visible: bool = False):
+    for uri in uris:
+        # get the resource and check for an existing handle and current publication status
+        try:
+            resource: RepositoryResource = ctx.obj.repo[uri].read()
+        except RepositoryError as e:
+            logger.error(f'Unable to retrieve {uri}: {e}')
+            continue
+
+        obj = resource.describe(HandleBearingResource)
+        if obj.handle.is_valid:
+            logger.debug(f'Handle in the repository: {obj.handle.value}')
+
+        handle = ctx.obj.handle_client.get_handle(repo_uri=uri)
+        if handle is not None:
+            logger.debug(f'Handle service returns handle: {handle.hdl_uri}')
+
+        public_url = ctx.obj.get_public_url(uri)
+        if handle is None:
+            # create a new handle
+            logger.debug(f'Minting new handle for {uri}')
+            handle = ctx.obj.handle_client.create_handle(
+                repo_uri=uri,
+                url=public_url,
+            )
+            if handle is None:
+                # if the handle is still not created, something *really* went wrong
+                logger.error(f'Unable to find or create handle for {uri}')
+                continue
+
+            obj.handle = handle.hdl_uri
+        else:
+            # check target URL, and update if needed
+            if handle.url != public_url:
+                logger.warning(f'Current target URL ({handle.url}) does not match the expected URL ({public_url})')
+                handle = ctx.obj.handle_client.update_handle(handle, url=public_url)
+
+            # check to ensure that the handle matches
+            if obj.handle.is_valid:
+                if handle.hdl_uri != str(obj.handle.value):
+                    logger.warning('Handle values differ; updating the repository to match the handle service')
+                    obj.handle = handle.hdl_uri
+
+        # add the Published (and optionally, add or remove the Hidden) access classes
+        obj.rdf_type.add(umdaccess.Published)
+        if force_hidden:
+            obj.rdf_type.add(umdaccess.Hidden)
+        elif force_visible:
+            obj.rdf_type.remove(umdaccess.Hidden)
+
+        # save changes
+        resource.update()
+
+        logger.info(f'Publication status of {uri} is {get_publication_status(obj)}')
+        logger.info(f'Handle for repo URI {uri} is {handle} ({handle.hdl_uri}) with target URL {handle.url}')

--- a/plastron-cli/src/plastron/cli/commands/reindex.py
+++ b/plastron-cli/src/plastron/cli/commands/reindex.py
@@ -1,9 +1,7 @@
 import logging
-
-from rdflib import URIRef
+from argparse import Namespace
 
 from plastron.cli import get_uris
-from plastron.repo.utils import context
 from plastron.cli.commands import BaseCommand
 from plastron.rdf import parse_predicate_list
 from plastron.rdfmapping.resources import RDFResource
@@ -29,24 +27,18 @@ def configure_cli(subparsers):
 
 
 class Command(BaseCommand):
-    def __init__(self, config=None):
-        super().__init__(config=config)
-        self.broker = None
-        self.repo = None
-
-    def __call__(self, repo, args):
-        self.broker.connect()
-        self.reindexing_queue = self.broker.destination('reindexing'),
+    def __call__(self, args: Namespace):
+        self.context.broker.connect()
+        self.reindexing_queue = self.context.broker.destination('reindexing'),
         self.username = args.delegated_user or 'plastron'
         traverse = parse_predicate_list(args.recursive) if args.recursive is not None else []
         uris = get_uris(args)
 
         for uri in uris:
-            for resource in self.repo[uri].walk(traverse=traverse):
+            for resource in self.context.repo[uri].walk(traverse=traverse):
                 logger.info(f'Reindexing {resource.url}')
-                # types = ','.join(resource.graph.objects(subject=URIRef(uri), predicate=rdf.type))
                 types = ','.join(resource.describe(RDFResource).rdf_type.values)
-                self.broker.send(
+                self.context.broker.send(
                     destination=self.reindexing_queue,
                     headers={
                         'CamelFcrepoUri': resource.url,
@@ -57,6 +49,4 @@ class Command(BaseCommand):
                     }
                 )
 
-        self.broker.disconnect()
-
-
+        self.context.broker.disconnect()

--- a/plastron-cli/src/plastron/cli/commands/set.py
+++ b/plastron-cli/src/plastron/cli/commands/set.py
@@ -5,13 +5,12 @@ from typing import Iterable, Tuple, Dict, Type
 
 from rdflib import Literal
 
-from plastron.cli import PlastronContext
 from plastron.cli.commands import BaseCommand
 from plastron.models import get_model_class
 from plastron.rdf import uri_or_curie
 from plastron.rdfmapping.descriptors import DataProperty, ObjectProperty
 from plastron.rdfmapping.resources import RDFResourceBase
-from plastron.repo import Repository, RepositoryResource
+from plastron.repo import RepositoryResource
 
 logger = logging.getLogger(__name__)
 
@@ -47,9 +46,9 @@ def configure_cli(subparsers):
 
 
 class Command(BaseCommand):
-    def __call__(self, fcrepo: Repository, args: Namespace):
+    def __call__(self, args: Namespace):
         # mimicking a click.Context object to bridge between argparse and click commands
-        ctx = Namespace(obj=PlastronContext(repo=self.repo))
+        ctx = Namespace(obj=self.context)
         return set_fields(ctx, args.model_name, args.fields_to_set, args.uris)
 
 

--- a/plastron-cli/src/plastron/cli/commands/stub.py
+++ b/plastron-cli/src/plastron/cli/commands/stub.py
@@ -7,7 +7,7 @@ from typing import Optional
 from rdflib import URIRef
 
 from plastron.cli.commands import BaseCommand
-from plastron.client import Client, ClientError
+from plastron.client import ClientError
 from plastron.files import BinarySource, HTTPFileSource, LocalFileSource
 from plastron.models.umd import Stub
 from plastron.rdf import uri_or_curie
@@ -121,7 +121,7 @@ def write_csv_header(csv_file: csv.DictReader, args: Namespace, csv_writer: csv.
 
 
 class Command(BaseCommand):
-    def __call__(self, client: Client, args: Namespace) -> None:
+    def __call__(self, args: Namespace) -> None:
         csv_file = csv.DictReader(args.source_file)
         if csv_file.fieldnames is None:
             logger.error(f'No fields found in {csv_file}. Exiting.')
@@ -134,8 +134,8 @@ class Command(BaseCommand):
         csv_writer = csv.DictWriter(output_file, fieldnames=csv_file.fieldnames)
 
         write_csv_header(csv_file, args, csv_writer)
-        container_path = args.container_path or self.repo.endpoint.relpath
-        container_resource: ContainerResource = self.repo[container_path:ContainerResource].read()
+        container_path = args.container_path or self.context.repo.endpoint.relpath
+        container_resource: ContainerResource = self.context.repo[container_path:ContainerResource].read()
 
         for _, row in enumerate(csv_file, start=1):
             identifier = row[args.identifier_column]
@@ -152,7 +152,7 @@ class Command(BaseCommand):
             if args.access is not None:
                 item.rdf_type.add(args.access)
 
-            with context(repo=self.repo):
+            with context(repo=self.context.repo):
                 try:
                     access_types = [args.access] if args.access is not None else []
 

--- a/plastron-cli/src/plastron/cli/commands/unpublish.py
+++ b/plastron-cli/src/plastron/cli/commands/unpublish.py
@@ -1,0 +1,72 @@
+import logging
+from argparse import FileType, Namespace
+from typing import Iterable
+from plastron.cli import get_uris
+
+from plastron.cli.commands import BaseCommand
+from plastron.cli.commands.publish import get_publication_status
+from plastron.namespaces import umdaccess
+from plastron.rdfmapping.resources import RDFResource
+from plastron.repo import RepositoryResource, RepositoryError
+
+logger = logging.getLogger(__name__)
+
+
+def configure_cli(subparsers):
+    parser = subparsers.add_parser(
+        name='unpublish',
+        description='Unpublish digital objects',
+    )
+    hide_or_show = parser.add_mutually_exclusive_group()
+    hide_or_show.add_argument(
+        '--hidden',
+        action='store_true',
+        help='set the "Hidden" state on these objects',
+    )
+    hide_or_show.add_argument(
+        '--visible',
+        action='store_true',
+        help='remove the "Hidden" state from these objects',
+    )
+    parser.add_argument(
+        '-f', '--uris-file',
+        action='store',
+        type=FileType(),
+        help='file containing URIs of objects to publish'
+    )
+    parser.add_argument(
+        'uris',
+        nargs='*',
+    )
+    parser.set_defaults(cmd_name='unpublish')
+
+
+class Command(BaseCommand):
+    def __call__(self, args: Namespace):
+        # mimicking a click.Context object to bridge between argparse and click commands
+        ctx = Namespace(obj=self.context)
+        return unpublish(ctx, uris=get_uris(args), force_hidden=args.hidden, force_visible=args.visible)
+
+
+def unpublish(ctx, uris: Iterable[str], force_hidden: bool = False, force_visible: bool = False):
+    for uri in uris:
+        # get the resource and check for an existing handle and current publication status
+        try:
+            resource: RepositoryResource = ctx.obj.repo[uri].read()
+        except RepositoryError as e:
+            logger.error(f'Unable to retrieve {uri}: {e}')
+            continue
+
+        obj = resource.describe(RDFResource)
+
+        # remove the Published (and optionally, add or remove the Hidden) access classes
+        obj.rdf_type.remove(umdaccess.Published)
+        if force_hidden:
+            obj.rdf_type.add(umdaccess.Hidden)
+        elif force_visible:
+            obj.rdf_type.remove(umdaccess.Hidden)
+
+        # save changes
+        resource.update()
+
+        logger.info(f'Publication status of {uri} is {get_publication_status(obj)}')

--- a/plastron-cli/src/plastron/cli/commands/update.py
+++ b/plastron-cli/src/plastron/cli/commands/update.py
@@ -2,7 +2,6 @@ import logging
 from argparse import FileType, Namespace
 
 from plastron.cli.commands import BaseCommand
-from plastron.client import Client
 from plastron.jobs.updatejob import UpdateJob
 from plastron.models import get_model_class
 from plastron.rdf import parse_predicate_list
@@ -68,8 +67,8 @@ def configure_cli(subparsers):
 
 
 class Command(BaseCommand):
-    def __call__(self, client: Client, args: Namespace):
-        client.test_connection()
+    def __call__(self, args: Namespace):
+        self.context.client.test_connection()
 
         if args.validate and args.model is None:
             raise RuntimeError("Model must be provided when performing validation")
@@ -90,7 +89,7 @@ class Command(BaseCommand):
         traverse = parse_predicate_list(args.recursive) if args.recursive is not None else []
 
         update_job = UpdateJob(
-            repo=self.repo,
+            repo=self.context.repo,
             uris=args.uris,
             sparql_update=sparql_update,
             model_class=model_class,

--- a/plastron-cli/src/plastron/cli/commands/verify.py
+++ b/plastron-cli/src/plastron/cli/commands/verify.py
@@ -21,17 +21,14 @@ def configure_cli(subparsers):
 
 
 class Command(BaseCommand):
-    def __call__(self, fcrepo, args: Namespace):
-        if not self.solr:
-            raise RuntimeError('A URL for the Solr connection was not provided in the configuration file')
-
+    def __call__(self, args: Namespace):
         invalid_items = []
         try:
             with open(args.log) as csvfile:
                 reader = csv.DictReader(csvfile)
 
                 for item in reader:
-                    query = self.solr.search(f'id:\"{item["uri"]}\"')
+                    query = self.context.solr.search(f'id:\"{item["uri"]}\"')
 
                     if len(query) == 0:
                         invalid_items.append(item["uri"])

--- a/plastron-cli/src/plastron/cli/context.py
+++ b/plastron-cli/src/plastron/cli/context.py
@@ -1,0 +1,114 @@
+import re
+from argparse import Namespace
+from dataclasses import dataclass
+from importlib.metadata import version
+from typing import Dict, Any, Optional
+
+import pysolr
+
+from plastron.client import Endpoint, Client, RepositoryStructure
+from plastron.client.auth import get_authenticator
+from plastron.repo import Repository
+from plastron.stomp.broker import Broker, ServerTuple
+
+
+@dataclass
+class PlastronContext:
+    config: Dict[str, Any] = None
+    args: Namespace = None
+    _repo: Repository = None
+    _endpoint: Endpoint = None
+    _client: Client = None
+    _broker: Broker = None
+    _solr: pysolr.Solr = None
+
+    @property
+    def version(self):
+        return version('plastron-cli')
+
+    @property
+    def endpoint(self) -> Endpoint:
+        if self._endpoint is None:
+            repo_config = self.config.get('REPOSITORY', {})
+            try:
+                self._endpoint = Endpoint(
+                    url=repo_config['REST_ENDPOINT'],
+                    default_path=repo_config.get('RELPATH', '/'),
+                    external_url=repo_config.get('REPO_EXTERNAL_URL'),
+                )
+            except KeyError as e:
+                raise RuntimeError(f"Missing configuration key {e} in section 'REPOSITORY'")
+
+        return self._endpoint
+
+    @property
+    def client(self) -> Client:
+        if self._client is None:
+            repo_config = self.config.get('REPOSITORY', {})
+            try:
+                # TODO: respect the batch mode flag when getting the authenticator
+                self._client = Client(
+                    endpoint=self.endpoint,
+                    auth=get_authenticator(repo_config),
+                    ua_string=f'plastron/{version}',
+                    on_behalf_of=self.args.delegated_user,
+                    structure=RepositoryStructure[repo_config.get('STRUCTURE', 'flat').upper()]
+                )
+            except KeyError as e:
+                raise RuntimeError(f"Missing configuration key {e} in section 'REPOSITORY'")
+
+        return self._client
+
+    @property
+    def repo(self) -> Repository:
+        if self._repo is None:
+            self._repo = Repository(client=self.client)
+        return self._repo
+
+    @property
+    def broker(self) -> Broker:
+        if self._broker is None:
+            broker_config = self.config.get('MESSAGE_BROKER', {})
+            try:
+                self._broker = Broker(
+                    server=ServerTuple.from_string(broker_config['SERVER']),
+                    message_store_dir=broker_config['MESSAGE_STORE_DIR'],
+                    destinations=broker_config['DESTINATIONS'],
+                )
+            except KeyError as e:
+                raise RuntimeError(f"Missing configuration key {e} in section 'MESSAGE_BROKER'")
+
+        return self._broker
+
+    @property
+    def solr(self) -> pysolr.Solr:
+        if self._solr is None:
+            solr_config = self.config.get('SOLR', {})
+            try:
+                self._solr = pysolr.Solr(solr_config['URL'], always_commit=True, timeout=10)
+            except KeyError as e:
+                raise RuntimeError(f"Missing configuration key {e} in section 'SOLR'")
+
+        return self._solr
+
+    def get_public_url(self, repo_uri: str) -> str:
+        try:
+            public_url_pattern = self.config.get('PUBLICATION_WORKFLOW', {})['PUBLIC_URL_PATTERN']
+        except KeyError as e:
+            raise RuntimeError(f"Missing configuration key {e} in section 'PUBLICATION_WORKFLOW'")
+
+        uuid = get_uuid_from_uri(repo_uri)
+        if uuid is None:
+            raise RuntimeError(f'Cannot create public URL; unable to find UUID in {repo_uri}')
+
+        return public_url_pattern.format(uuid=uuid.lower())
+
+
+UUID_REGEX = re.compile(r'([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})', re.IGNORECASE)
+
+
+def get_uuid_from_uri(uri: str) -> Optional[str]:
+    if m := UUID_REGEX.search(uri):
+        return m[1]
+    else:
+        return None

--- a/plastron-cli/tests/commands/test_base_command.py
+++ b/plastron-cli/tests/commands/test_base_command.py
@@ -1,8 +1,0 @@
-from plastron.cli.commands import BaseCommand
-
-
-def test_repo_config():
-    # Default implementation simply returns the provided dictionary
-    command = BaseCommand()
-    repo_config = {'foo': 'bar', 'quuz': 'baz'}
-    assert repo_config is command.repo_config(repo_config)

--- a/plastron-cli/tests/commands/test_find.py
+++ b/plastron-cli/tests/commands/test_find.py
@@ -35,6 +35,7 @@ def test_find(datadir, repo, simulate_repo, matcher, properties, expected_count)
     [
         (
             Namespace(
+                delegated_user=None,
                 recursive='ldp:contains',
                 data_properties=[],
                 object_properties=[],
@@ -47,6 +48,7 @@ def test_find(datadir, repo, simulate_repo, matcher, properties, expected_count)
         ),
         (
             Namespace(
+                delegated_user=None,
                 recursive='ldp:contains',
                 data_properties=[],
                 object_properties=[],
@@ -59,6 +61,7 @@ def test_find(datadir, repo, simulate_repo, matcher, properties, expected_count)
         ),
         (
             Namespace(
+                delegated_user=None,
                 recursive='ldp:contains',
                 data_properties=[('dcterms:title', 'Moonpig')],
                 object_properties=[],
@@ -72,12 +75,12 @@ def test_find(datadir, repo, simulate_repo, matcher, properties, expected_count)
     ]
 )
 @httpretty.activate
-def test_find_command(capsys, datadir, repo, simulate_repo, args, expected_paths):
+def test_find_command(capsys, datadir, repo, plastron_context, simulate_repo, args, expected_paths):
     graph = Graph().parse(file=(datadir / 'graph.ttl').open())
     simulate_repo(graph)
-    cmd = Command()
-    cmd.repo = repo
-    cmd(client=repo.client, args=args)
+    plastron_context.args = args
+    cmd = Command(context=plastron_context)
+    cmd(args)
     captured = capsys.readouterr()
     assert len(captured.out.splitlines()) == len(expected_paths)
     for path in expected_paths:

--- a/plastron-cli/tests/commands/test_importcommand.py
+++ b/plastron-cli/tests/commands/test_importcommand.py
@@ -22,78 +22,81 @@ def test_cannot_resume_without_job_id(client):
     args = argparse.Namespace(resume=True, job_id=None)
 
     with pytest.raises(RuntimeError) as excinfo:
-        for _ in command(client, args):
+        for _ in command(args):
             pass
 
     assert "Resuming a job requires a job id" in str(excinfo.value)
 
 
-def test_cannot_resume_without_job_directory(client):
+def test_cannot_resume_without_job_directory(plastron_context):
     # Verifies that the import command throws RuntimeError when resuming a
     # job and the directory associated with job id is not found
     jobs_dir = '/nonexistent_directory'
-    config = {'JOBS_DIR': jobs_dir}
-    command = Command(config)
+    plastron_context.config.update({'COMMANDS': {'IMPORT': {'JOBS_DIR': jobs_dir}}})
     args = create_args('test_job_id')
     args.resume = True
+    plastron_context.args = args
+    command = Command(context=plastron_context)
 
     with pytest.raises(RuntimeError) as excinfo:
-        for _ in command(client, args):
+        for _ in command(args):
             pass
 
     assert "no such job directory" in str(excinfo.value)
 
 
-def test_cannot_resume_without_config_file(client):
+def test_cannot_resume_without_config_file(plastron_context):
     # Verifies that the import command throws ConfigMissingError when resuming a
     # job and a config file is not found
     job_id = 'test_id'
     args = create_args(job_id)
     args.resume = True
+    plastron_context.args = args
 
     with tempfile.TemporaryDirectory() as tmpdirname:
-        config = {'JOBS_DIR': tmpdirname}
+        plastron_context.config.update({'COMMANDS': {'IMPORT': {'JOBS_DIR': tmpdirname}}})
 
         # Make subdirectory in tmpdirname for job
         job_dir = os.path.join(tmpdirname, job_id)
         os.mkdir(job_dir)
 
-        command = Command(config)
+        command = Command(context=plastron_context)
 
         with pytest.raises(JobConfigError) as excinfo:
-            for _ in command(client, args):
+            for _ in command(args):
                 pass
 
         assert "config.yml is missing" in str(excinfo.value)
 
 
-def test_model_is_required_unless_resuming(client):
+def test_model_is_required_unless_resuming(plastron_context):
     # Verifies that the import command throws RuntimeError if model
     # is not provided when not resuming
     job_id = 'test_id'
     args = create_args(job_id)
     args.model = None
-    config = {}
+    plastron_context.args = args
 
-    command = Command(config)
+    command = Command(context=plastron_context)
     with pytest.raises(RuntimeError) as excinfo:
-        for _ in command(client, args):
+        for _ in command(args):
             pass
 
     assert "A model is required unless resuming an existing job" in str(excinfo.value)
 
 
-def test_import_file_is_required_unless_resuming(datadir, client):
+def test_import_file_is_required_unless_resuming(datadir, plastron_context):
     # Verifies that the import command throws RuntimeError if an import_file
     # is not provided when not resuming
     job_id = 'test_id'
     args = create_args(job_id)
     args.import_file = None
-    config = {'JOBS_DIR': datadir}
+    plastron_context.args = args
+    plastron_context.config.update({'COMMANDS': {'IMPORT': {'JOBS_DIR': datadir}}})
 
-    command = Command(config)
+    command = Command(context=plastron_context)
     with pytest.raises(RuntimeError) as excinfo:
-        for _ in command(client, args):
+        for _ in command(args):
             pass
 
     assert "An import file is required unless resuming an existing job" in str(excinfo.value)
@@ -110,7 +113,9 @@ def create_args(job_id):
     :return: a configured argparse.Namespace object
     """
     return argparse.Namespace(
-        resume=False, job_id=job_id,
+        job_id=job_id,
+        delegated_user=None,
+        resume=False,
         model='Item',
         access=None,
         member_of="test",

--- a/plastron-cli/tests/commands/test_list.py
+++ b/plastron-cli/tests/commands/test_list.py
@@ -7,12 +7,13 @@ from plastron.cli.commands.list import Command
 
 
 @httpretty.activate
-def test_list_command(capsys, datadir, repo, simulate_repo):
+def test_list_command(capsys, datadir, plastron_context, simulate_repo):
     graph = Graph().parse(file=(datadir / 'graph.ttl').open())
     simulate_repo(graph)
-    cmd = Command()
-    cmd.repo = repo
-    cmd(client=repo.client, args=Namespace(long=False, uris=['/container']))
+    args = Namespace(long=False, uris=['/container'], delegated_user=None)
+    plastron_context.args = args
+    cmd = Command(context=plastron_context)
+    cmd(args)
     captured = capsys.readouterr()
     assert len(captured.out.splitlines()) == 2
     assert f'http://localhost:9999/container/1\n' in captured.out
@@ -20,12 +21,13 @@ def test_list_command(capsys, datadir, repo, simulate_repo):
 
 
 @httpretty.activate
-def test_list_long_command(capsys, datadir, repo, simulate_repo):
+def test_list_long_command(capsys, datadir, plastron_context, simulate_repo):
     graph = Graph().parse(file=(datadir / 'graph.ttl').open())
     simulate_repo(graph)
-    cmd = Command()
-    cmd.repo = repo
-    cmd(client=repo.client, args=Namespace(long=True, uris=['/container']))
+    args = Namespace(long=True, uris=['/container'], delegated_user=None)
+    plastron_context.args = args
+    cmd = Command(context=plastron_context)
+    cmd(args)
     captured = capsys.readouterr()
     assert len(captured.out.splitlines()) == 2
     assert f'http://localhost:9999/container/1 Foobar\n' in captured.out

--- a/plastron-cli/tests/commands/test_publish.py
+++ b/plastron-cli/tests/commands/test_publish.py
@@ -1,0 +1,146 @@
+from argparse import Namespace
+from unittest.mock import MagicMock
+
+from plastron.cli.commands.publish import Command, get_publication_status, publish
+from plastron.cli.context import PlastronContext
+from plastron.handles import Handle, HandleServiceClient
+from plastron.models.umd import Item
+from plastron.namespaces import umdaccess, umdtype
+from plastron.rdfmapping.resources import RDFResource
+from plastron.repo import Repository, RepositoryError, RepositoryResource
+import pytest
+from rdflib import Literal
+
+
+def get_mock_context(obj):
+    mock_resource = MagicMock(spec=RepositoryResource)
+    mock_resource.read.return_value = mock_resource
+    mock_resource.describe.return_value = obj
+    mock_resource.update = lambda: obj.apply_changes()
+    mock_repo = MagicMock(spec=Repository)
+    mock_repo.__getitem__.return_value = mock_resource
+    mock_handle_client = MagicMock(spec=HandleServiceClient)
+    mock_handle_client.get_handle.return_value = None
+    mock_handle_client.create_handle.return_value = Handle(
+        prefix='1903.1',
+        suffix='123',
+        url='http://example.com/foobar',
+    )
+    return MagicMock(
+        spec=PlastronContext,
+        repo=mock_repo,
+        handle_client=mock_handle_client,
+        get_public_url=lambda uri: uri.replace('fcrepo-local:8080/fcrepo/rest', 'digital-local')
+    )
+
+
+@pytest.mark.parametrize(
+    ('obj', 'expected_status'),
+    [
+        (RDFResource(), 'Unpublished'),
+        (RDFResource(rdf_type=umdaccess.Hidden), 'UnpublishedHidden'),
+        (RDFResource(rdf_type=umdaccess.Published), 'Published'),
+        (RDFResource(rdf_type=[umdaccess.Published, umdaccess.Hidden]), 'PublishedHidden'),
+    ],
+)
+def test_get_publication_status(obj, expected_status):
+    assert get_publication_status(obj) == expected_status
+
+
+def test_publish():
+    obj = Item()
+    publish(Namespace(obj=get_mock_context(obj)), uris=['http://fcrepo-local:8080/fcrepo/rest/foo'])
+
+    assert umdaccess.Published in obj.rdf_type.values
+    assert umdaccess.Hidden not in obj.rdf_type.values
+
+
+def test_publish_hidden():
+    obj = Item()
+    publish(Namespace(obj=get_mock_context(obj)), force_hidden=True, uris=['http://fcrepo-local:8080/fcrepo/rest/foo'])
+
+    assert umdaccess.Published in obj.rdf_type.values
+    assert umdaccess.Hidden in obj.rdf_type.values
+
+
+def test_publish_force_visible():
+    obj = Item(rdf_type=umdaccess.Hidden)
+    publish(Namespace(obj=get_mock_context(obj)), force_visible=True, uris=['http://fcrepo-local:8080/fcrepo/rest/foo'])
+
+    assert umdaccess.Published in obj.rdf_type.values
+    assert umdaccess.Hidden not in obj.rdf_type.values
+
+
+def test_publish_repo_error(caplog):
+    mock_repo = MagicMock(spec=Repository)
+    mock_repo.__getitem__.side_effect = RepositoryError('something bad')
+
+    publish(
+        Namespace(obj=MagicMock(spec=PlastronContext, repo=mock_repo)),
+        uris=['http://fcrepo-local:8080/fcrepo/rest/foo'],
+    )
+    assert 'Unable to retrieve http://fcrepo-local:8080/fcrepo/rest/foo: something bad' in caplog.messages
+
+
+def test_publish_handle_service_error(caplog):
+    obj = Item()
+    mock_resource = MagicMock(spec=RepositoryResource)
+    mock_resource.read.return_value = mock_resource
+    mock_resource.describe.return_value = obj
+    mock_resource.update = lambda: obj.apply_changes()
+    mock_repo = MagicMock(spec=Repository)
+    mock_repo.__getitem__.return_value = mock_resource
+    mock_handle_client = MagicMock(spec=HandleServiceClient)
+    mock_handle_client.get_handle.return_value = None
+    mock_handle_client.create_handle.return_value = None
+
+    publish(
+        Namespace(obj=MagicMock(spec=PlastronContext, repo=mock_repo, handle_client=mock_handle_client)),
+        uris=['http://fcrepo-local:8080/fcrepo/rest/foo'],
+    )
+    assert 'Unable to find or create handle for http://fcrepo-local:8080/fcrepo/rest/foo' in caplog.messages
+
+
+def test_publish_new_handle_update_handle_in_repo():
+    obj = Item(handle='hdl:1903.1/987')
+    publish(Namespace(obj=get_mock_context(obj)), uris=['http://fcrepo-local:8080/fcrepo/rest/foo'])
+
+    assert umdaccess.Published in obj.rdf_type.values
+    assert umdaccess.Hidden not in obj.rdf_type.values
+    assert obj.handle.value == Literal('hdl:1903.1/123', datatype=umdtype.handle)
+
+
+def test_publish_existing_handle_update_handle_in_repo():
+    obj = Item(handle='hdl:1903.1/987')
+    handle = Handle(
+        prefix='1903.1',
+        suffix='123',
+        url='http://example.com/foobar',
+    )
+    mock_resource = MagicMock(spec=RepositoryResource)
+    mock_resource.read.return_value = mock_resource
+    mock_resource.describe.return_value = obj
+    mock_resource.update = lambda: obj.apply_changes()
+    mock_repo = MagicMock(spec=Repository)
+    mock_repo.__getitem__.return_value = mock_resource
+    mock_handle_client = MagicMock(spec=HandleServiceClient)
+    mock_handle_client.get_handle.return_value = handle
+    mock_handle_client.update_handle.return_value = handle
+
+    publish(
+        Namespace(obj=MagicMock(spec=PlastronContext, repo=mock_repo, handle_client=mock_handle_client)),
+        uris=['http://fcrepo-local:8080/fcrepo/rest/foo'],
+    )
+
+    assert umdaccess.Published in obj.rdf_type.values
+    assert umdaccess.Hidden not in obj.rdf_type.values
+    assert obj.handle.value == Literal('hdl:1903.1/123', datatype=umdtype.handle)
+
+
+def test_publish_command_class():
+    obj = Item()
+    cmd = Command(get_mock_context(obj))
+    cmd(Namespace(uris=['http://fcrepo-local:8080/fcrepo/rest/foo'], hidden=False, visible=False))
+
+    assert umdaccess.Published in obj.rdf_type.values
+    assert umdaccess.Hidden not in obj.rdf_type.values

--- a/plastron-cli/tests/commands/test_unpublish.py
+++ b/plastron-cli/tests/commands/test_unpublish.py
@@ -1,0 +1,76 @@
+from argparse import Namespace
+from unittest.mock import MagicMock
+
+from plastron.cli.commands.unpublish import Command, unpublish
+from plastron.cli.context import PlastronContext
+from plastron.models.umd import Item
+from plastron.namespaces import umdaccess
+from plastron.repo import Repository, RepositoryError, RepositoryResource
+
+
+def get_mock_context(obj):
+    mock_resource = MagicMock(spec=RepositoryResource)
+    mock_resource.read.return_value = mock_resource
+    mock_resource.describe.return_value = obj
+    mock_resource.update = lambda: obj.apply_changes()
+    mock_repo = MagicMock(spec=Repository)
+    mock_repo.__getitem__.return_value = mock_resource
+
+    return MagicMock(spec=PlastronContext, repo=mock_repo)
+
+
+def test_unpublish():
+    obj = Item(rdf_type=umdaccess.Published)
+
+    unpublish(
+        Namespace(obj=get_mock_context(obj)),
+        uris=['http://fcrepo-local:8080/fcrepo/rest/foo'],
+    )
+
+    assert umdaccess.Published not in obj.rdf_type.values
+
+
+def test_unpublish_hidden():
+    obj = Item(rdf_type=umdaccess.Published)
+
+    unpublish(
+        Namespace(obj=get_mock_context(obj)),
+        uris=['http://fcrepo-local:8080/fcrepo/rest/foo'],
+        force_hidden=True,
+    )
+
+    assert umdaccess.Published not in obj.rdf_type.values
+    assert umdaccess.Hidden in obj.rdf_type.values
+
+
+def test_unpublish_make_visible():
+    obj = Item(rdf_type=[umdaccess.Published, umdaccess.Hidden])
+
+    unpublish(
+        Namespace(obj=get_mock_context(obj)),
+        uris=['http://fcrepo-local:8080/fcrepo/rest/foo'],
+        force_visible=True,
+    )
+
+    assert umdaccess.Published not in obj.rdf_type.values
+    assert umdaccess.Hidden not in obj.rdf_type.values
+
+
+def test_unpublish_repo_error(caplog):
+    mock_repo = MagicMock(spec=Repository)
+    mock_repo.__getitem__.side_effect = RepositoryError('something bad')
+
+    unpublish(
+        Namespace(obj=MagicMock(spec=PlastronContext, repo=mock_repo)),
+        uris=['http://fcrepo-local:8080/fcrepo/rest/foo'],
+    )
+    assert 'Unable to retrieve http://fcrepo-local:8080/fcrepo/rest/foo: something bad' in caplog.messages
+
+
+def test_unpublish_command_class():
+    obj = Item(rdf_type=umdaccess.Published)
+    cmd = Command(get_mock_context(obj))
+    cmd(Namespace(uris=['http://fcrepo-local:8080/fcrepo/rest/foo'], hidden=False, visible=False))
+
+    assert umdaccess.Published not in obj.rdf_type.values
+    assert umdaccess.Hidden not in obj.rdf_type.values

--- a/plastron-cli/tests/conftest.py
+++ b/plastron-cli/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from httpretty import httpretty
 from rdflib import Graph
 
+from plastron.cli import PlastronContext
 from plastron.client import Endpoint, Client
 from plastron.client.auth import get_authenticator
 from plastron.repo import Repository
@@ -20,6 +21,11 @@ def repo_base_config():
         'LOG_DIR': '/logs',
         'AUTH_TOKEN': 'foobar'
     }
+
+
+@pytest.fixture
+def plastron_context(repo_base_config, repo):
+    return PlastronContext(config={'REPOSITORY': repo_base_config})
 
 
 @pytest.fixture

--- a/plastron-cli/tests/test_update_command.py
+++ b/plastron-cli/tests/test_update_command.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from plastron.cli import PlastronContext
 from plastron.client import Client
 from plastron.cli.commands.update import Command
 from plastron.models import Letter, Item
@@ -12,14 +13,16 @@ from pytest import raises
 
 
 def test_validate_requires_model():
-    cmd = Command()
+    mock_context = MagicMock(spec=PlastronContext, client=MagicMock(spec=Client))
+    cmd = Command(
+        context=mock_context
+    )
     args = Namespace(
         dry_run=False,
         use_transactions=False,
         validate=True,
         model=None
     )
-    mock_repo = MagicMock(spec=Client)
     with raises(RuntimeError) as exc_info:
-        cmd.__call__(mock_repo, args)
+        cmd.__call__(args)
     assert exc_info.value.args[0] == "Model must be provided when performing validation"

--- a/plastron-models/src/plastron/handles/__init__.py
+++ b/plastron-models/src/plastron/handles/__init__.py
@@ -1,0 +1,105 @@
+import dataclasses
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+import requests
+from requests_jwtauth import HTTPBearerAuth
+
+from plastron.namespaces import dcterms, umdtype
+from plastron.rdfmapping.descriptors import DataProperty
+from plastron.rdfmapping.resources import RDFResource
+from plastron.validation import is_handle
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Handle:
+    prefix: str
+    suffix: str
+    url: str
+
+    def __str__(self):
+        return '/'.join((self.prefix, self.suffix))
+
+    @property
+    def hdl_uri(self):
+        """The handle in `hdl:{prefix}/{suffix}` form"""
+        return f'hdl:{self}'
+
+
+class HandleServiceClient:
+    def __init__(self, endpoint_url: str, jwt_token: str, default_prefix: str = None, default_repo: str = None):
+        self.endpoint_url = endpoint_url
+        self.auth = HTTPBearerAuth(jwt_token)
+        self.default_prefix = default_prefix
+        self.default_repo = default_repo
+
+    def get_handle(self, repo_uri: str, repo: str = None) -> Optional[Handle]:
+        response = requests.get(
+            f'{self.endpoint_url}/handles/exists',
+            params={
+                'repo': repo or self.default_repo,
+                'repo_id': repo_uri,
+            },
+            auth=self.auth,
+        )
+        if not response.ok:
+            raise HandleServerError(str(response))
+        result = response.json()
+        logger.debug(result)
+        if result['exists']:
+            return Handle(
+                prefix=result['prefix'],
+                suffix=result['suffix'],
+                url=result['url'],
+            )
+        else:
+            return None
+
+    def create_handle(self, repo_uri: str, url: str, prefix: str = None, repo: str = None) -> Handle:
+        request = {
+            'prefix': prefix or self.default_prefix,
+            'repo': repo or self.default_repo,
+            'repo_id': repo_uri,
+            'url': url,
+        }
+        response = requests.post(
+            f'{self.endpoint_url}/handles',
+            json=request,
+            auth=self.auth,
+        )
+        if not response.ok:
+            raise HandleServerError(str(response))
+        result = response.json()
+        logger.debug(result)
+        return Handle(
+            prefix=result['request']['prefix'],
+            suffix=result['suffix'],
+            url=result['request']['url'],
+        )
+
+    def update_handle(self, handle: Handle, **fields) -> Handle:
+        updated_handle = dataclasses.replace(handle, **fields)
+        response = requests.patch(
+            f'{self.endpoint_url}/handles/{handle.prefix}/{handle.suffix}',
+            json=dataclasses.asdict(updated_handle),
+            auth=self.auth,
+        )
+        if not response.ok:
+            raise HandleServerError(str(response))
+        result = response.json()
+        logger.debug(result)
+        return updated_handle
+
+
+class HandleServerError(Exception):
+    pass
+
+
+class HandleBearingResource(RDFResource):
+    """This class be used by itself for instances where the handle field is the only
+    one need, or it can be used as a mix-in to other full models to give them a handle
+    field."""
+    handle = DataProperty(dcterms.identifier, datatype=umdtype.handle, validate=is_handle)

--- a/plastron-models/src/plastron/models/umd.py
+++ b/plastron-models/src/plastron/models/umd.py
@@ -1,8 +1,9 @@
+from plastron.handles import HandleBearingResource
 from plastron.namespaces import dc, dcterms, edm, rdfs, owl, ldp, fabio, pcdm, iana, ore, ebucore, premis, xsd, umdtype
 from plastron.rdfmapping.decorators import rdf_type
 from plastron.rdfmapping.descriptors import ObjectProperty, DataProperty
 from plastron.rdfmapping.resources import RDFResource, RDFResourceBase
-from plastron.validation import is_edtf_formatted, is_valid_iso639_code, is_handle
+from plastron.validation import is_edtf_formatted, is_valid_iso639_code
 from plastron.validation.vocabularies import get_subjects
 
 
@@ -62,7 +63,7 @@ class PCDMImageFile(PCDMFile):
     width = DataProperty(ebucore.width)
 
 
-class Item(PCDMObject):
+class Item(PCDMObject, HandleBearingResource):
     object_type = ObjectProperty(
         dcterms.type,
         required=True,
@@ -93,7 +94,6 @@ class Item(PCDMObject):
     rights_holder = ObjectProperty(dcterms.rightsHolder, repeatable=True, embed=True, cls=LabeledThing)
     bibliographic_citation = DataProperty(dcterms.bibliographicCitation)
     accession_number = DataProperty(dcterms.identifier, datatype=umdtype.accessionNumber)
-    handle = DataProperty(dcterms.identifier, datatype=umdtype.handle, validate=is_handle)
 
     _ORIGINAL_HEADER_MAP = {
         'object_type': 'Object Type',

--- a/plastron-models/src/plastron/models/umd.py
+++ b/plastron-models/src/plastron/models/umd.py
@@ -34,8 +34,8 @@ class LDPContainer(RDFResource):
 
 
 class AggregationMixin(RDFResourceBase):
-    first = ObjectProperty(iana.first, required=True, cls='Proxy')
-    last = ObjectProperty(iana.last, required=True, cls='Proxy')
+    first = ObjectProperty(iana.first, cls='Proxy')
+    last = ObjectProperty(iana.last, cls='Proxy')
 
 
 @rdf_type(pcdm.Object)

--- a/plastron-models/tests/serializers/test_csv_functions.py
+++ b/plastron-models/tests/serializers/test_csv_functions.py
@@ -4,7 +4,7 @@ from rdflib import Literal, URIRef
 from plastron.namespaces import rdfs, owl, dcterms
 from plastron.rdfmapping.descriptors import DataProperty, ObjectProperty
 from plastron.rdfmapping.embed import EmbeddedObject
-from plastron.rdfmapping.resources import RDFResourceBase
+from plastron.rdfmapping.resources import RDFResource, RDFResourceBase
 from plastron.serializers.csv import join_values, flatten_headers, unflatten, flatten, ensure_text_mode, \
     ensure_binary_mode
 
@@ -20,12 +20,12 @@ def header_map():
     }
 
 
-class Subject(RDFResourceBase):
+class Subject(RDFResource):
     label = DataProperty(rdfs.label)
     same_as = ObjectProperty(owl.sameAs)
 
 
-class Thing(RDFResourceBase):
+class Thing(RDFResource):
     title = DataProperty(dcterms.title)
     subject = ObjectProperty(dcterms.subject, cls=Subject, repeatable=True)
 

--- a/plastron-models/tests/test_handles.py
+++ b/plastron-models/tests/test_handles.py
@@ -1,0 +1,119 @@
+from http import HTTPStatus
+import json
+import httpretty
+import pytest
+from rdflib import Literal
+
+from plastron.handles import Handle, HandleBearingResource, HandleServerError, HandleServiceClient
+from plastron.namespaces import umdtype
+
+
+@pytest.fixture
+def handle():
+    return Handle(prefix='1903.1', suffix='123', url='http://example.com/foobar')
+
+
+def test_handle_attributes(handle):
+    assert handle.prefix == '1903.1'
+    assert handle.suffix == '123'
+    assert handle.url == 'http://example.com/foobar'
+    assert handle.hdl_uri == 'hdl:1903.1/123'
+    assert str(handle) == '1903.1/123'
+
+
+def test_handle_bearing_resource():
+    obj = HandleBearingResource(handle='hdl:1903.1/123')
+    assert obj.is_valid
+    assert obj.handle.value == Literal('hdl:1903.1/123', datatype=umdtype.handle)
+
+
+def test_invalid_handle_bearing_resource():
+    obj = HandleBearingResource(handle='not-a-handle')
+    assert not obj.is_valid
+    assert obj.validate()['handle'].message == 'is not a handle URI'
+
+
+@pytest.fixture
+def handle_client():
+    return HandleServiceClient('http://handle-local:3000', jwt_token='TOKEN')
+
+
+@httpretty.activate
+def test_get_handle_error(handle_client):
+    httpretty.register_uri(
+        httpretty.GET,
+        uri='http://handle-local:3000/handles/exists',
+        status=HTTPStatus.BAD_REQUEST,
+    )
+    with pytest.raises(HandleServerError):
+        handle_client.get_handle('http://example.com/foobar')
+
+
+@httpretty.activate
+def test_get_handle_does_not_exist(handle_client):
+    httpretty.register_uri(
+        httpretty.GET,
+        uri='http://handle-local:3000/handles/exists',
+        body=json.dumps({'exists': False})
+    )
+    assert handle_client.get_handle('http://example.com/foobar') is None
+
+
+@httpretty.activate
+def test_get_handle_exists(handle_client):
+    httpretty.register_uri(
+        httpretty.GET,
+        uri='http://handle-local:3000/handles/exists',
+        body=json.dumps({'exists': True, 'prefix': '1903.1', 'suffix': '123', 'url': 'http://example.com/foobar'})
+    )
+    handle = handle_client.get_handle('http://example.com/foobar')
+    assert handle.prefix == '1903.1'
+    assert handle.suffix == '123'
+    assert handle.url == 'http://example.com/foobar'
+
+
+@httpretty.activate
+def test_create_handle_success(handle_client):
+    httpretty.register_uri(
+        httpretty.POST,
+        uri='http://handle-local:3000/handles',
+        body=json.dumps(
+            {'suffix': '123', 'request': {'url': 'http://example.com/foobar', 'prefix': '1903.1'}}
+        )
+    )
+    handle = handle_client.create_handle(repo_uri='http://localhost/fcrepo/foobar', url='http://example.com/foobar')
+    assert handle.prefix == '1903.1'
+    assert handle.suffix == '123'
+    assert handle.url == 'http://example.com/foobar'
+
+
+@httpretty.activate
+def test_create_handle_error(handle_client):
+    httpretty.register_uri(
+        httpretty.POST,
+        uri='http://handle-local:3000/handles',
+        status=HTTPStatus.BAD_REQUEST,
+    )
+    with pytest.raises(HandleServerError):
+        handle_client.create_handle(repo_uri='http://localhost/fcrepo/foobar', url='http://example.com/foobar')
+
+
+@httpretty.activate
+def test_update_handle(handle, handle_client):
+    httpretty.register_uri(
+        httpretty.PATCH,
+        uri='http://handle-local:3000/handles/1903.1/123',
+    )
+    updated_handle = handle_client.update_handle(handle=handle, url='http://example.com/new-url')
+    assert updated_handle.url == 'http://example.com/new-url'
+
+
+@httpretty.activate
+def test_update_handle_error(handle, handle_client):
+    httpretty.register_uri(
+        httpretty.PATCH,
+        uri='http://handle-local:3000/handles/1903.1/123',
+        status=HTTPStatus.BAD_REQUEST,
+    )
+    with pytest.raises(HandleServerError):
+        handle_client.update_handle(handle=handle, url='http://example.com/new-url')

--- a/plastron-rdf/src/plastron/rdfmapping/resources.py
+++ b/plastron-rdf/src/plastron/rdfmapping/resources.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 from copy import deepcopy, copy
-from functools import reduce
-from typing import List, Optional, Union, Any, Type, TypeVar
+from typing import List, Optional, Union, Any, Type, TypeVar, Set, Dict, Callable
 from uuid import uuid4
 
 from rdflib import Graph, URIRef
@@ -30,9 +29,9 @@ def is_iterable(value: Any) -> bool:
 
 class RDFResourceBase:
     """Base class for RDF description classes."""
-    rdf_property_names = set()
-    default_values = defaultdict(set)
-    validators = []
+    rdf_property_names: Set = set()
+    default_values: Dict[Any, Set] = defaultdict(set)
+    validators: List[Callable[['RDFResourceBase'], bool]] = []
 
     def __init_subclass__(cls, **kwargs):
         # make new copies of the class variables for the subclasses
@@ -40,6 +39,8 @@ class RDFResourceBase:
         # have already run, so we start with the names of this class's
         # own Property descriptors
         cls.rdf_property_names = {k for k, v in cls.__dict__.items() if isinstance(v, Property)}
+        cls.default_values = defaultdict(set)
+        cls.validators = []
         base_classes = list(filter(lambda c: issubclass(c, RDFResourceBase), cls.__mro__))
         for base_class in base_classes:
             cls.rdf_property_names |= copy(base_class.rdf_property_names)


### PR DESCRIPTION
- added Handle, HandleServiceClient, HandleBearingResource, and HandleServerError
- added handle_client property to PlastronContext
- added tests for handles
- updated vscode settings to generate the coverage.xml from pytest
- added tests
- encapsulated the configuration for repo, client, endpoint, broker, solr, and handle_client into a PlastronContext object
- reworked the way the commands objects are created and called:
  - created using the PlastronContext object, which includes the full config
  - each cli command has access to the full config
  - called with just the argparse args

Fixed bugs discovered when implementing tests for publish:
- `first` and `last` should not be required in the AggregationMixin class
- when building a class's `rdf_property_names`, `default_values`, and `validators`, must consider all of its base classes (using __mro__)

https://umd-dit.atlassian.net/browse/LIBFCREPO-1256