### PR TITLE
LIBFCREPO-1335. Enable additional substitution values in public URL template for handle generation.

### DIFF
--- a/plastron-cli/src/plastron/cli/commands/publish.py
+++ b/plastron-cli/src/plastron/cli/commands/publish.py
@@ -58,7 +58,7 @@ def publish(ctx, uris: Iterable[str], force_hidden: bool = False, force_visible:
         try:
             handle = resource.publish(
                 handle_client=ctx.obj.handle_client,
-                public_url=ctx.obj.get_public_url(uri),
+                public_url=ctx.obj.get_public_url(resource),
                 force_hidden=force_hidden,
                 force_visible=force_visible,
             )

--- a/plastron-models/src/plastron/models/fedora.py
+++ b/plastron-models/src/plastron/models/fedora.py
@@ -1,0 +1,7 @@
+from plastron.namespaces import fedora
+from plastron.rdfmapping.descriptors import ObjectProperty
+from plastron.rdfmapping.resources import RDFResource
+
+
+class FedoraResource(RDFResource):
+    parent = ObjectProperty(fedora.hasParent)

--- a/plastron-repo/src/plastron/jobs/importjob/__init__.py
+++ b/plastron-repo/src/plastron/jobs/importjob/__init__.py
@@ -533,7 +533,7 @@ class ImportRow:
     def publish(self, resource: PublishableObjectResource) -> Handle:
         return resource.publish(
             handle_client=self.context.handle_client,
-            public_url=self.context.get_public_url(resource.url),
+            public_url=self.context.get_public_url(resource),
         )
 
     def create_resource(self) -> PublishableObjectResource:

--- a/plastron-repo/src/plastron/jobs/publicationjob.py
+++ b/plastron-repo/src/plastron/jobs/publicationjob.py
@@ -46,7 +46,7 @@ class PublicationJob(Job):
                 if self.action == PublicationAction.PUBLISH:
                     handle = resource.publish(
                         handle_client=self.context.handle_client,
-                        public_url=self.context.get_public_url(uri),
+                        public_url=self.context.get_public_url(resource),
                         force_hidden=self.force_hidden,
                         force_visible=self.force_visible,
                     )

--- a/plastron-repo/tests/context/test_get_public_url.py
+++ b/plastron-repo/tests/context/test_get_public_url.py
@@ -1,0 +1,55 @@
+from unittest.mock import MagicMock
+
+import pytest
+from rdflib import URIRef
+
+from plastron.context import PlastronContext
+from plastron.models.fedora import FedoraResource
+from plastron.repo import RepositoryResource
+
+
+@pytest.mark.parametrize(
+    ('public_url_pattern', 'resource_url', 'container_url', 'expected_public_url'),
+    [
+        (
+            'http://digital-test/result/id/{uuid}',
+            'http://fcrepo-test/fcrepo/rest/pcdm/f4/f0/46/77/f4f04677-6ebe-4166-b30d-232fd2ad4e10',
+            'http://fcrepo-test/fcrepo/rest/pcdm',
+            'http://digital-test/result/id/f4f04677-6ebe-4166-b30d-232fd2ad4e10',
+        ),
+        (
+            'http://digital-test/result/id/{uuid}?relpath={container_path}',
+            'http://fcrepo-test/fcrepo/rest/pcdm/f4/f0/46/77/f4f04677-6ebe-4166-b30d-232fd2ad4e10',
+            'http://fcrepo-test/fcrepo/rest/pcdm',
+            'http://digital-test/result/id/f4f04677-6ebe-4166-b30d-232fd2ad4e10?relpath=/pcdm',
+        ),
+        (
+            'http://digital-test/result/id/{uuid}?relpath={relpath}',
+            'http://fcrepo-test/fcrepo/rest/pcdm/f4/f0/46/77/f4f04677-6ebe-4166-b30d-232fd2ad4e10',
+            'http://fcrepo-test/fcrepo/rest/pcdm',
+            'http://digital-test/result/id/f4f04677-6ebe-4166-b30d-232fd2ad4e10?relpath=pcdm',
+        ),
+        (
+            'http://digital-test/result/?path={path}',
+            'http://fcrepo-test/fcrepo/rest/pcdm/f4/f0/46/77/f4f04677-6ebe-4166-b30d-232fd2ad4e10',
+            'http://fcrepo-test/fcrepo/rest/pcdm',
+            'http://digital-test/result/?path=/pcdm/f4/f0/46/77/f4f04677-6ebe-4166-b30d-232fd2ad4e10',
+        ),
+    ]
+)
+def test_get_public_url(public_url_pattern, resource_url, container_url, expected_public_url):
+    resource = MagicMock(
+        spec=RepositoryResource,
+        url=resource_url,
+    )
+    resource.describe.return_value = FedoraResource(parent=URIRef(container_url))
+    config = {
+        'REPOSITORY': {
+            'REST_ENDPOINT': 'http://fcrepo-test/fcrepo/rest',
+        },
+        'PUBLICATION_WORKFLOW': {
+            'PUBLIC_URL_PATTERN': public_url_pattern,
+        }
+    }
+    context = PlastronContext(config)
+    assert context.get_public_url(resource) == expected_public_url

--- a/plastron-web/src/plastron/web/activitystream.py
+++ b/plastron-web/src/plastron/web/activitystream.py
@@ -24,7 +24,7 @@ def new_activity():
             if activity.publish:
                 resource.publish(
                     handle_client=ctx.handle_client,
-                    public_url=ctx.get_public_url(uri),
+                    public_url=ctx.get_public_url(resource),
                     force_hidden=activity.force_hidden,
                     force_visible=False,
                 )


### PR DESCRIPTION
* `path`: the full repository path to the resource
* `container_path`: the repository path to the resource's parent container
* `relpath`: same as `container_path`, but omits the leading "/"
* `uuid`: the UUID portion of the resource's path

https://umd-dit.atlassian.net/browse/LIBFCREPO-1335