### PR TITLE
LIBFCREPO-1274. Created separate add_properties and set_properties methods.

### DIFF
--- a/plastron-rdf/tests/test_resources.py
+++ b/plastron-rdf/tests/test_resources.py
@@ -1,0 +1,38 @@
+from plastron.rdfmapping.resources import RDFResource
+from rdflib import URIRef
+
+
+def test_add_properties():
+    resource = RDFResource()
+    assert len(resource.rdf_type) == 0
+    resource.add_properties(rdf_type=URIRef('http://purl.org/dc/dcmitype/Text'))
+    assert len(resource.rdf_type) == 1
+    resource.add_properties(rdf_type=URIRef('http://purl.org/dc/dcmitype/Image'))
+    assert len(resource.rdf_type) == 2
+    assert set(resource.rdf_type.values) == {URIRef('http://purl.org/dc/dcmitype/Text'), URIRef('http://purl.org/dc/dcmitype/Image')}
+
+
+def test_add_properties_list():
+    resource = RDFResource()
+    assert len(resource.rdf_type) == 0
+    resource.add_properties(rdf_type=[URIRef('http://purl.org/dc/dcmitype/Text'), URIRef('http://purl.org/dc/dcmitype/Image')])
+    assert len(resource.rdf_type) == 2
+    assert set(resource.rdf_type.values) == {URIRef('http://purl.org/dc/dcmitype/Text'), URIRef('http://purl.org/dc/dcmitype/Image')}
+
+
+def test_set_properties():
+    resource = RDFResource()
+    assert len(resource.rdf_type) == 0
+    resource.set_properties(rdf_type=URIRef('http://purl.org/dc/dcmitype/Text'))
+    assert len(resource.rdf_type) == 1
+    resource.set_properties(rdf_type=URIRef('http://purl.org/dc/dcmitype/Image'))
+    assert len(resource.rdf_type) == 1
+    assert set(resource.rdf_type.values) == {URIRef('http://purl.org/dc/dcmitype/Image')}
+
+
+def test_set_properties_list():
+    resource = RDFResource()
+    assert len(resource.rdf_type) == 0
+    resource.set_properties(rdf_type=[URIRef('http://purl.org/dc/dcmitype/Text'), URIRef('http://purl.org/dc/dcmitype/Image')])
+    assert len(resource.rdf_type) == 2
+    assert set(resource.rdf_type.values) == {URIRef('http://purl.org/dc/dcmitype/Text'), URIRef('http://purl.org/dc/dcmitype/Image')}

--- a/plastron-repo/src/plastron/jobs/importjob/spreadsheet.py
+++ b/plastron-repo/src/plastron/jobs/importjob/spreadsheet.py
@@ -221,7 +221,8 @@ class Row:
         # to their correct positional locations
         row_index = build_lookup_index(self.index_string)
         params = unflatten(self.data, self.spreadsheet.model_class, self.spreadsheet.model_class.HEADER_MAP, row_index)
-        item: RDFResourceType = self.spreadsheet.model_class(uri=self.uri, graph=resource.graph, **params)
+        item: RDFResourceType = self.spreadsheet.model_class(uri=self.uri, graph=resource.graph)
+        item.set_properties(**params)
 
         return item
 

--- a/plastron-repo/src/plastron/repo/pcdm.py
+++ b/plastron-repo/src/plastron/repo/pcdm.py
@@ -237,7 +237,7 @@ class PCDMObjectResource(PCDMFileBearingResource, AggregationResource):
         page_resource = self.members_container.create_child(
             resource_class=PCDMPageResource,
             slug=slug,
-            description=Page(title=title, number=number, member_of=parent),
+            description=Page(title=title, number=Literal(number), member_of=parent),
         )
         parent.has_member.add(URIRef(page_resource.url))
         for file_spec in file_group.files:


### PR DESCRIPTION
- add_properties appends the given properties to existing properties
- set_properties clears the existing properties before adding the given properties
- the resource constructor uses add_properties to add defaults and any kwargs
- when importing and existing item, uses set_properties to replace the existing data with the values from the spreadsheet

https://umd-dit.atlassian.net/browse/LIBFCREPO-1274