### PR TITLE
LIBFCREPO-1318. Custom page labels for import.

### DIFF
--- a/plastron-repo/docs/jobs/import.md
+++ b/plastron-repo/docs/jobs/import.md
@@ -142,3 +142,46 @@ imported during the first run of the job.
 
 If you specify a percentage that would generate a subset larger than the number
 of remaining items, Plastron will import all the remaining items.
+
+## Metadata Spreadsheet
+
+### `FILES` column format
+
+In the metadata spreadsheet CSV file, the `FILES` column (if present) 
+specifies both the binary files that should be included with the object, 
+and also their ordering into a sequence of member objects of the main object.
+
+* The `FILES` column of an import spreadsheet may have zero or more 
+  relpaths (relative paths), separated by semicolons (e.g., 
+  `ex-99/ex-99-0001.tif;ex-99/ex-99-0001.jpg;ex-99/ex-99-0002.tif;ex-99/ex-99-0002.jpg`)
+* A relpath is a relative path to an individual file (e.g., 
+  `ex-99/ex-99-0001.tif`)
+* The filename is the right-most segment of the relpath (e.g., 
+  `ex-99-0001.tif`)
+* The basename is the filename, excluding the file extension and its period 
+  separator (e.g., `ex-99-0001`)
+* All relpaths that share a basename are considered to be part of a single 
+  file group
+* Each file group corresponds to one member object
+* Each relpath within a file group will be used to create a `pcdm:File` 
+  object for that file group's member object
+* The member objects will be added to a sequence in the order in which 
+  their basename first occurs in the `FILES` field
+
+By default, the member objects have titles of the form "Page 1" to "Page 
+N". You may also specify custom labels in the relpath list to get custom 
+titles on the member objects.
+
+* A relpath may have an initial string followed by a colon; this is a label 
+  for the page for files in its file group (e.g.,
+  `Front Cover:ex-99/ex-99-0001.tif`)
+* If using a label, only one relpath in a file group is required to have that 
+  label
+* If more than one relpath from a single file group has a label, those labels 
+  must match; mismatched labels will cause the validation of the item to fail
+* If at least one relpath has a label, then each file group must have at 
+  least one relpath with a label; otherwise this will cause validation of 
+  the item to fail
+* If no relpaths have labels, the default behavior of assigning the labels 
+  "Page 1" through "Page N" based on the document order of the relpaths 
+  will be used

--- a/plastron-repo/src/plastron/files/__init__.py
+++ b/plastron-repo/src/plastron/files/__init__.py
@@ -412,6 +412,7 @@ class FileSpec:
 @dataclass
 class FileGroup:
     rootname: str
+    label: str = None
     files: List[FileSpec] = field(default_factory=list)
 
     def __str__(self):

--- a/plastron-repo/src/plastron/files/__init__.py
+++ b/plastron-repo/src/plastron/files/__init__.py
@@ -418,3 +418,7 @@ class FileGroup:
     def __str__(self):
         extensions = list(map(lambda f: str(f).replace(self.rootname, ''), self.files))
         return f'{self.rootname}{{{",".join(extensions)}}}'
+
+    @property
+    def filenames(self) -> List[str]:
+        return [file.name for file in self.files]

--- a/plastron-repo/src/plastron/jobs/importjob/__init__.py
+++ b/plastron-repo/src/plastron/jobs/importjob/__init__.py
@@ -17,7 +17,7 @@ from plastron.context import PlastronContext
 from plastron.files import BinarySource, ZipFileSource, RemoteFileSource, HTTPFileSource, LocalFileSource
 from plastron.handles import Handle
 from plastron.jobs import JobError, JobConfig, Job
-from plastron.jobs.importjob.spreadsheet import LineReference, MetadataSpreadsheet, InvalidRow, Row
+from plastron.jobs.importjob.spreadsheet import LineReference, MetadataSpreadsheet, InvalidRow, Row, MetadataError
 from plastron.models import get_model_class, ModelClassNotFoundError
 from plastron.models.annotations import FullTextAnnotation, TextualBody
 from plastron.namespaces import umdaccess, sc
@@ -338,7 +338,10 @@ class ImportJob(Job):
         })
 
     def get_metadata(self) -> MetadataSpreadsheet:
-        return MetadataSpreadsheet(metadata_filename=self.metadata_filename, model_class=self.model_class)
+        try:
+            return MetadataSpreadsheet(metadata_filename=self.metadata_filename, model_class=self.model_class)
+        except MetadataError as e:
+            raise JobError(job=self) from e
 
     def run(
             self,

--- a/plastron-repo/src/plastron/jobs/importjob/spreadsheet.py
+++ b/plastron-repo/src/plastron/jobs/importjob/spreadsheet.py
@@ -13,7 +13,6 @@ from rdflib import URIRef, Literal
 from rdflib.util import from_n3
 
 from plastron.files import FileSpec, FileGroup
-from plastron.jobs import JobError
 from plastron.namespaces import get_manager
 from plastron.rdfmapping.descriptors import Property, DataProperty
 from plastron.rdfmapping.embed import EmbeddedObject
@@ -36,7 +35,7 @@ class ColumnSpec:
     datatype: Optional[URIRef] = None
 
 
-class MetadataError(JobError):
+class MetadataError(Exception):
     pass
 
 
@@ -135,11 +134,34 @@ def build_file_groups(filenames_string: str) -> Dict[str, FileGroup]:
     if filenames_string.strip() == '':
         return file_groups
     for filename in filenames_string.split(';'):
+        if ':' in filename:
+            label, filename = filename.split(':', 1)
+        else:
+            label = None
         root, ext = splitext(basename(filename))
         if root not in file_groups:
-            file_groups[root] = FileGroup(rootname=root)
+            file_groups[root] = FileGroup(rootname=root, label=label)
+        file_group = file_groups[root]
+        if label is not None:
+            if file_group.label is not None:
+                if file_group.label != label:
+                    raise MetadataError(f'Multiple files with rootname "{root}" have differing labels')
+            else:
+                file_group.label = label
+
         file_groups[root].files.append(FileSpec(name=filename))
-    logger.debug(f'Found {len(file_groups.keys())} unique file basename(s)')
+
+    labels = [g.label for g in file_groups.values()]
+    if any(label is not None for label in labels) and not all(label is not None for label in labels):
+        raise MetadataError('If any file group has a label, all file groups must have a label')
+    elif all(label is None for label in labels):
+        # no explicit labels, default to "Page 1" to "Page N"
+        logger.info('No explicit page labels given, using default "Page 1" to "Page N"')
+        for i, group in enumerate(file_groups.values(), 1):
+            group.label = f'Page {i}'
+            labels[i - 1] = group.label
+    logger.debug(f'Found {len(file_groups)} unique file basename(s)')
+    logger.debug(f'File group labels: {labels}')
     return file_groups
 
 

--- a/plastron-repo/src/plastron/jobs/importjob/spreadsheet.py
+++ b/plastron-repo/src/plastron/jobs/importjob/spreadsheet.py
@@ -4,6 +4,7 @@ import re
 from collections import defaultdict, OrderedDict
 from collections.abc import Sized, Container
 from dataclasses import dataclass
+from itertools import chain
 from os.path import splitext, basename
 from pathlib import Path
 from typing import Optional, Dict, List, Tuple, Union, Mapping, Type, Iterator, NamedTuple, Protocol
@@ -210,6 +211,7 @@ class Row:
         self.data = data
         self.identifier_column = identifier_column
         self._file_groups = build_file_groups(self.data.get('FILES', ''))
+        self._filenames = list(chain(*[group.filenames for group in self._file_groups.values()]))
 
     def __getitem__(self, item):
         return self.data[item]
@@ -271,7 +273,7 @@ class Row:
 
     @property
     def filenames(self):
-        return self.data['FILES'].strip().split(';') if self.has_files else []
+        return self._filenames
 
     @property
     def file_groups(self):

--- a/plastron-repo/src/plastron/repo/pcdm.py
+++ b/plastron-repo/src/plastron/repo/pcdm.py
@@ -236,24 +236,23 @@ class PCDMObjectResource(PCDMFileBearingResource, AggregationResource):
             self.repo.create(resource_class=ContainerResource, url=self.members_container.url)
 
         parent = self.describe(PCDMObject)
-        title = get_new_member_title(parent, file_group.rootname, number)
-        logger.info(f'Creating page {number} for {parent} as "{title}"')
+        logger.info(f'Creating page {number} as "{file_group.label}"')
         page_resource = self.members_container.create_child(
             resource_class=PCDMPageResource,
             slug=slug,
-            description=Page(title=title, number=Literal(number), member_of=parent),
+            description=Page(title=Literal(file_group.label), number=Literal(number), member_of=parent),
         )
         parent.has_member.add(URIRef(page_resource.url))
         for file_spec in file_group.files:
             page_resource.create_file(source=file_spec.source)
         self.update()
         self.member_urls.add(page_resource.url)
-        logger.debug(f'Created page: {page_resource.url} {title}')
+        logger.debug(f'Created page {number}: {page_resource.url} "{file_group.label}"')
         return page_resource
 
     def create_page_sequence(self, file_groups: Dict[str, FileGroup]):
         def create_pages() -> Iterator[PCDMObject]:
-            for n, (rootname, file_group) in enumerate(file_groups.items(), 1):
+            for n, file_group in enumerate(file_groups.values(), 1):
                 page_resource = self.create_page(number=n, file_group=file_group)
                 yield page_resource.read().describe(Page)
 

--- a/plastron-repo/tests/jobs/test_import_job_utils.py
+++ b/plastron-repo/tests/jobs/test_import_job_utils.py
@@ -3,7 +3,8 @@ from rdflib import URIRef
 
 from plastron.files import LocalFileSource, RemoteFileSource, ZipFileSource
 from plastron.jobs.importjob import ImportJob
-from plastron.jobs.importjob.spreadsheet import ColumnSpec, build_fields, build_file_groups, parse_value_string
+from plastron.jobs.importjob.spreadsheet import ColumnSpec, build_fields, build_file_groups, parse_value_string, \
+    MetadataError
 from plastron.models import Item
 from plastron.namespaces import umdtype
 from plastron.rdfmapping.descriptors import DataProperty
@@ -19,6 +20,40 @@ from plastron.rdfmapping.descriptors import DataProperty
 )
 def test_build_file_groups(value, expected_count):
     assert len(build_file_groups(value)) == expected_count
+
+
+@pytest.mark.parametrize(
+    ('value', 'error_message'),
+    [
+        # mismatched labels
+        ('Page 1:foo.jpg;p 1:foo.png', 'Multiple files with rootname "foo" have differing labels'),
+        # missing labels
+        ('Page 1:foo.jpg;bar.jpg', 'If any file group has a label, all file groups must have a label'),
+    ]
+)
+def test_build_file_groups_errors(value, error_message):
+    with pytest.raises(MetadataError) as e:
+        build_file_groups(value)
+    assert str(e.value) == error_message
+
+
+@pytest.mark.parametrize(
+    ('value', 'expected_count', 'expected_labels'),
+    [
+        ('Page 1:foo.jpg;foo.png;Page 2:bar.jpg;bar.png', 2, {'foo': 'Page 1', 'bar': 'Page 2'}),
+        ('foo.jpg;Page 1:foo.png;Page 2:bar.jpg;bar.png', 2, {'foo': 'Page 1', 'bar': 'Page 2'}),
+        ('p. 37:foo.jpg;foo.png;p. 38:bar.jpg;bar.png', 2, {'foo': 'p. 37', 'bar': 'p. 38'}),
+        ('XVII:foo.jpg;foo.png;XV:bar.jpg;bar.png', 2, {'foo': 'XVII', 'bar': 'XV'}),
+        ('Page 1:foo.jpg;foo.png', 1, {'foo': 'Page 1'}),
+        # default labels
+        ('foo.jpg;foo.png;bar.jpg;bar.png;baz.jpg', 3, {'foo': 'Page 1', 'bar': 'Page 2', 'baz': 'Page 3'}),
+    ]
+)
+def test_build_file_groups_labeled(value, expected_count, expected_labels):
+    groups = build_file_groups(value)
+    assert len(groups) == expected_count
+    for rootname, label in expected_labels.items():
+        assert groups[rootname].label == label
 
 
 def test_build_fields_with_default_datatype():


### PR DESCRIPTION
- added label field to the FileGroup class
- changed MetadataError to not be a subclass of JobError
- added a re-raising clause for MetadataErrors that occur during a job as a JobError
- add ability to parse a label for members from the FILES column

https://umd-dit.atlassian.net/browse/LIBFCREPO-1318