### PR TITLE
LIBFCREPO-1286. Don't wrap the PlastronContext in a Namespace for the webapp.

### DIFF
--- a/plastron-web/src/plastron/web/__init__.py
+++ b/plastron-web/src/plastron/web/__init__.py
@@ -43,7 +43,7 @@ def create_app(config_file: str):
     app = Flask(__name__)
     with open(config_file, "r") as stream:
         config = envsubst(yaml.safe_load(stream))
-        app.config['CONTEXT'] = Namespace(obj=PlastronContext(config=config, args=Namespace(delegated_user=None)))
+        app.config['CONTEXT'] = PlastronContext(config=config, args=Namespace(delegated_user=None))
     jobs_dir = Path(os.environ.get('JOBS_DIR', 'jobs'))
     jobs = Jobs(directory=jobs_dir)
     app.register_blueprint(activitystream_bp)


### PR DESCRIPTION
Since we are no longer reusing the CLI commands for the webapp, we don't need the wrapper.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1286