### PR TITLE
LIBFCREPO-1287. Added "presentation_set" field to Item model

### DIFF
--- a/plastron-models/src/plastron/models/letter.py
+++ b/plastron-models/src/plastron/models/letter.py
@@ -3,8 +3,8 @@ from rdflib import Namespace
 from plastron.rdfmapping.decorators import rdf_type
 from plastron.rdfmapping.descriptors import ObjectProperty, DataProperty
 from plastron.rdfmapping.resources import RDFResource
-from plastron.validation.rules import is_edtf_formatted, is_handle
-from plastron.namespaces import bibo, dc, dcmitype, dcterms, edm, geo, rel, skos, owl, umd
+from plastron.validation.rules import is_edtf_formatted, is_handle, is_from_vocabulary
+from plastron.namespaces import bibo, dc, dcmitype, dcterms, edm, geo, rel, skos, ore, owl, umd
 
 umdtype = Namespace('http://vocab.lib.umd.edu/datatype#')
 
@@ -52,6 +52,11 @@ class Letter(RDFResource):
     extent = DataProperty(dcterms.extent, required=True)
     rights_holder = DataProperty(dcterms.rightsHolder, required=True)
     handle = DataProperty(dcterms.identifier, datatype=umdtype.handle, validate=is_handle)
+    presentation_set = ObjectProperty(
+        ore.isAggregatedBy,
+        repeatable=True,
+        validate=is_from_vocabulary('http://vocab.lib.umd.edu/set#'),
+    )
 
     HEADER_MAP = {
         'title': 'Title',
@@ -83,6 +88,7 @@ class Letter(RDFResource):
             'label': 'Author',
         },
         'handle': 'Handle',
+        'presentation_set': 'Presentation Set',
     }
 
 

--- a/plastron-models/src/plastron/models/newspaper.py
+++ b/plastron-models/src/plastron/models/newspaper.py
@@ -2,12 +2,12 @@ from lxml.etree import parse, XMLSyntaxError
 
 from plastron.models.annotations import TextblockOnPage
 from plastron.models.umd import PCDMObject, PCDMFile
-from plastron.namespaces import bibo, carriers, dc, dcterms, fabio, ndnp, pcdmuse, umdtype, pcdm, umd
+from plastron.namespaces import bibo, carriers, dc, dcterms, fabio, ndnp, ore, pcdmuse, umdtype, pcdm, umd
 from plastron.rdf.ocr import ALTOResource
 from plastron.rdfmapping.decorators import rdf_type
 from plastron.rdfmapping.descriptors import DataProperty, ObjectProperty
 from plastron.repo import DataReadError
-from plastron.validation.rules import is_handle, is_iso_8601_date
+from plastron.validation.rules import is_handle, is_iso_8601_date, is_from_vocabulary
 
 
 @rdf_type(bibo.Issue, umd.Newspaper)
@@ -19,6 +19,11 @@ class Issue(PCDMObject):
     issue = DataProperty(bibo.issue, required=True)
     edition = DataProperty(bibo.edition, required=True)
     handle = DataProperty(dcterms.identifier, datatype=umdtype.handle, validate=is_handle)
+    presentation_set = ObjectProperty(
+        ore.isAggregatedBy,
+        repeatable=True,
+        validate=is_from_vocabulary('http://vocab.lib.umd.edu/set#'),
+    )
 
     HEADER_MAP = {
         'title': 'Title',
@@ -26,7 +31,8 @@ class Issue(PCDMObject):
         'volume': 'Volume',
         'issue': 'Issue',
         'edition': 'Edition',
-        'handle': 'Handle'
+        'handle': 'Handle',
+        'presentation_set': 'Presentation Set',
     }
 
 

--- a/plastron-models/src/plastron/models/poster.py
+++ b/plastron-models/src/plastron/models/poster.py
@@ -1,10 +1,10 @@
 from rdflib import URIRef
 
 from plastron.models.umd import PCDMObject
-from plastron.namespaces import dcterms, dc, edm, bibo, geo, umd, umdtype
+from plastron.namespaces import dcterms, dc, edm, bibo, geo, ore, umd, umdtype
 from plastron.rdfmapping.decorators import rdf_type
 from plastron.rdfmapping.descriptors import ObjectProperty, DataProperty, Property
-from plastron.validation.rules import is_edtf_formatted, is_handle
+from plastron.validation.rules import is_edtf_formatted, is_handle, is_from_vocabulary
 
 
 @rdf_type(bibo.Image, umd.Poster)
@@ -32,6 +32,11 @@ class Poster(PCDMObject):
     identifier = DataProperty(dcterms.identifier, required=True)
     handle = DataProperty(dcterms.identifier, validate=is_handle, datatype=umdtype.handle)
     place = ObjectProperty(dcterms.spatial)
+    presentation_set = ObjectProperty(
+        ore.isAggregatedBy,
+        repeatable=True,
+        validate=is_from_vocabulary('http://vocab.lib.umd.edu/set#'),
+    )
 
     HEADER_MAP = {
         'title': 'Title',
@@ -52,5 +57,6 @@ class Poster(PCDMObject):
         'subject': 'Subject',
         'rights': 'Rights',
         'identifier': 'Identifier',
-        'handle': 'Handle'
+        'handle': 'Handle',
+        'presentation_set': 'Presentation Set',
     }

--- a/plastron-models/src/plastron/models/umd.py
+++ b/plastron-models/src/plastron/models/umd.py
@@ -72,6 +72,11 @@ class Item(PCDMObject, HandleBearingResource):
         dcterms.isPartOf,
         validate=is_from_vocabulary('http://vocab.lib.umd.edu/collection#'),
     )
+    presentation_set = ObjectProperty(
+        ore.isAggregatedBy,
+        repeatable=True,
+        validate=is_from_vocabulary('http://vocab.lib.umd.edu/set#'),
+    )
     date = DataProperty(dc.date, validate=is_edtf_formatted)
     description = DataProperty(dcterms.description)
     alternate_title = DataProperty(dcterms.alternative, repeatable=True)
@@ -93,6 +98,7 @@ class Item(PCDMObject, HandleBearingResource):
         'title': 'Title',
         'format': 'Format',
         'archival_collection': 'Archival Collection',
+        'presentation_set': 'Presentation Set',
         'date': 'Date',
         'description': 'Description',
         'alternate_title': 'Alternate Title',

--- a/plastron-models/tests/test_issue_model.py
+++ b/plastron-models/tests/test_issue_model.py
@@ -8,9 +8,10 @@ base_uri = 'http://example.com/xyz'
 
 
 @pytest.mark.skip('Test cannot be run because Issue validation does not currently work')
-def test_issue_without_presentation_set_is_valid():
+def test_issue_valid_with_only_required_fields():
     issue = Issue()
-    # Required fields
+
+    # Only provide required fields
     issue.identifier = 'test_issue'
     issue.title = 'Test Issue'
     issue.date = '1970-01-01'
@@ -19,81 +20,3 @@ def test_issue_without_presentation_set_is_valid():
     issue.edition = '1'
 
     assert issue.is_valid
-
-
-def test_issue_with_single_presentation_set():
-    issue = create_issue_with_presentation_set(
-        base_uri, ['foo']
-    )
-
-    assert len(issue.presentation_set) == 1
-    assert issue.presentation_set.value == URIRef('http://vocab.lib.umd.edu/set#foo')
-
-
-def test_letter_validation_with_valid_presentation_set():
-    issue = create_issue_with_presentation_set(
-        base_uri, ['test']
-    )
-    assert issue.presentation_set.is_valid
-
-
-def test_issue_validation_with_invalid_presentation_set():
-    issue = create_issue_with_presentation_set(
-        base_uri, ['not_valid']
-    )
-    assert not issue.presentation_set.is_valid
-
-
-def test_issue_with_multiple_presentation_sets():
-    issue = create_issue_with_presentation_set(
-        base_uri, ['foo', 'bar']
-    )
-
-    assert len(issue.presentation_set) == 2
-
-    expected = sorted([URIRef('http://vocab.lib.umd.edu/set#bar'), URIRef('http://vocab.lib.umd.edu/set#foo')])
-    assert sorted(list(issue.presentation_set.values)) == expected
-
-
-def test_single_presentation_set_can_be_set_on_letter():
-    issue = Issue(uri=URIRef('http://example.com/123'), presentation_set=URIRef('http://vocab.lib.umd.edu/set#foobar'))
-
-    expected = (URIRef('http://example.com/123'), ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar'))
-    assert expected in issue.graph
-
-
-def test_multiple_presentation_sets_can_be_set_on_issue():
-    base_uri = URIRef('http://example.com/123')
-
-    graph = Graph()
-    graph.add((base_uri, ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar')))
-    graph.add((base_uri, ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#barbaz')))
-
-    issue = Issue(uri=base_uri, presentation_set=graph.objects())
-
-    expected = [
-        (URIRef('http://example.com/123'), ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar')),
-        (URIRef('http://example.com/123'), ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#barbaz'))
-    ]
-
-    for e in expected:
-        assert e in issue.graph
-
-
-# Helper Functions
-
-def create_presentation_set_turtle_format(set_names):
-    preamble = '@prefix ore: <http://www.openarchives.org/ore/terms/> .'
-    preamble = preamble + '@prefix umdset: <http://vocab.lib.umd.edu/set#> .'
-    presentation_set = preamble
-    for set_name in set_names:
-        presentation_set += f'<> ore:isAggregatedBy umdset:{set_name} .'
-    return presentation_set
-
-
-def create_issue_with_presentation_set(item_uri, set_names):
-    presentation_set = create_presentation_set_turtle_format(set_names)
-    return Issue(
-        graph=Graph().parse(data=presentation_set, format='turtle', publicID=base_uri),
-        uri=item_uri
-    )

--- a/plastron-models/tests/test_issue_model.py
+++ b/plastron-models/tests/test_issue_model.py
@@ -1,0 +1,99 @@
+from plastron.models.newspaper import Issue
+from plastron.namespaces import ore
+from rdflib import Graph, URIRef
+
+import pytest
+
+base_uri = 'http://example.com/xyz'
+
+
+@pytest.mark.skip('Test cannot be run because Issue validation does not currently work')
+def test_issue_without_presentation_set_is_valid():
+    issue = Issue()
+    # Required fields
+    issue.identifier = 'test_issue'
+    issue.title = 'Test Issue'
+    issue.date = '1970-01-01'
+    issue.volume = '1'
+    issue.issue = '1'
+    issue.edition = '1'
+
+    assert issue.is_valid
+
+
+def test_issue_with_single_presentation_set():
+    issue = create_issue_with_presentation_set(
+        base_uri, ['foo']
+    )
+
+    assert len(issue.presentation_set) == 1
+    assert issue.presentation_set.value == URIRef('http://vocab.lib.umd.edu/set#foo')
+
+
+def test_letter_validation_with_valid_presentation_set():
+    issue = create_issue_with_presentation_set(
+        base_uri, ['test']
+    )
+    assert issue.presentation_set.is_valid
+
+
+def test_issue_validation_with_invalid_presentation_set():
+    issue = create_issue_with_presentation_set(
+        base_uri, ['not_valid']
+    )
+    assert not issue.presentation_set.is_valid
+
+
+def test_issue_with_multiple_presentation_sets():
+    issue = create_issue_with_presentation_set(
+        base_uri, ['foo', 'bar']
+    )
+
+    assert len(issue.presentation_set) == 2
+
+    expected = sorted([URIRef('http://vocab.lib.umd.edu/set#bar'), URIRef('http://vocab.lib.umd.edu/set#foo')])
+    assert sorted(list(issue.presentation_set.values)) == expected
+
+
+def test_single_presentation_set_can_be_set_on_letter():
+    issue = Issue(uri=URIRef('http://example.com/123'), presentation_set=URIRef('http://vocab.lib.umd.edu/set#foobar'))
+
+    expected = (URIRef('http://example.com/123'), ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar'))
+    assert expected in issue.graph
+
+
+def test_multiple_presentation_sets_can_be_set_on_issue():
+    base_uri = URIRef('http://example.com/123')
+
+    graph = Graph()
+    graph.add((base_uri, ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar')))
+    graph.add((base_uri, ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#barbaz')))
+
+    issue = Issue(uri=base_uri, presentation_set=graph.objects())
+
+    expected = [
+        (URIRef('http://example.com/123'), ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar')),
+        (URIRef('http://example.com/123'), ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#barbaz'))
+    ]
+
+    for e in expected:
+        assert e in issue.graph
+
+
+# Helper Functions
+
+def create_presentation_set_turtle_format(set_names):
+    preamble = '@prefix ore: <http://www.openarchives.org/ore/terms/> .'
+    preamble = preamble + '@prefix umdset: <http://vocab.lib.umd.edu/set#> .'
+    presentation_set = preamble
+    for set_name in set_names:
+        presentation_set += f'<> ore:isAggregatedBy umdset:{set_name} .'
+    return presentation_set
+
+
+def create_issue_with_presentation_set(item_uri, set_names):
+    presentation_set = create_presentation_set_turtle_format(set_names)
+    return Issue(
+        graph=Graph().parse(data=presentation_set, format='turtle', publicID=base_uri),
+        uri=item_uri
+    )

--- a/plastron-models/tests/test_letter_model.py
+++ b/plastron-models/tests/test_letter_model.py
@@ -1,0 +1,100 @@
+from plastron.models.letter import Letter
+from plastron.namespaces import ore
+from rdflib import Graph, URIRef
+
+base_uri = 'http://example.com/xyz'
+
+
+def test_letter_without_presentation_set_is_valid():
+    letter = Letter()
+    # Required fields
+    letter.identifier = 'test_letter'
+    letter.object_type = 'http://purl.org/dc/dcmitype/Text'
+    letter.rights = 'http://vocab.lib.umd.edu/rightsStatement#InC-EDU'
+    letter.title = 'Test Letter'
+    letter.description = 'Test Letter Description'
+    letter.language = 'en'
+    letter.part_of = 'http://fedora.info/definitions/v4/repository#inaccessibleResource'
+    letter.bibliographic_citation = 'Test Bibliographic Citation'
+    letter.rights_holder = 'Test Rights Holder'
+    letter.type = 'http://purl.org/dc/dcmitype/Text'
+    letter.extent = '1 page'
+    assert letter.is_valid
+
+
+def test_letter_with_single_presentation_set():
+    letter = create_letter_with_presentation_set(
+        base_uri, ['foo']
+    )
+
+    assert len(letter.presentation_set) == 1
+    assert letter.presentation_set.value == URIRef('http://vocab.lib.umd.edu/set#foo')
+
+
+def test_letter_validation_with_valid_presentation_set():
+    letter = create_letter_with_presentation_set(
+        base_uri, ['test']
+    )
+    assert letter.presentation_set.is_valid
+
+
+def test_letter_validation_with_invalid_presentation_set():
+    letter = create_letter_with_presentation_set(
+        base_uri, ['not_valid']
+    )
+    assert not letter.presentation_set.is_valid
+
+
+def test_letter_with_multiple_presentation_sets():
+    letter = create_letter_with_presentation_set(
+        base_uri, ['foo', 'bar']
+    )
+
+    assert len(letter.presentation_set) == 2
+
+    expected = sorted([URIRef('http://vocab.lib.umd.edu/set#bar'), URIRef('http://vocab.lib.umd.edu/set#foo')])
+    assert sorted(list(letter.presentation_set.values)) == expected
+
+
+def test_single_presentation_set_can_be_set_on_letter():
+    letter = Letter(uri=URIRef('http://example.com/123'), presentation_set=URIRef('http://vocab.lib.umd.edu/set#foobar'))
+
+    expected = (URIRef('http://example.com/123'), ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar'))
+    assert expected in letter.graph
+
+
+def test_multiple_presentation_sets_can_be_set_on_letter():
+    base_uri = URIRef('http://example.com/123')
+
+    graph = Graph()
+    graph.add((base_uri, ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar')))
+    graph.add((base_uri, ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#barbaz')))
+
+    letter = Letter(uri=base_uri, presentation_set=graph.objects())
+
+    expected = [
+        (URIRef('http://example.com/123'), ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar')),
+        (URIRef('http://example.com/123'), ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#barbaz'))
+    ]
+
+    for e in expected:
+        assert e in letter.graph
+
+
+# Helper Functions
+
+def create_presentation_set_turtle_format(set_names):
+    preamble = '@prefix ore: <http://www.openarchives.org/ore/terms/> .'
+    preamble = preamble + '@prefix umdset: <http://vocab.lib.umd.edu/set#> .'
+    presentation_set = preamble
+    for set_name in set_names:
+        presentation_set += f'<> ore:isAggregatedBy umdset:{set_name} .'
+    return presentation_set
+
+
+def create_letter_with_presentation_set(item_uri, set_names):
+    presentation_set = create_presentation_set_turtle_format(set_names)
+    return Letter(
+        graph=Graph().parse(data=presentation_set, format='turtle', publicID=base_uri),
+        uri=item_uri
+    )

--- a/plastron-models/tests/test_letter_model.py
+++ b/plastron-models/tests/test_letter_model.py
@@ -5,9 +5,10 @@ from rdflib import Graph, URIRef
 base_uri = 'http://example.com/xyz'
 
 
-def test_letter_without_presentation_set_is_valid():
+def test_letter_valid_with_only_required_fields():
     letter = Letter()
-    # Required fields
+
+    # Only provide required fields
     letter.identifier = 'test_letter'
     letter.object_type = 'http://purl.org/dc/dcmitype/Text'
     letter.rights = 'http://vocab.lib.umd.edu/rightsStatement#InC-EDU'
@@ -20,81 +21,3 @@ def test_letter_without_presentation_set_is_valid():
     letter.type = 'http://purl.org/dc/dcmitype/Text'
     letter.extent = '1 page'
     assert letter.is_valid
-
-
-def test_letter_with_single_presentation_set():
-    letter = create_letter_with_presentation_set(
-        base_uri, ['foo']
-    )
-
-    assert len(letter.presentation_set) == 1
-    assert letter.presentation_set.value == URIRef('http://vocab.lib.umd.edu/set#foo')
-
-
-def test_letter_validation_with_valid_presentation_set():
-    letter = create_letter_with_presentation_set(
-        base_uri, ['test']
-    )
-    assert letter.presentation_set.is_valid
-
-
-def test_letter_validation_with_invalid_presentation_set():
-    letter = create_letter_with_presentation_set(
-        base_uri, ['not_valid']
-    )
-    assert not letter.presentation_set.is_valid
-
-
-def test_letter_with_multiple_presentation_sets():
-    letter = create_letter_with_presentation_set(
-        base_uri, ['foo', 'bar']
-    )
-
-    assert len(letter.presentation_set) == 2
-
-    expected = sorted([URIRef('http://vocab.lib.umd.edu/set#bar'), URIRef('http://vocab.lib.umd.edu/set#foo')])
-    assert sorted(list(letter.presentation_set.values)) == expected
-
-
-def test_single_presentation_set_can_be_set_on_letter():
-    letter = Letter(uri=URIRef('http://example.com/123'), presentation_set=URIRef('http://vocab.lib.umd.edu/set#foobar'))
-
-    expected = (URIRef('http://example.com/123'), ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar'))
-    assert expected in letter.graph
-
-
-def test_multiple_presentation_sets_can_be_set_on_letter():
-    base_uri = URIRef('http://example.com/123')
-
-    graph = Graph()
-    graph.add((base_uri, ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar')))
-    graph.add((base_uri, ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#barbaz')))
-
-    letter = Letter(uri=base_uri, presentation_set=graph.objects())
-
-    expected = [
-        (URIRef('http://example.com/123'), ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar')),
-        (URIRef('http://example.com/123'), ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#barbaz'))
-    ]
-
-    for e in expected:
-        assert e in letter.graph
-
-
-# Helper Functions
-
-def create_presentation_set_turtle_format(set_names):
-    preamble = '@prefix ore: <http://www.openarchives.org/ore/terms/> .'
-    preamble = preamble + '@prefix umdset: <http://vocab.lib.umd.edu/set#> .'
-    presentation_set = preamble
-    for set_name in set_names:
-        presentation_set += f'<> ore:isAggregatedBy umdset:{set_name} .'
-    return presentation_set
-
-
-def create_letter_with_presentation_set(item_uri, set_names):
-    presentation_set = create_presentation_set_turtle_format(set_names)
-    return Letter(
-        graph=Graph().parse(data=presentation_set, format='turtle', publicID=base_uri),
-        uri=item_uri
-    )

--- a/plastron-models/tests/test_poster_model.py
+++ b/plastron-models/tests/test_poster_model.py
@@ -8,9 +8,10 @@ base_uri = 'http://example.com/xyz'
 
 
 @pytest.mark.skip('Test cannot be run because Poster validation does not currently work')
-def test_poster_without_presentation_set_is_valid():
+def test_poster_valid_with_only_required_fields():
     poster = Poster()
-    # Required fields
+
+    # Only provide required fields
     poster.identifier = 'test_poster'
     poster.title = 'Test Poster'
     poster.language = 'en'
@@ -21,81 +22,3 @@ def test_poster_without_presentation_set_is_valid():
     poster.rights = 'http://rightsstatements.org/vocab/NoC-US/1.0/'
 
     assert poster.is_valid
-
-
-def test_poster_with_single_presentation_set():
-    poster = create_poster_with_presentation_set(
-        base_uri, ['foo']
-    )
-
-    assert len(poster.presentation_set) == 1
-    assert poster.presentation_set.value == URIRef('http://vocab.lib.umd.edu/set#foo')
-
-
-def test_poster_validation_with_valid_presentation_set():
-    poster = create_poster_with_presentation_set(
-        base_uri, ['test']
-    )
-    assert poster.presentation_set.is_valid
-
-
-def test_poster_validation_with_invalid_presentation_set():
-    poster = create_poster_with_presentation_set(
-        base_uri, ['not_valid']
-    )
-    assert not poster.presentation_set.is_valid
-
-
-def test_poster_with_multiple_presentation_sets():
-    poster = create_poster_with_presentation_set(
-        base_uri, ['foo', 'bar']
-    )
-
-    assert len(poster.presentation_set) == 2
-
-    expected = sorted([URIRef('http://vocab.lib.umd.edu/set#bar'), URIRef('http://vocab.lib.umd.edu/set#foo')])
-    assert sorted(list(poster.presentation_set.values)) == expected
-
-
-def test_single_presentation_set_can_be_set_on_poster():
-    poster = Poster(uri=URIRef('http://example.com/123'), presentation_set=URIRef('http://vocab.lib.umd.edu/set#foobar'))
-
-    expected = (URIRef('http://example.com/123'), ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar'))
-    assert expected in poster.graph
-
-
-def test_multiple_presentation_sets_can_be_set_on_poster():
-    base_uri = URIRef('http://example.com/123')
-
-    graph = Graph()
-    graph.add((base_uri, ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar')))
-    graph.add((base_uri, ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#barbaz')))
-
-    poster = Poster(uri=base_uri, presentation_set=graph.objects())
-
-    expected = [
-        (URIRef('http://example.com/123'), ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar')),
-        (URIRef('http://example.com/123'), ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#barbaz'))
-    ]
-
-    for e in expected:
-        assert e in poster.graph
-
-
-# Helper Functions
-
-def create_presentation_set_turtle_format(set_names):
-    preamble = '@prefix ore: <http://www.openarchives.org/ore/terms/> .'
-    preamble = preamble + '@prefix umdset: <http://vocab.lib.umd.edu/set#> .'
-    presentation_set = preamble
-    for set_name in set_names:
-        presentation_set += f'<> ore:isAggregatedBy umdset:{set_name} .'
-    return presentation_set
-
-
-def create_poster_with_presentation_set(item_uri, set_names):
-    presentation_set = create_presentation_set_turtle_format(set_names)
-    return Poster(
-        graph=Graph().parse(data=presentation_set, format='turtle', publicID=base_uri),
-        uri=item_uri
-    )

--- a/plastron-models/tests/test_poster_model.py
+++ b/plastron-models/tests/test_poster_model.py
@@ -1,0 +1,101 @@
+from plastron.models.poster import Poster
+from plastron.namespaces import ore
+from rdflib import Graph, Literal, URIRef
+
+import pytest
+
+base_uri = 'http://example.com/xyz'
+
+
+@pytest.mark.skip('Test cannot be run because Poster validation does not currently work')
+def test_poster_without_presentation_set_is_valid():
+    poster = Poster()
+    # Required fields
+    poster.identifier = 'test_poster'
+    poster.title = 'Test Poster'
+    poster.language = 'en'
+    poster.part_of = 'http://fedora.info/definitions/v4/repository#inaccessibleResource'
+    poster.type = Literal('http://purl.org/dc/dcmitype/Image')
+    poster.format = "Test Poster Format"
+    poster.locator = 'NZK120'
+    poster.rights = 'http://rightsstatements.org/vocab/NoC-US/1.0/'
+
+    assert poster.is_valid
+
+
+def test_poster_with_single_presentation_set():
+    poster = create_poster_with_presentation_set(
+        base_uri, ['foo']
+    )
+
+    assert len(poster.presentation_set) == 1
+    assert poster.presentation_set.value == URIRef('http://vocab.lib.umd.edu/set#foo')
+
+
+def test_poster_validation_with_valid_presentation_set():
+    poster = create_poster_with_presentation_set(
+        base_uri, ['test']
+    )
+    assert poster.presentation_set.is_valid
+
+
+def test_poster_validation_with_invalid_presentation_set():
+    poster = create_poster_with_presentation_set(
+        base_uri, ['not_valid']
+    )
+    assert not poster.presentation_set.is_valid
+
+
+def test_poster_with_multiple_presentation_sets():
+    poster = create_poster_with_presentation_set(
+        base_uri, ['foo', 'bar']
+    )
+
+    assert len(poster.presentation_set) == 2
+
+    expected = sorted([URIRef('http://vocab.lib.umd.edu/set#bar'), URIRef('http://vocab.lib.umd.edu/set#foo')])
+    assert sorted(list(poster.presentation_set.values)) == expected
+
+
+def test_single_presentation_set_can_be_set_on_poster():
+    poster = Poster(uri=URIRef('http://example.com/123'), presentation_set=URIRef('http://vocab.lib.umd.edu/set#foobar'))
+
+    expected = (URIRef('http://example.com/123'), ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar'))
+    assert expected in poster.graph
+
+
+def test_multiple_presentation_sets_can_be_set_on_poster():
+    base_uri = URIRef('http://example.com/123')
+
+    graph = Graph()
+    graph.add((base_uri, ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar')))
+    graph.add((base_uri, ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#barbaz')))
+
+    poster = Poster(uri=base_uri, presentation_set=graph.objects())
+
+    expected = [
+        (URIRef('http://example.com/123'), ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar')),
+        (URIRef('http://example.com/123'), ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#barbaz'))
+    ]
+
+    for e in expected:
+        assert e in poster.graph
+
+
+# Helper Functions
+
+def create_presentation_set_turtle_format(set_names):
+    preamble = '@prefix ore: <http://www.openarchives.org/ore/terms/> .'
+    preamble = preamble + '@prefix umdset: <http://vocab.lib.umd.edu/set#> .'
+    presentation_set = preamble
+    for set_name in set_names:
+        presentation_set += f'<> ore:isAggregatedBy umdset:{set_name} .'
+    return presentation_set
+
+
+def create_poster_with_presentation_set(item_uri, set_names):
+    presentation_set = create_presentation_set_turtle_format(set_names)
+    return Poster(
+        graph=Graph().parse(data=presentation_set, format='turtle', publicID=base_uri),
+        uri=item_uri
+    )

--- a/plastron-models/tests/test_presentation_set.py
+++ b/plastron-models/tests/test_presentation_set.py
@@ -1,0 +1,93 @@
+from plastron.models.umd import Item
+from plastron.models.letter import Letter
+from plastron.models.newspaper import Issue
+from plastron.models.poster import Poster
+from plastron.namespaces import ore
+from rdflib import Graph, URIRef
+
+import pytest
+
+base_uri = 'http://example.com/xyz'
+
+
+@pytest.mark.parametrize("model_class", [Item, Letter, Poster, Issue])
+def test_model_with_single_presentation_set(model_class):
+    model = create_model_with_presentation_set(
+        model_class, base_uri, ['foo']
+    )
+
+    assert len(model.presentation_set) == 1
+    assert model.presentation_set.value == URIRef('http://vocab.lib.umd.edu/set#foo')
+
+
+@pytest.mark.parametrize("model_class", [Item, Letter, Poster, Issue])
+def test_model_validation_with_valid_presentation_set(model_class):
+    model = create_model_with_presentation_set(
+        model_class, base_uri, ['test']
+    )
+    assert model.presentation_set.is_valid
+
+
+@pytest.mark.parametrize("model_class", [Item, Letter, Poster, Issue])
+def test_model_validation_with_invalid_presentation_set(model_class):
+    model = create_model_with_presentation_set(
+        model_class, base_uri, ['not_valid']
+    )
+    assert not model.presentation_set.is_valid
+
+
+@pytest.mark.parametrize("model_class", [Item, Letter, Poster, Issue])
+def test_model_with_multiple_presentation_sets(model_class):
+    model = create_model_with_presentation_set(
+        model_class, base_uri, ['foo', 'bar']
+    )
+
+    assert len(model.presentation_set) == 2
+
+    expected = sorted([URIRef('http://vocab.lib.umd.edu/set#bar'), URIRef('http://vocab.lib.umd.edu/set#foo')])
+    assert sorted(list(model.presentation_set.values)) == expected
+
+
+@pytest.mark.parametrize("model_class", [Item, Letter, Poster, Issue])
+def test_single_presentation_set_can_be_set_on_model(model_class):
+    model = model_class(uri=base_uri)
+    model.presentation_set = URIRef('http://vocab.lib.umd.edu/set#foobar')
+
+    expected = (URIRef(base_uri), ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar'))
+    assert expected in model.graph
+
+
+@pytest.mark.parametrize("model_class", [Item, Letter, Poster, Issue])
+def test_multiple_presentation_sets_can_be_set_on_model(model_class):
+    base_uri_ref = URIRef(base_uri)
+
+    model = model_class(uri=base_uri)
+    model.presentation_set.add(URIRef('http://vocab.lib.umd.edu/set#foobar'))
+    model.presentation_set.add(URIRef('http://vocab.lib.umd.edu/set#barbaz'))
+
+    expected = [
+        (base_uri_ref, ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar')),
+        (base_uri_ref, ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#barbaz'))
+    ]
+
+    for e in expected:
+        assert e in model.graph
+
+
+# Helper Functions
+
+def create_presentation_set_turtle_format(set_names):
+    preamble = '@prefix ore: <http://www.openarchives.org/ore/terms/> .'
+    preamble = preamble + '@prefix umdset: <http://vocab.lib.umd.edu/set#> .'
+    presentation_set = preamble
+    for set_name in set_names:
+        presentation_set += f'<> ore:isAggregatedBy umdset:{set_name} .'
+    return presentation_set
+
+
+def create_model_with_presentation_set(model_class, item_uri, set_names):
+    presentation_set = create_presentation_set_turtle_format(set_names)
+    model_graph = Graph().parse(data=presentation_set, format='turtle', publicID=item_uri)
+    model = model_class(graph=model_graph, uri=item_uri)
+
+    return model

--- a/plastron-models/tests/test_umd_model.py
+++ b/plastron-models/tests/test_umd_model.py
@@ -1,8 +1,7 @@
-from rdflib import Graph, Literal, Namespace, URIRef
-
 from plastron.models.umd import Item
 from plastron.namespaces import umdform
 from plastron.repo.pcdm import get_new_member_title
+from rdflib import Graph, Literal, Namespace, URIRef
 
 rdf = (
     '@prefix dcterms: <http://purl.org/dc/terms/> .'
@@ -18,6 +17,7 @@ item = Item(
 )
 dcterms = Namespace('http://purl.org/dc/terms/')
 umdtype = Namespace('http://vocab.lib.umd.edu/datatype#')
+ore = Namespace('http://www.openarchives.org/ore/terms/')
 
 
 def test_identifier_distinct_from_accession_number():
@@ -45,3 +45,91 @@ def test_get_new_member_pool_report():
 
     attachment_title = get_new_member_title(pool_report, 'foo', 2)
     assert str(attachment_title) == 'Attachment 1'
+
+
+def test_item_without_presentation_set_is_valid():
+    item = Item()
+    # Required fields
+    item.identifier = 'test_item'
+    item.object_type = 'http://purl.org/dc/dcmitype/Text'
+    item.rights = 'http://vocab.lib.umd.edu/rightsStatement#InC-EDU'
+    item.title = 'Test Item'
+    assert item.is_valid
+
+
+def test_item_with_single_presentation_set():
+    item = create_item_with_presentation_set(
+        base_uri, ['foo']
+    )
+
+    assert len(item.presentation_set) == 1
+    assert item.presentation_set.value == URIRef('http://vocab.lib.umd.edu/set#foo')
+
+
+def test_item_validation_with_valid_presentation_set():
+    item = create_item_with_presentation_set(
+        base_uri, ['test']
+    )
+    assert item.presentation_set.is_valid
+
+
+def test_item_validation_with_invalid_presentation_set():
+    item = create_item_with_presentation_set(
+        base_uri, ['not_valid']
+    )
+    assert not item.presentation_set.is_valid
+
+
+def test_item_with_multiple_presentation_sets():
+    item = create_item_with_presentation_set(
+        base_uri, ['foo', 'bar']
+    )
+
+    assert len(item.presentation_set) == 2
+
+    expected = sorted([URIRef('http://vocab.lib.umd.edu/set#bar'), URIRef('http://vocab.lib.umd.edu/set#foo')])
+    assert sorted(list(item.presentation_set.values)) == expected
+
+
+def test_single_presentation_set_can_be_set_on_item():
+    item = Item(uri=URIRef('http://example.com/123'), presentation_set=URIRef('http://vocab.lib.umd.edu/set#foobar'))
+
+    expected = (URIRef('http://example.com/123'), ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar'))
+    assert expected in item.graph
+
+
+def test_multiple_presentation_sets_can_be_set_on_item():
+    base_uri = URIRef('http://example.com/123')
+
+    graph = Graph()
+    graph.add((base_uri, ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar')))
+    graph.add((base_uri, ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#barbaz')))
+
+    item = Item(uri=base_uri, presentation_set=graph.objects())
+
+    expected = [
+        (URIRef('http://example.com/123'), ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar')),
+        (URIRef('http://example.com/123'), ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#barbaz'))
+    ]
+
+    for e in expected:
+        assert e in item.graph
+
+
+# Helper Functions
+
+def create_presentation_set_turtle_format(set_names):
+    preamble = '@prefix ore: <http://www.openarchives.org/ore/terms/> .'
+    preamble = preamble + '@prefix umdset: <http://vocab.lib.umd.edu/set#> .'
+    presentation_set = preamble
+    for set_name in set_names:
+        presentation_set += f'<> ore:isAggregatedBy umdset:{set_name} .'
+    return presentation_set
+
+
+def create_item_with_presentation_set(item_uri, set_names):
+    presentation_set = create_presentation_set_turtle_format(set_names)
+    return Item(
+        graph=Graph().parse(data=presentation_set, format='turtle', publicID=base_uri),
+        uri=item_uri
+    )

--- a/plastron-models/tests/test_umd_model.py
+++ b/plastron-models/tests/test_umd_model.py
@@ -1,7 +1,7 @@
 from plastron.models.umd import Item
-from plastron.namespaces import umdform
+from plastron.namespaces import dcterms, umdform, umdtype, ore
 from plastron.repo.pcdm import get_new_member_title
-from rdflib import Graph, Literal, Namespace, URIRef
+from rdflib import Graph, Literal, URIRef
 
 rdf = (
     '@prefix dcterms: <http://purl.org/dc/terms/> .'
@@ -15,9 +15,6 @@ item = Item(
     graph=Graph().parse(data=rdf, format='turtle', publicID=base_uri),
     uri=base_uri
 )
-dcterms = Namespace('http://purl.org/dc/terms/')
-umdtype = Namespace('http://vocab.lib.umd.edu/datatype#')
-ore = Namespace('http://www.openarchives.org/ore/terms/')
 
 
 def test_identifier_distinct_from_accession_number():

--- a/plastron-models/tests/test_umd_model.py
+++ b/plastron-models/tests/test_umd_model.py
@@ -44,89 +44,12 @@ def test_get_new_member_pool_report():
     assert str(attachment_title) == 'Attachment 1'
 
 
-def test_item_without_presentation_set_is_valid():
+def test_item_valid_with_only_required_fields():
     item = Item()
-    # Required fields
+
+    # Only provide required fields
     item.identifier = 'test_item'
     item.object_type = 'http://purl.org/dc/dcmitype/Text'
     item.rights = 'http://vocab.lib.umd.edu/rightsStatement#InC-EDU'
     item.title = 'Test Item'
     assert item.is_valid
-
-
-def test_item_with_single_presentation_set():
-    item = create_item_with_presentation_set(
-        base_uri, ['foo']
-    )
-
-    assert len(item.presentation_set) == 1
-    assert item.presentation_set.value == URIRef('http://vocab.lib.umd.edu/set#foo')
-
-
-def test_item_validation_with_valid_presentation_set():
-    item = create_item_with_presentation_set(
-        base_uri, ['test']
-    )
-    assert item.presentation_set.is_valid
-
-
-def test_item_validation_with_invalid_presentation_set():
-    item = create_item_with_presentation_set(
-        base_uri, ['not_valid']
-    )
-    assert not item.presentation_set.is_valid
-
-
-def test_item_with_multiple_presentation_sets():
-    item = create_item_with_presentation_set(
-        base_uri, ['foo', 'bar']
-    )
-
-    assert len(item.presentation_set) == 2
-
-    expected = sorted([URIRef('http://vocab.lib.umd.edu/set#bar'), URIRef('http://vocab.lib.umd.edu/set#foo')])
-    assert sorted(list(item.presentation_set.values)) == expected
-
-
-def test_single_presentation_set_can_be_set_on_item():
-    item = Item(uri=URIRef('http://example.com/123'), presentation_set=URIRef('http://vocab.lib.umd.edu/set#foobar'))
-
-    expected = (URIRef('http://example.com/123'), ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar'))
-    assert expected in item.graph
-
-
-def test_multiple_presentation_sets_can_be_set_on_item():
-    base_uri = URIRef('http://example.com/123')
-
-    graph = Graph()
-    graph.add((base_uri, ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar')))
-    graph.add((base_uri, ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#barbaz')))
-
-    item = Item(uri=base_uri, presentation_set=graph.objects())
-
-    expected = [
-        (URIRef('http://example.com/123'), ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#foobar')),
-        (URIRef('http://example.com/123'), ore.isAggregatedBy, URIRef('http://vocab.lib.umd.edu/set#barbaz'))
-    ]
-
-    for e in expected:
-        assert e in item.graph
-
-
-# Helper Functions
-
-def create_presentation_set_turtle_format(set_names):
-    preamble = '@prefix ore: <http://www.openarchives.org/ore/terms/> .'
-    preamble = preamble + '@prefix umdset: <http://vocab.lib.umd.edu/set#> .'
-    presentation_set = preamble
-    for set_name in set_names:
-        presentation_set += f'<> ore:isAggregatedBy umdset:{set_name} .'
-    return presentation_set
-
-
-def create_item_with_presentation_set(item_uri, set_names):
-    presentation_set = create_presentation_set_turtle_format(set_names)
-    return Item(
-        graph=Graph().parse(data=presentation_set, format='turtle', publicID=base_uri),
-        uri=item_uri
-    )


### PR DESCRIPTION
Added repeatable "presentation_set" field to the "Item" model, that uses the "ore.isAggregatedBy" predicate
(<http://www.openarchives.org/ore/1.0/vocabulary#ore-is-aggregated-by>)

Added tests.

In order to the tests to run, added a "set" vocabulary (http://vocab.lib.umd.edu/set#) via Archelon with a "test" term.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1287