### PR TITLE
LIBFCREPO-1304. Fixed failing validation tests for Issue and Poster models.

### DIFF
--- a/plastron-cli/README.md
+++ b/plastron-cli/README.md
@@ -432,7 +432,7 @@ import logging
 from argparse import Namespace
 
 from plastron.cli.commands import BaseCommand
-from plastron.models.umd import PCDMFile
+from plastron.models.pcdm import PCDMFile
 from plastron.namespaces import ldp
 
 logger = logging.getLogger(__name__)
@@ -468,7 +468,8 @@ class Command(BaseCommand):
                 print(uri)
                 continue
 
-            for child_resource in resource.walk(min_depth=1, max_depth=1, traverse=[ldp.contains]):
+            for child_resource in resource.walk(min_depth=1, max_depth=1,
+                                                traverse=[ldp.contains]):
                 if self.long:
                     description = child_resource.describe(PCDMFile)
                     title = str(description.title)

--- a/plastron-cli/src/plastron/cli/commands/delete.py
+++ b/plastron-cli/src/plastron/cli/commands/delete.py
@@ -6,7 +6,7 @@ from plastron.cli import get_uris
 from plastron.repo.utils import context
 from plastron.cli.commands import BaseCommand
 from plastron.client import ClientError
-from plastron.models.umd import PCDMObject
+from plastron.models.pcdm import PCDMObject
 from plastron.rdf import parse_predicate_list
 from plastron.repo import RepositoryError
 from plastron.utils import ItemLog

--- a/plastron-cli/src/plastron/cli/commands/imgsize.py
+++ b/plastron-cli/src/plastron/cli/commands/imgsize.py
@@ -4,7 +4,7 @@ from argparse import Namespace
 from PIL import Image
 
 from plastron.cli.commands import BaseCommand
-from plastron.models.umd import PCDMImageFile
+from plastron.models.pcdm import PCDMImageFile
 from plastron.repo import BinaryResource
 from plastron.repo.utils import context
 

--- a/plastron-cli/src/plastron/cli/commands/list.py
+++ b/plastron-cli/src/plastron/cli/commands/list.py
@@ -2,7 +2,7 @@ import logging
 from argparse import Namespace
 
 from plastron.cli.commands import BaseCommand
-from plastron.models.umd import PCDMFile
+from plastron.models.pcdm import PCDMFile
 from plastron.namespaces import ldp
 
 logger = logging.getLogger(__name__)

--- a/plastron-models/src/plastron/models/ldp.py
+++ b/plastron-models/src/plastron/models/ldp.py
@@ -1,0 +1,7 @@
+from plastron.namespaces import ldp
+from plastron.rdfmapping.descriptors import ObjectProperty
+from plastron.rdfmapping.resources import RDFResource
+
+
+class LDPContainer(RDFResource):
+    contains = ObjectProperty(ldp.contains, repeatable=True)

--- a/plastron-models/src/plastron/models/newspaper.py
+++ b/plastron-models/src/plastron/models/newspaper.py
@@ -1,7 +1,7 @@
 from lxml.etree import parse, XMLSyntaxError
 
 from plastron.models.annotations import TextblockOnPage
-from plastron.models.umd import PCDMObject, PCDMFile
+from plastron.models.pcdm import PCDMObject, PCDMFile
 from plastron.namespaces import bibo, carriers, dc, dcterms, fabio, ndnp, ore, pcdmuse, umdtype, pcdm, umd
 from plastron.rdf.ocr import ALTOResource
 from plastron.rdfmapping.decorators import rdf_type

--- a/plastron-models/src/plastron/models/ore.py
+++ b/plastron-models/src/plastron/models/ore.py
@@ -1,0 +1,18 @@
+from plastron.namespaces import ore, dcterms, iana
+from plastron.rdfmapping.decorators import rdf_type
+from plastron.rdfmapping.descriptors import DataProperty, ObjectProperty
+from plastron.rdfmapping.resources import RDFResource, RDFResourceBase
+
+
+@rdf_type(ore.Proxy)
+class Proxy(RDFResource):
+    title = DataProperty(dcterms.title)
+    prev = ObjectProperty(iana.prev, cls='Proxy')
+    next = ObjectProperty(iana.next, cls='Proxy')
+    proxy_for = ObjectProperty(ore.proxyFor, cls=RDFResourceBase)
+    proxy_in = ObjectProperty(ore.proxyIn, cls=RDFResourceBase)
+
+
+class AggregationMixin(RDFResourceBase):
+    first = ObjectProperty(iana.first, cls=Proxy)
+    last = ObjectProperty(iana.last, cls=Proxy)

--- a/plastron-models/src/plastron/models/pcdm.py
+++ b/plastron-models/src/plastron/models/pcdm.py
@@ -1,0 +1,30 @@
+from plastron.models.ore import AggregationMixin
+from plastron.namespaces import pcdm, dcterms, ebucore, premis, xsd
+from plastron.rdfmapping.decorators import rdf_type
+from plastron.rdfmapping.descriptors import DataProperty, ObjectProperty
+from plastron.rdfmapping.resources import RDFResource
+
+
+@rdf_type(pcdm.Object)
+class PCDMObject(RDFResource, AggregationMixin):
+    title = DataProperty(dcterms.title)
+    has_member = ObjectProperty(pcdm.hasMember, repeatable=True, cls='PCDMObject')
+    member_of = ObjectProperty(pcdm.memberOf, repeatable=True, cls='PCDMObject')
+    has_file = ObjectProperty(pcdm.hasFile, repeatable=True, cls='PCDMFile')
+
+
+@rdf_type(pcdm.File)
+class PCDMFile(RDFResource):
+    title = DataProperty(dcterms.title)
+    file_of = ObjectProperty(pcdm.fileOf, repeatable=True, cls=PCDMObject)
+    mime_type = DataProperty(ebucore.hasMimeType)
+    filename = DataProperty(ebucore.filename)
+    size = DataProperty(premis.hasSize, datatype=xsd.long)
+
+    def __str__(self):
+        return str(self.title or self.uri)
+
+
+class PCDMImageFile(PCDMFile):
+    height = DataProperty(ebucore.height)
+    width = DataProperty(ebucore.width)

--- a/plastron-models/src/plastron/models/poster.py
+++ b/plastron-models/src/plastron/models/poster.py
@@ -1,6 +1,6 @@
 from rdflib import URIRef
 
-from plastron.models.umd import PCDMObject
+from plastron.models.pcdm import PCDMObject
 from plastron.namespaces import dcterms, dc, edm, bibo, geo, ore, umd, umdtype
 from plastron.rdfmapping.decorators import rdf_type
 from plastron.rdfmapping.descriptors import ObjectProperty, DataProperty, Property

--- a/plastron-models/src/plastron/models/umd.py
+++ b/plastron-models/src/plastron/models/umd.py
@@ -1,9 +1,9 @@
 from plastron.handles import HandleBearingResource
-from plastron.namespaces import dc, dcterms, edm, rdfs, owl, ldp, fabio, pcdm, iana, ore, ebucore, premis, xsd, \
-    umdtype, umd
+from plastron.models.pcdm import PCDMObject
+from plastron.namespaces import dc, dcterms, edm, rdfs, owl, fabio, pcdm, ore, umdtype, umd
 from plastron.rdfmapping.decorators import rdf_type
 from plastron.rdfmapping.descriptors import ObjectProperty, DataProperty
-from plastron.rdfmapping.resources import RDFResource, RDFResourceBase
+from plastron.rdfmapping.resources import RDFResource
 from plastron.validation.rules import is_edtf_formatted, is_valid_iso639_code, is_from_vocabulary
 
 
@@ -17,40 +17,6 @@ class Stub(RDFResource):
 class LabeledThing(RDFResource):
     label = DataProperty(rdfs.label, required=True)
     same_as = ObjectProperty(owl.sameAs)
-
-
-class LDPContainer(RDFResource):
-    contains = ObjectProperty(ldp.contains, repeatable=True)
-
-
-class AggregationMixin(RDFResourceBase):
-    first = ObjectProperty(iana.first, cls='Proxy')
-    last = ObjectProperty(iana.last, cls='Proxy')
-
-
-@rdf_type(pcdm.Object)
-class PCDMObject(RDFResource, AggregationMixin):
-    title = DataProperty(dcterms.title)
-    has_member = ObjectProperty(pcdm.hasMember, repeatable=True, cls='PCDMObject')
-    member_of = ObjectProperty(pcdm.memberOf, repeatable=True, cls='PCDMObject')
-    has_file = ObjectProperty(pcdm.hasFile, repeatable=True, cls='PCDMFile')
-
-
-@rdf_type(pcdm.File)
-class PCDMFile(RDFResource):
-    title = DataProperty(dcterms.title)
-    file_of = ObjectProperty(pcdm.fileOf, repeatable=True, cls=PCDMObject)
-    mime_type = DataProperty(ebucore.hasMimeType)
-    filename = DataProperty(ebucore.filename)
-    size = DataProperty(premis.hasSize, datatype=xsd.long)
-
-    def __str__(self):
-        return str(self.title or self.uri)
-
-
-class PCDMImageFile(PCDMFile):
-    height = DataProperty(ebucore.height)
-    width = DataProperty(ebucore.width)
 
 
 @rdf_type(umd.Item)
@@ -141,12 +107,3 @@ class Page(PCDMObject):
 
     def __str__(self):
         return str(self.title or self.uri)
-
-
-@rdf_type(ore.Proxy)
-class Proxy(RDFResource):
-    title = DataProperty(dcterms.title)
-    prev = ObjectProperty(iana.prev, cls='Proxy')
-    next = ObjectProperty(iana.next, cls='Proxy')
-    proxy_for = ObjectProperty(ore.proxyFor, cls=RDFResourceBase)
-    proxy_in = ObjectProperty(ore.proxyIn, cls=RDFResourceBase)

--- a/plastron-models/src/plastron/serializers/csv.py
+++ b/plastron-models/src/plastron/serializers/csv.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 from rdflib import URIRef, Literal
 from urlobject import URLObject
 
-from plastron.models.umd import PCDMFile
+from plastron.models.pcdm import PCDMFile
 from plastron.namespaces import fedora
 from plastron.rdfmapping.descriptors import ObjectProperty
 from plastron.rdfmapping.embed import EmbeddedObject

--- a/plastron-models/tests/test_issue_model.py
+++ b/plastron-models/tests/test_issue_model.py
@@ -1,13 +1,13 @@
 from plastron.models.newspaper import Issue
-from plastron.namespaces import ore
-from rdflib import Graph, URIRef
-
-import pytest
 
 base_uri = 'http://example.com/xyz'
 
 
-@pytest.mark.skip('Test cannot be run because Issue validation does not currently work')
+def test_issue_invalid_with_no_fields():
+    issue = Issue()
+    assert not issue.is_valid
+
+
 def test_issue_valid_with_only_required_fields():
     issue = Issue()
 

--- a/plastron-models/tests/test_letter_model.py
+++ b/plastron-models/tests/test_letter_model.py
@@ -1,8 +1,11 @@
 from plastron.models.letter import Letter
-from plastron.namespaces import ore
-from rdflib import Graph, URIRef
 
 base_uri = 'http://example.com/xyz'
+
+
+def test_letter_invalid_with_no_fields():
+    letter = Letter()
+    assert not letter.is_valid
 
 
 def test_letter_valid_with_only_required_fields():
@@ -20,4 +23,5 @@ def test_letter_valid_with_only_required_fields():
     letter.rights_holder = 'Test Rights Holder'
     letter.type = 'http://purl.org/dc/dcmitype/Text'
     letter.extent = '1 page'
+
     assert letter.is_valid

--- a/plastron-models/tests/test_poster_model.py
+++ b/plastron-models/tests/test_poster_model.py
@@ -1,13 +1,15 @@
-from plastron.models.poster import Poster
-from plastron.namespaces import ore
-from rdflib import Graph, Literal, URIRef
+from rdflib import Literal
 
-import pytest
+from plastron.models.poster import Poster
 
 base_uri = 'http://example.com/xyz'
 
 
-@pytest.mark.skip('Test cannot be run because Poster validation does not currently work')
+def test_poster_invalid_with_no_fields():
+    poster = Poster()
+    assert not poster.is_valid
+
+
 def test_poster_valid_with_only_required_fields():
     poster = Poster()
 

--- a/plastron-rdf/src/plastron/rdfmapping/descriptors.py
+++ b/plastron-rdf/src/plastron/rdfmapping/descriptors.py
@@ -7,6 +7,8 @@ from rdflib import URIRef, Literal
 from plastron.rdfmapping.embed import EmbeddedObject
 from plastron.rdfmapping.properties import RDFDataProperty, RDFObjectProperty, RDFProperty
 
+OBJECT_CLASSES = {}
+
 
 class Property:
     def __init__(
@@ -65,8 +67,7 @@ class ObjectProperty(Property):
         if instance is None:
             return self
         if isinstance(self.object_class, str):
-            module = import_module(instance.__module__)
-            self.object_class = getattr(module, self.object_class)
+            self.object_class = OBJECT_CLASSES[self.object_class]
         return RDFObjectProperty(
             **self._get_property_kwargs(instance),
             object_class=self.object_class,

--- a/plastron-rdf/src/plastron/rdfmapping/resources.py
+++ b/plastron-rdf/src/plastron/rdfmapping/resources.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 from rdflib import Graph, URIRef
 
-from plastron.rdfmapping.descriptors import ObjectProperty, Property, DataProperty
+from plastron.rdfmapping.descriptors import ObjectProperty, Property, DataProperty, OBJECT_CLASSES
 from plastron.rdfmapping.graph import TrackChangesGraph, copy_triples
 from plastron.rdfmapping.properties import RDFProperty
 from plastron.rdfmapping.validation import ValidationResultsDict
@@ -48,6 +48,8 @@ class RDFResourceBase:
             # run after the __init_subclass__ method
             cls.default_values.update(deepcopy(base_class.default_values))
             cls.validators.extend(deepcopy(base_class.validators))
+        # build the lookup table of class name to class
+        OBJECT_CLASSES[cls.__name__] = cls
 
     def __init__(self, uri: Union[URIRef, str] = None, graph: Graph = None, **kwargs):
         if uri is not None:

--- a/plastron-repo/src/plastron/jobs/exportjob.py
+++ b/plastron-repo/src/plastron/jobs/exportjob.py
@@ -21,7 +21,7 @@ from plastron.client import ClientError
 from plastron.files import get_ssh_client
 from plastron.jobs import Job
 from plastron.models import Item
-from plastron.models.umd import PCDMFile
+from plastron.models.pcdm import PCDMFile
 from plastron.repo import DataReadError, Repository, BinaryResource
 from plastron.repo.pcdm import PCDMObjectResource, AggregationResource, PCDMFileBearingResource
 from plastron.serializers import SERIALIZER_CLASSES, detect_resource_class

--- a/plastron-repo/src/plastron/repo/pcdm.py
+++ b/plastron-repo/src/plastron/repo/pcdm.py
@@ -9,7 +9,10 @@ from plastron.client import random_slug
 from plastron.files import BinarySource, FileGroup
 from plastron.models import Item
 from plastron.models.annotations import Annotation
-from plastron.models.umd import PCDMObject, PCDMFile, Page, Proxy, LDPContainer
+from plastron.models.ore import Proxy
+from plastron.models.umd import Page
+from plastron.models.ldp import LDPContainer
+from plastron.models.pcdm import PCDMObject, PCDMFile
 from plastron.namespaces import umdform
 from plastron.rdfmapping.resources import RDFResourceBase
 from plastron.repo import ContainerResource, Repository, BinaryResource


### PR DESCRIPTION
Build a lookup table of object class names: In the `__init_subclass__()` method for RDFResourceBase, record the short name of the class being defined and a pointer to the class object in a dictionary. Then use this dictionary to look up object_class values that are given as strings.

Re-enabled skipped model tests, and added test for empty objects too.

Moved classes out of plastron.models.umd into new plastron.models modules:

* Proxy, AggregationMixin --> plastron.models.ore
* LDPContainer --> plastron.models.ldp
* PCDMObject, PCDMFile --> plastron.models.pcdm

https://umd-dit.atlassian.net/browse/LIBFCREPO-1304