### PR TITLE
LIBFCREPO-1313. Replaced "get_handle()" method with "resolve()".

### DIFF
--- a/plastron-repo/src/plastron/repo/publish.py
+++ b/plastron-repo/src/plastron/repo/publish.py
@@ -41,17 +41,18 @@ class PublishableResource(RepositoryResource):
 
             # check the handle service to see if there is a registered handle
             # if so, check the URL and update it to the fcrepo url if need be
-            handle = handle_client.get_handle(str(obj.handle.value))
+            handle = handle_client.resolve(Handle.parse(obj.handle.value))
             if handle is None:
                 logger.error(f'Unable to find expected handle {obj.handle.value} for {self.url} on the handle server')
                 raise RepositoryError(f'Unable to publish {self}')
 
-            logger.debug(f'Handle service returns handle: {handle.hdl_uri}')
+            logger.debug(f'Handle service resolves {handle.hdl_uri} to {handle.url}')
 
             # check target URL, and update if needed
             if handle.url != public_url:
                 logger.warning(f'Current target URL ({handle.url}) does not match the expected URL ({public_url})')
                 handle = handle_client.update_handle(handle, url=public_url)
+                logger.info(f'Updated {handle.hdl_uri} target URL to {public_url}')
         else:
             handle = handle_client.find_handle(repo_uri=self.url)
             if handle is None:

--- a/plastron-repo/tests/repo/test_publishable_resource.py
+++ b/plastron-repo/tests/repo/test_publishable_resource.py
@@ -28,9 +28,10 @@ def test_get_publication_status(obj, expected_status):
 
 # TODO: this should go into a common library
 class MockHandleClient:
-    def __init__(self, get_handle_lookup=None, find_handle_lookup=None):
+    def __init__(self, get_handle_lookup=None, find_handle_lookup=None, resolver=None):
         self.get_handle_lookup = get_handle_lookup or {}
         self.find_handle_lookup = find_handle_lookup or {}
+        self.resolver = resolver or {}
 
     FIND_HANDLE_LOOKUP = {
         # this fcrepo resource has a handle and its target
@@ -48,6 +49,9 @@ class MockHandleClient:
             url='http://fedora2-local/bar',
         ),
     }
+
+    def resolve(self, handle: Handle) -> Optional[Handle]:
+        return self.resolver.get(handle.hdl_uri, None)
 
     def get_handle(self, handle: str, _repo: str = None) -> Optional[Handle]:
         return self.get_handle_lookup.get(handle, None)
@@ -116,7 +120,7 @@ def mock_repo(endpoint):
     ]
 )
 def test_existing_handle(mock_repo, fcrepo_path, existing_handle, expected_suffix, expected_url):
-    mock_client = MockHandleClient(get_handle_lookup={existing_handle.hdl_uri: existing_handle})
+    mock_client = MockHandleClient(resolver={existing_handle.hdl_uri: existing_handle})
     resource = PublishableResource(
         repo=mock_repo(path=fcrepo_path, handle=existing_handle.hdl_uri),
         path=fcrepo_path

--- a/plastron-stomp/src/plastron/stomp/commands/importcommand.py
+++ b/plastron-stomp/src/plastron/stomp/commands/importcommand.py
@@ -42,9 +42,9 @@ def importcommand(
         limit = int(limit)
     message.body = message.body.encode('utf-8').decode('utf-8-sig')
     percentage = message.args.get('percent', None)
-    validate_only = strtobool(message.args.get('validate-only', 'false'))
-    publish = strtobool(message.args.get('publish', 'false'))
-    resume = strtobool(message.args.get('resume', 'false'))
+    validate_only = bool(strtobool(message.args.get('validate-only', 'false')))
+    publish = bool(strtobool(message.args.get('publish', 'false')))
+    resume = bool(strtobool(message.args.get('resume', 'false')))
     import_file = io.StringIO(message.body)
 
     # options that are saved to the config

--- a/plastron-stomp/tests/commands/test_importcommand_stomp.py
+++ b/plastron-stomp/tests/commands/test_importcommand_stomp.py
@@ -34,7 +34,7 @@ def mock_repo():
             },
             # expected args
             {
-                'repo': mock_repo,
+                'context': ANY,
                 'import_file': ANY,
                 'limit': None,
                 'percentage': None,
@@ -54,7 +54,7 @@ def mock_repo():
             },
             # expected args
             {
-                'repo': mock_repo,
+                'context': ANY,
                 'import_file': ANY,
                 'limit': None,
                 'percentage': None,


### PR DESCRIPTION
- the "resolve()" method returns None if the handle is not found on the handle server
- allow a Handle object to be created without a URL
- added "has_url" property to Handle class

https://umd-dit.atlassian.net/browse/LIBFCREPO-1313