### PR TITLE
LIBFCREPO-1313. Fix handle creation and updating when publishing.

### DIFF
--- a/plastron-cli/tests/commands/test_publish.py
+++ b/plastron-cli/tests/commands/test_publish.py
@@ -1,18 +1,19 @@
+import dataclasses
 from argparse import Namespace
+from typing import Optional
 from unittest.mock import MagicMock
+from uuid import uuid4
 
 import pytest
-from rdflib import Literal
 
 from plastron.cli.commands.publish import Command, publish
-from plastron.context import PlastronContext
 from plastron.client import Endpoint, Client, TypedText
-from plastron.handles import Handle, HandleServiceClient
+from plastron.context import PlastronContext
+from plastron.handles import Handle
 from plastron.models.umd import Item
-from plastron.namespaces import umdaccess, umdtype
-from plastron.rdfmapping.resources import RDFResource
+from plastron.namespaces import umdaccess
 from plastron.repo import Repository, RepositoryError
-from plastron.repo.publish import get_publication_status, PublishableResource
+from plastron.repo.publish import PublishableResource
 
 
 @pytest.fixture
@@ -20,46 +21,83 @@ def handle():
     return Handle(
         prefix='1903.1',
         suffix='123',
-        url='http://fcrepo-local:8080/fcrepo/rest/foo',
+        url='http://digital-local/foo',
     )
 
 
-def get_mock_context(obj, handle, existing_handle=None):
+class MockHandleClient:
+    GET_HANDLE_LOOKUP = {
+        # existing handle with fcrepo target URL
+        '1903.1/123': Handle(
+            prefix='1903.1',
+            suffix='123',
+            url='http://digital-local/foo',
+        ),
+        # existing handle with fedora2 target URL
+        # if publishing the resource with this handle,
+        # should call the handle server to update the
+        # target URL
+        '1903.1/456': Handle(
+            prefix='1903.1',
+            suffix='456',
+            url='http://fedora2-local/bar',
+        ),
+        # there is no handle with this prefix/suffix pair
+        '1903.1/789': None,
+    }
+    FIND_HANDLE_LOOKUP = {
+        # this fcrepo resource has a handle and its target
+        # URL points to the correct public URL
+        'http://fcrepo-local:8080/fcrepo/rest/foo': Handle(
+            prefix='1903.1',
+            suffix='123',
+            url='http://digital-local/foo',
+        ),
+        # this fcrepo resource has a handle and its target
+        # URL needs to be updated to the correct public URL
+        'http://fcrepo-local:8080/fcrepo/rest/bar': Handle(
+            prefix='1903.1',
+            suffix='456',
+            url='http://fedora2-local/bar',
+        ),
+    }
+
+    def get_handle(self, handle: str, _repo: str = None) -> Optional[Handle]:
+        return self.GET_HANDLE_LOOKUP.get(handle, None)
+
+    def find_handle(self, repo_uri: str, _repo: str = None) -> Optional[Handle]:
+        return self.FIND_HANDLE_LOOKUP.get(repo_uri, None)
+
+    @staticmethod
+    def create_handle(repo_uri: str, url: str, prefix: str = None, _repo: str = None) -> Optional[Handle]:
+        if repo_uri.endswith('NO_HANDLE'):
+            return None
+        return Handle(prefix=prefix, suffix=str(uuid4()), url=url)
+
+    @staticmethod
+    def update_handle(handle: Handle, **fields) -> Handle:
+        return dataclasses.replace(handle, **fields)
+
+
+def get_mock_context(obj, path):
     endpoint = Endpoint('http://fcrepo-local:8080/fcrepo/rest')
     mock_client = MagicMock(spec=Client, endpoint=endpoint)
     mock_client.get_description.return_value = TypedText('application/n-triples', '')
     mock_repo = MagicMock(spec=Repository, client=mock_client, endpoint=endpoint)
-    resource = PublishableResource(repo=mock_repo, path='/foo')
+    resource = PublishableResource(repo=mock_repo, path=path)
     resource.describe = lambda _: obj
     mock_repo.__getitem__.return_value = resource
-    mock_handle_client = MagicMock(spec=HandleServiceClient)
-    mock_handle_client.get_handle.return_value = existing_handle
-    mock_handle_client.create_handle.return_value = handle
-    mock_handle_client.update_handle.return_value = handle
     return MagicMock(
         spec=PlastronContext,
         repo=mock_repo,
-        handle_client=mock_handle_client,
+        handle_client=MockHandleClient(),
         get_public_url=lambda uri: uri.replace('fcrepo-local:8080/fcrepo/rest', 'digital-local')
     )
 
 
-@pytest.mark.parametrize(
-    ('obj', 'expected_status'),
-    [
-        (RDFResource(), 'Unpublished'),
-        (RDFResource(rdf_type=umdaccess.Hidden), 'UnpublishedHidden'),
-        (RDFResource(rdf_type=umdaccess.Published), 'Published'),
-        (RDFResource(rdf_type=[umdaccess.Published, umdaccess.Hidden]), 'PublishedHidden'),
-    ],
-)
-def test_get_publication_status(obj, expected_status):
-    assert get_publication_status(obj) == expected_status
-
-
 def test_publish(handle):
     obj = Item()
-    publish(Namespace(obj=get_mock_context(obj, handle)), uris=['http://fcrepo-local:8080/fcrepo/rest/foo'])
+    publish(Namespace(obj=get_mock_context(obj, '/foo')), uris=['http://fcrepo-local:8080/fcrepo/rest/foo'])
 
     assert umdaccess.Published in obj.rdf_type.values
     assert umdaccess.Hidden not in obj.rdf_type.values
@@ -68,7 +106,7 @@ def test_publish(handle):
 def test_publish_hidden(handle):
     obj = Item()
     publish(
-        Namespace(obj=get_mock_context(obj, handle)),
+        Namespace(obj=get_mock_context(obj, '/foo')),
         force_hidden=True,
         uris=['http://fcrepo-local:8080/fcrepo/rest/foo'],
     )
@@ -80,7 +118,7 @@ def test_publish_hidden(handle):
 def test_publish_force_visible(handle):
     obj = Item(rdf_type=umdaccess.Hidden)
     publish(
-        Namespace(obj=get_mock_context(obj, handle)),
+        Namespace(obj=get_mock_context(obj, '/foo')),
         force_visible=True,
         uris=['http://fcrepo-local:8080/fcrepo/rest/foo'],
     )
@@ -100,41 +138,9 @@ def test_publish_repo_error(caplog):
     assert 'Unable to retrieve http://fcrepo-local:8080/fcrepo/rest/foo: something bad' in caplog.messages
 
 
-def test_publish_handle_service_error(caplog):
-    obj = Item()
-
-    publish(
-        Namespace(obj=get_mock_context(obj, handle=None)),
-        uris=['http://fcrepo-local:8080/fcrepo/rest/foo'],
-    )
-    assert 'Unable to find or create handle for http://fcrepo-local:8080/fcrepo/rest/foo' in caplog.messages
-
-
-def test_publish_new_handle_update_handle_in_repo(handle):
-    obj = Item(handle=Literal('hdl:1903.1/987'))
-    publish(Namespace(obj=get_mock_context(obj, handle)), uris=['http://fcrepo-local:8080/fcrepo/rest/foo'])
-
-    assert umdaccess.Published in obj.rdf_type.values
-    assert umdaccess.Hidden not in obj.rdf_type.values
-    assert obj.handle.value == Literal('hdl:1903.1/123', datatype=umdtype.handle)
-
-
-def test_publish_existing_handle_update_handle_in_repo(handle):
-    obj = Item(handle=Literal('hdl:1903.1/987'))
-
-    publish(
-        Namespace(obj=get_mock_context(obj, handle, existing_handle=handle)),
-        uris=['http://fcrepo-local:8080/fcrepo/rest/foo'],
-    )
-
-    assert umdaccess.Published in obj.rdf_type.values
-    assert umdaccess.Hidden not in obj.rdf_type.values
-    assert obj.handle.value == Literal('hdl:1903.1/123', datatype=umdtype.handle)
-
-
 def test_publish_command_class(handle):
     obj = Item()
-    cmd = Command(get_mock_context(obj, handle))
+    cmd = Command(get_mock_context(obj, '/foo'))
     cmd(Namespace(uris=['http://fcrepo-local:8080/fcrepo/rest/foo'], hidden=False, visible=False))
 
     assert umdaccess.Published in obj.rdf_type.values

--- a/plastron-models/tests/test_handles.py
+++ b/plastron-models/tests/test_handles.py
@@ -47,17 +47,7 @@ def test_get_handle_error(handle_client):
         status=HTTPStatus.BAD_REQUEST,
     )
     with pytest.raises(HandleServerError):
-        handle_client.get_handle('http://example.com/foobar')
-
-
-@httpretty.activate
-def test_get_handle_not_found(handle_client):
-    httpretty.register_uri(
-        httpretty.GET,
-        uri='http://handle-local:3000/handles/exists',
-        status=HTTPStatus.NOT_FOUND,
-    )
-    assert handle_client.get_handle('http://example.com/foobar') is None
+        handle_client.find_handle('http://example.com/foobar')
 
 
 @httpretty.activate
@@ -67,7 +57,7 @@ def test_get_handle_does_not_exist(handle_client):
         uri='http://handle-local:3000/handles/exists',
         body=json.dumps({'exists': False})
     )
-    assert handle_client.get_handle('http://example.com/foobar') is None
+    assert handle_client.find_handle('http://example.com/foobar') is None
 
 
 @httpretty.activate
@@ -77,7 +67,7 @@ def test_get_handle_exists(handle_client):
         uri='http://handle-local:3000/handles/exists',
         body=json.dumps({'exists': True, 'prefix': '1903.1', 'suffix': '123', 'url': 'http://example.com/foobar'})
     )
-    handle = handle_client.get_handle('http://example.com/foobar')
+    handle = handle_client.find_handle('http://example.com/foobar')
     assert handle.prefix == '1903.1'
     assert handle.suffix == '123'
     assert handle.url == 'http://example.com/foobar'

--- a/plastron-repo/docs/handles.puml
+++ b/plastron-repo/docs/handles.puml
@@ -1,0 +1,30 @@
+@startuml
+start
+if (Handle in metadata?) then (yes)
+    :Look up handle on server
+    by metadata handle value;
+    if (Server handle exists?) then (yes)
+        :Compare server handle target URL
+        with fcrepo object public URL;
+        if (URLs match?) then (yes)
+        else (no)
+            :Set server handle target URL
+            to fcrepo object public URL;
+        endif
+    else (no)
+        :Halt publication;
+        :Send error message;
+        end
+    endif
+else (no)
+    :Look up handle on server
+    by fcrepo object URL;
+    if (Server handle exists?) then (yes)
+    else (no)
+        :Mint new handle;
+    endif
+    :Set metadata handle
+    to server handle;
+endif
+stop
+@enduml

--- a/plastron-repo/src/plastron/jobs/importjob/__init__.py
+++ b/plastron-repo/src/plastron/jobs/importjob/__init__.py
@@ -13,7 +13,9 @@ from bs4 import BeautifulSoup
 from rdflib import URIRef
 
 from plastron.client import ClientError
+from plastron.context import PlastronContext
 from plastron.files import BinarySource, ZipFileSource, RemoteFileSource, HTTPFileSource, LocalFileSource
+from plastron.handles import Handle
 from plastron.jobs import JobError, JobConfig, Job
 from plastron.jobs.importjob.spreadsheet import LineReference, MetadataSpreadsheet, InvalidRow, Row
 from plastron.models import get_model_class, ModelClassNotFoundError
@@ -21,8 +23,9 @@ from plastron.models.annotations import FullTextAnnotation, TextualBody
 from plastron.namespaces import umdaccess, sc
 from plastron.rdf.pcdm import File, PreservationMasterFile
 from plastron.rdfmapping.validation import ValidationResultsDict, ValidationResult, ValidationSuccess, ValidationFailure
-from plastron.repo import Repository, RepositoryError, ContainerResource
+from plastron.repo import RepositoryError, ContainerResource
 from plastron.repo.pcdm import PCDMObjectResource
+from plastron.repo.publish import PublishableResource
 from plastron.utils import datetimestamp, ItemLog
 from plastron.validation import ValidationError
 
@@ -104,7 +107,7 @@ class ImportRun:
 
     def run(
             self,
-            repo: Repository,
+            context: PlastronContext,
             limit: int = None,
             percentage: int = None,
             validate_only: bool = False,
@@ -181,7 +184,7 @@ class ImportRun:
                 continue
 
             logger.debug(f'Row data: {row.data}')
-            import_row = ImportRow(self.job, repo, row, validate_only, publish)
+            import_row = ImportRow(self.job, context, row, validate_only, publish)
 
             # count the number of files referenced in this row
             count['files'] += len(row.filenames)
@@ -342,7 +345,7 @@ class ImportJob(Job):
 
     def run(
             self,
-            repo: Repository,
+            context: PlastronContext,
             limit: int = None,
             percentage: int = None,
             validate_only: bool = False,
@@ -351,7 +354,7 @@ class ImportJob(Job):
     ) -> Generator[Dict[str, Any], None, Dict[str, Any]]:
         run = self.new_run()
         return run(
-            repo=repo,
+            context=context,
             limit=limit,
             percentage=percentage,
             validate_only=validate_only,
@@ -379,9 +382,6 @@ class ImportJob(Job):
             return self.config.extract_text_types.split(',')
         else:
             return []
-
-    def get_import_row(self, repo: Repository, row: Row):
-        return ImportRow(self, repo, row)
 
     def get_source(self, base_location: str, path: str) -> BinarySource:
         """
@@ -442,14 +442,27 @@ class ImportJob(Job):
         return file_class.from_source(title=basename(filename), source=source)
 
 
+class PublishableObjectResource(PCDMObjectResource, PublishableResource):
+    pass
+
+
 class ImportRow:
-    def __init__(self, job: ImportJob, repo: Repository, row: Row, validate_only: bool = False, publish: bool = False):
+    def __init__(
+            self,
+            job: ImportJob,
+            context: PlastronContext,
+            row: Row,
+            validate_only: bool = False,
+            publish: bool = None,
+    ):
         self.job = job
         self.row = row
-        self.repo = repo
-        self.item = row.get_object(repo, read_from_repo=not validate_only)
-        if publish:
-            self.item.rdf_type.add(umdaccess.Published)
+        self.context = context
+        self.item = row.get_object(context.repo, read_from_repo=not validate_only)
+        if publish is not None:
+            self._publish = publish
+        else:
+            self._publish = row.publish
 
     def __str__(self):
         return str(self.row.line_reference)
@@ -501,9 +514,12 @@ class ImportRow:
             # construct the SPARQL Update query if there are any deletions or insertions
             # then do a PATCH update of an existing item
             try:
-                resource = self.repo[self.item.uri:PCDMObjectResource].read()
+                resource: PublishableObjectResource = self.context.repo[self.item.uri:PublishableObjectResource].read()
                 resource.attach_description(self.item)
                 resource.update()
+                # publish this resource, if requested
+                if self._publish:
+                    self.publish(resource)
             except RepositoryError as e:
                 raise JobError(f'Updating item failed: {e}') from e
 
@@ -514,7 +530,13 @@ class ImportRow:
             logger.info(f'No changes found for "{self.item}" ({self.item.uri}); skipping')
             return ImportedItemStatus.UNCHANGED
 
-    def create_resource(self) -> PCDMObjectResource:
+    def publish(self, resource: PublishableObjectResource) -> Handle:
+        return resource.publish(
+            handle_client=self.context.handle_client,
+            public_url=self.context.get_public_url(resource.url),
+        )
+
+    def create_resource(self) -> PublishableObjectResource:
         """Create a new item in the repository."""
 
         # if an item is new, don't construct a SPARQL Update query
@@ -539,15 +561,15 @@ class ImportRow:
             annotate_from_files(self.item, self.job.extract_text_types)
 
         logger.debug(f"Creating resources in container: {self.job.config.container}")
-        logger.debug(f'Repo: {self.repo}')
-        container: ContainerResource = self.repo[self.job.config.container:ContainerResource]
+        logger.debug(f'Repo: {self.context.repo}')
+        container: ContainerResource = self.context.repo[self.job.config.container:ContainerResource]
 
         try:
-            with self.repo.transaction():
+            with self.context.repo.transaction():
                 # create the main resource
                 logger.debug(f'Creating main resource for "{self.item}"')
                 resource = container.create_child(
-                    resource_class=PCDMObjectResource,
+                    resource_class=PublishableObjectResource,
                     description=self.item,
                 )
                 # add pages and files to those pages
@@ -563,6 +585,10 @@ class ImportRow:
                     for filename in self.row.item_filenames:
                         source = self.job.get_source(self.job.config.binaries_location, filename)
                         resource.create_file(source=source)
+
+                # publish this resource, if requested
+                if self._publish:
+                    self.publish(resource)
 
         except ClientError as e:
             raise JobError(self.job, f'Creating item failed: {e}', e.response.text) from e

--- a/plastron-repo/tests/repo/test_publishable_resource.py
+++ b/plastron-repo/tests/repo/test_publishable_resource.py
@@ -1,0 +1,163 @@
+import dataclasses
+from random import randint
+from typing import Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from plastron.client import Endpoint, Client, TypedText
+from plastron.handles import Handle, HandleServerError
+from plastron.namespaces import umdaccess
+from plastron.rdfmapping.resources import RDFResource
+from plastron.repo import Repository, RepositoryError
+from plastron.repo.publish import PublishableResource, get_publication_status
+
+
+@pytest.mark.parametrize(
+    ('obj', 'expected_status'),
+    [
+        (RDFResource(), 'Unpublished'),
+        (RDFResource(rdf_type=umdaccess.Hidden), 'UnpublishedHidden'),
+        (RDFResource(rdf_type=umdaccess.Published), 'Published'),
+        (RDFResource(rdf_type=[umdaccess.Published, umdaccess.Hidden]), 'PublishedHidden'),
+    ],
+)
+def test_get_publication_status(obj, expected_status):
+    assert get_publication_status(obj) == expected_status
+
+
+# TODO: this should go into a common library
+class MockHandleClient:
+    def __init__(self, get_handle_lookup=None, find_handle_lookup=None):
+        self.get_handle_lookup = get_handle_lookup or {}
+        self.find_handle_lookup = find_handle_lookup or {}
+
+    FIND_HANDLE_LOOKUP = {
+        # this fcrepo resource has a handle and its target
+        # URL points to the correct public URL
+        'http://fcrepo-local:8080/fcrepo/rest/foo': Handle(
+            prefix='1903.1',
+            suffix='123',
+            url='http://digital-local/foo',
+        ),
+        # this fcrepo resource has a handle and its target
+        # URL needs to be updated to the correct public URL
+        'http://fcrepo-local:8080/fcrepo/rest/bar': Handle(
+            prefix='1903.1',
+            suffix='456',
+            url='http://fedora2-local/bar',
+        ),
+    }
+
+    def get_handle(self, handle: str, _repo: str = None) -> Optional[Handle]:
+        return self.get_handle_lookup.get(handle, None)
+
+    def find_handle(self, repo_uri: str, _repo: str = None) -> Optional[Handle]:
+        return self.find_handle_lookup.get(repo_uri, None)
+
+    @staticmethod
+    def create_handle(repo_uri: str, url: str, prefix: str = '1903.1', _repo: str = None) -> Handle:
+        if repo_uri.endswith('NO_HANDLE'):
+            raise HandleServerError()
+        return Handle(prefix=prefix, suffix=str(randint(1000, 10000)), url=url)
+
+    @staticmethod
+    def update_handle(handle: Handle, **fields) -> Handle:
+        return dataclasses.replace(handle, **fields)
+
+
+@pytest.fixture
+def endpoint():
+    return Endpoint('http://fcrepo-local:8080/fcrepo/rest')
+
+
+@pytest.fixture
+def mock_client(endpoint):
+    return mock_client
+
+
+@pytest.fixture
+def mock_repo(endpoint):
+    def _mock_repo(path, handle):
+        mock_client = MagicMock(spec=Client, endpoint=endpoint)
+        if handle is not None:
+            value = (
+                f'<{endpoint.url}{path}> '
+                '<http://purl.org/dc/terms/identifier> '
+                f'"{handle}"^^<http://vocab.lib.umd.edu/datatype#handle> .\n'
+            )
+        else:
+            value = ''
+
+        mock_client.get_description.return_value = TypedText(media_type='application/n-triples', value=value)
+        return MagicMock(spec=Repository, client=mock_client, endpoint=endpoint)
+
+    return _mock_repo
+
+
+@pytest.mark.parametrize(
+    ('fcrepo_path', 'existing_handle', 'expected_suffix', 'expected_url'),
+    [
+        # existing handle with fcrepo target URL
+        (
+            '/foo',
+            Handle(prefix='1903.1', suffix='123', url='http://digital-local/foo'),
+            '123',
+            'http://digital-local/foo',
+        ),
+        # existing handle with fedora2 target URL; if publishing the resource with this handle,
+        # should call the handle server to update the target URL
+        (
+            '/bar',
+            Handle(prefix='1903.1', suffix='456', url='http://fedora2-local/bar'),
+            '456',
+            'http://digital-local/bar',
+        ),
+    ]
+)
+def test_existing_handle(mock_repo, fcrepo_path, existing_handle, expected_suffix, expected_url):
+    mock_client = MockHandleClient(get_handle_lookup={existing_handle.hdl_uri: existing_handle})
+    resource = PublishableResource(
+        repo=mock_repo(path=fcrepo_path, handle=existing_handle.hdl_uri),
+        path=fcrepo_path
+    ).read()
+    handle = resource.publish(mock_client, expected_url)
+    assert handle.suffix == expected_suffix
+    assert handle.url == expected_url
+
+
+def test_missing_handle(mock_repo):
+    # resource metadata has a handle value, but that handle is not found in the handle service
+    # should raise a RepositoryError
+    mock_handle_client = MockHandleClient(get_handle_lookup={'hdl:1903.1/789': None})
+    resource = PublishableResource(
+        repo=mock_repo(path='/abc', handle='hdl:1903.1/789'),
+        path='/abc',
+    ).read()
+    with pytest.raises(RepositoryError) as e:
+        resource.publish(mock_handle_client, 'http://digital-local/abc')
+    assert str(e.value).startswith('Unable to publish')
+
+
+def test_mint_new_handle(mock_repo):
+    # resource metadata has no handle value, so we create one in the handle service
+    mock_handle_client = MockHandleClient()
+    resource = PublishableResource(
+        repo=mock_repo(path='/def', handle=None),
+        path='/def',
+    ).read()
+    handle = resource.publish(mock_handle_client, 'http://digital-local/def')
+    assert handle.url == 'http://digital-local/def'
+    assert 1000 <= int(handle.suffix) <= 10000
+
+
+def test_error_creating_handle(mock_repo):
+    # resource has no handle, and handle client fails to create a handle
+    mock_handle_client = MockHandleClient()
+    resource = PublishableResource(
+        repo=mock_repo(path='/NO_HANDLE', handle=None),
+        path='/NO_HANDLE',
+    ).read()
+    with pytest.raises(RepositoryError) as e:
+        resource.publish(mock_handle_client, 'http://digital-local/abc')
+    assert str(e.value).startswith('Unable to publish')


### PR DESCRIPTION
- renamed get_handle() to find_handle() (to look up by repo URI)
- added a get_handle() method (to look up by prefix and suffix)
- raise an error on a 404 response from the handle service (since the "handle not found" condition is relayed via the "exists" key in the response, and not the status code)
- updated handle assignment logic to look up handles from the metadata in the handle service, and update their target URLs if necessary
- created documentation flowchart for the handle assignment process
- added has_handle property to the HandleBearingResource class
- created plastron-repo tests for publishing

https://umd-dit.atlassian.net/browse/LIBFCREPO-1313