### PR TITLE
LIBFCREPO-1322. Enable metadata-only import job from exported CSV file

### DIFF
--- a/plastron-cli/tests/commands/test_importcommand.py
+++ b/plastron-cli/tests/commands/test_importcommand.py
@@ -132,4 +132,3 @@ def create_args(**kwargs):
     }
     params.update(kwargs)
     return argparse.Namespace(**params)
-

--- a/plastron-repo/tests/jobs/test_import_job.py
+++ b/plastron-repo/tests/jobs/test_import_job.py
@@ -150,7 +150,7 @@ def test_config_write_none_as_null(jobs):
 
 def test_import_job_validation_fails_for_job_with_files_column_and_file_missing(jobs, datadir):
     """
-    Verifies the import validation fails when
+    Verifies that import validation fails when
     - The CSV file contains an "ITEM_FILES" column that contains non-empty values
     - A "binaries_location" parameter is provided
     - The file is not found
@@ -186,7 +186,7 @@ def test_import_job_raises_runtime_error_job_with_files_and_no_binaries_location
 
 def test_import_job_validation_succeeds_for_job_with_files_column_and_file_exists(jobs, datadir, tmpdir):
     """
-    Verifies the import validation fails when
+    Verifies that import validation succeeds when
     - The CSV file contains an "ITEM_FILES" column that contains non-empty values
     - A "binaries_location" parameter is provided
     - The indicated file is found
@@ -199,6 +199,24 @@ def test_import_job_validation_succeeds_for_job_with_files_column_and_file_exist
     mock_repo = MagicMock(spec=Repository)
 
     import_job = jobs.create_job(ImportJob, config=ImportConfig(job_id='456', model='Item', binaries_location=str(binaries_location)))
+    with pytest.raises(StopIteration) as exc_info:
+      next(import_job.run(repo=mock_repo, validate_only=True, import_file=import_file.open()))
+
+    return_value = exc_info.value.value
+    assert return_value['type'] == 'validate_success'
+
+
+def test_import_job_validation_passes_for_job_with_files_column_and_no_files_specified(jobs, datadir):
+    """
+    Verifies that import validation succeed when
+    - The CSV file contains an "ITEM_FILES" column that is empty for ALL rows
+    - A "binaries_location" parameter is not provided
+    """
+    import_file = datadir / 'item_with_empty_item_files_column.csv'
+    binaries_location = 'test_binaries_location'
+    mock_repo = MagicMock(spec=Repository)
+
+    import_job = jobs.create_job(ImportJob, config=ImportConfig(job_id='456', model='Item'))
     with pytest.raises(StopIteration) as exc_info:
       next(import_job.run(repo=mock_repo, validate_only=True, import_file=import_file.open()))
 

--- a/plastron-repo/tests/jobs/test_import_job.py
+++ b/plastron-repo/tests/jobs/test_import_job.py
@@ -159,9 +159,12 @@ def test_import_job_validation_fails_for_job_with_files_column_and_file_missing(
     binaries_location = 'test_binaries_location'
     mock_repo = MagicMock(spec=Repository)
 
-    import_job = jobs.create_job(ImportJob, config=ImportConfig(job_id='456', model='Item', binaries_location=binaries_location))
+    import_job = jobs.create_job(
+        ImportJob,
+        config=ImportConfig(job_id='456', model='Item', binaries_location=binaries_location)
+    )
     with pytest.raises(StopIteration) as exc_info:
-      next(import_job.run(repo=mock_repo, validate_only=True, import_file=import_file.open()))
+        next(import_job.run(repo=mock_repo, validate_only=True, import_file=import_file.open()))
 
     return_value = exc_info.value.value
     assert return_value['type'] == 'validate_failed'
@@ -178,7 +181,7 @@ def test_import_job_raises_runtime_error_job_with_files_and_no_binaries_location
 
     import_job = jobs.create_job(ImportJob, config=ImportConfig(job_id='456', model='Item'))
     with pytest.raises(RuntimeError) as exc_info:
-      next(import_job.run(repo=mock_repo, validate_only=True, import_file=import_file.open()))
+        next(import_job.run(repo=mock_repo, validate_only=True, import_file=import_file.open()))
 
     expected_message = 'Must specify --binaries-location if the metadata has a FILES and/or ITEM_FILES column'
     assert expected_message == str(exc_info.value)
@@ -198,9 +201,12 @@ def test_import_job_validation_succeeds_for_job_with_files_column_and_file_exist
 
     mock_repo = MagicMock(spec=Repository)
 
-    import_job = jobs.create_job(ImportJob, config=ImportConfig(job_id='456', model='Item', binaries_location=str(binaries_location)))
+    import_job = jobs.create_job(
+        ImportJob,
+        config=ImportConfig(job_id='456', model='Item', binaries_location=str(binaries_location))
+    )
     with pytest.raises(StopIteration) as exc_info:
-      next(import_job.run(repo=mock_repo, validate_only=True, import_file=import_file.open()))
+        next(import_job.run(repo=mock_repo, validate_only=True, import_file=import_file.open()))
 
     return_value = exc_info.value.value
     assert return_value['type'] == 'validate_success'
@@ -218,7 +224,7 @@ def test_import_job_validation_passes_for_job_with_files_column_and_no_files_spe
 
     import_job = jobs.create_job(ImportJob, config=ImportConfig(job_id='456', model='Item'))
     with pytest.raises(StopIteration) as exc_info:
-      next(import_job.run(repo=mock_repo, validate_only=True, import_file=import_file.open()))
+        next(import_job.run(repo=mock_repo, validate_only=True, import_file=import_file.open()))
 
     return_value = exc_info.value.value
     assert return_value['type'] == 'validate_success'

--- a/plastron-repo/tests/jobs/test_import_job/item_with_empty_item_files_column.csv
+++ b/plastron-repo/tests/jobs/test_import_job/item_with_empty_item_files_column.csv
@@ -1,0 +1,2 @@
+Object Type,Identifier,Rights Statement,Title,Format,Archival Collection,Presentation Set,Date,Description,Creator,Creator URI,Contributor URI,Publisher,Publisher URI,Extent,Subject,Rights Holder,Collection Information,Handle,URI,CREATED,MODIFIED,INDEX,ITEM_FILES,HIDDEN
+http://purl.org/dc/dcmitype/Image,test-item-with-empty_item-files-column,http://vocab.lib.umd.edu/rightsStatement#InC-NC,"Test Item with empty ITEM_FILES column",,,,,,,,,,,,,,,,,,,,,

--- a/plastron-repo/tests/jobs/test_import_job/item_with_file_in_item_files_column.csv
+++ b/plastron-repo/tests/jobs/test_import_job/item_with_file_in_item_files_column.csv
@@ -1,0 +1,2 @@
+Object Type,Identifier,Rights Statement,Title,Format,Archival Collection,Presentation Set,Date,Description,Creator,Creator URI,Contributor URI,Publisher,Publisher URI,Extent,Subject,Rights Holder,Collection Information,Handle,URI,CREATED,MODIFIED,INDEX,ITEM_FILES,HIDDEN
+http://purl.org/dc/dcmitype/Image,test-item-with-empty_item-files-column,http://vocab.lib.umd.edu/rightsStatement#InC-NC,"Test Item with empty ITEM_FILES column",,,,,,,,,,,,,,,,,,,,"test_file.tif",


### PR DESCRIPTION
This change modifies the import job validation to not
require a "binaries_location" argument for the import job
when a CSV file contains an "FILES" or "ITEM_FILES"
column that has no values.

This change was necessary to support metadata-only imports
(which do not specify a "binaries_location" argument) where the
CSV file being imported was generated from an Archelon export
job (which by default includes an "ITEM_FILES" column).

https://umd-dit.atlassian.net/browse/LIBFCREPO-1322