### PR TITLE
LIBFCREPO-1267. Fix logging of URIs for import.

### DIFF
--- a/plastron-repo/src/plastron/jobs/imports/spreadsheet.py
+++ b/plastron-repo/src/plastron/jobs/imports/spreadsheet.py
@@ -180,7 +180,7 @@ class Row:
         self.number = row_number
         self.data = data
         self.identifier_column = identifier_column
-        self._file_groups = build_file_groups(self.data['FILES'])
+        self._file_groups = build_file_groups(self.data.get('FILES', ''))
 
     def __getitem__(self, item):
         return self.data[item]

--- a/plastron-repo/src/plastron/repo/__init__.py
+++ b/plastron-repo/src/plastron/repo/__init__.py
@@ -293,7 +293,7 @@ class ContainerResource(RepositoryResource):
             # To create the resource and metadata at the same time (when the URI is not known),
             # we must use the empty URI for the subject, and serialize as Turtle. Fedora will
             # interpret the empty URI as a placeholder for "this resource".
-            description.graph.change_uri(description.uri, URIRef(''))
+            description.uri = URIRef('')
             resource = self.repo.create(
                 resource_class=resource_class,
                 container_path=self.path,
@@ -303,6 +303,8 @@ class ContainerResource(RepositoryResource):
                 data=description.graph.serialize(format='text/turtle').encode(),
                 **kwargs,
             )
+            # update the description URI the newly created URL
+            description.uri = URIRef(resource.url)
         else:
             resource = self.repo.create(resource_class=resource_class, container_path=self.path, **kwargs)
         return resource


### PR DESCRIPTION
- ContainerResource.create_child() updates the URI of the description after creation
- omit placeholder "urn:uuid:..." URIs in the dropped/failed logs
- other fixes to the ImportSpreadsheet and ImportJob classes

https://umd-dit.atlassian.net/browse/LIBFCREPO-1267