### PR TITLE
LIBFCREPO-1346. Ensure the PUBLISH and HIDDEN columns get written on export.

### DIFF
--- a/plastron-cli/src/plastron/cli/commands/export.py
+++ b/plastron-cli/src/plastron/cli/commands/export.py
@@ -57,7 +57,7 @@ def configure_cli(subparsers):
 class Command(BaseCommand):
     def __call__(self, args: Namespace):
         export_job = ExportJob(
-            repo=self.context.repo,
+            context=self.context,
             export_binaries=args.export_binaries,
             binary_types=args.binary_types,
             uris=args.uris,

--- a/plastron-models/src/plastron/models/fedora.py
+++ b/plastron-models/src/plastron/models/fedora.py
@@ -1,7 +1,9 @@
-from plastron.namespaces import fedora
-from plastron.rdfmapping.descriptors import ObjectProperty
+from plastron.namespaces import fedora, xsd
+from plastron.rdfmapping.descriptors import ObjectProperty, DataProperty
 from plastron.rdfmapping.resources import RDFResource
 
 
 class FedoraResource(RDFResource):
+    created = DataProperty(fedora.created, datatype=xsd.dateTime)
+    last_modified = DataProperty(fedora.lastModified, datatype=xsd.dateTime)
     parent = ObjectProperty(fedora.hasParent)

--- a/plastron-models/src/plastron/serializers/csv.py
+++ b/plastron-models/src/plastron/serializers/csv.py
@@ -6,17 +6,17 @@ from contextlib import contextmanager
 from itertools import zip_longest
 from pathlib import Path
 from typing import List, Union, Dict, Type, NamedTuple, Mapping, Iterable
-from urllib.parse import urlparse
 
 from rdflib import URIRef, Literal
 from urlobject import URLObject
 
+from plastron.models.fedora import FedoraResource
 from plastron.models.pcdm import PCDMFile
-from plastron.namespaces import fedora
+from plastron.namespaces import umdaccess
 from plastron.rdfmapping.descriptors import ObjectProperty
 from plastron.rdfmapping.embed import EmbeddedObject
 from plastron.rdfmapping.properties import RDFObjectProperty, RDFDataProperty
-from plastron.rdfmapping.resources import RDFResourceBase
+from plastron.rdfmapping.resources import RDFResourceBase, RDFResource
 from plastron.repo import BinaryResource
 
 
@@ -342,8 +342,8 @@ class CSVSerializer:
         'URI', 'PUBLIC URI', 'CREATED', 'MODIFIED', 'INDEX', 'FILES', 'ITEM_FILES', 'PUBLISH', 'HIDDEN'
     ]
 
-    def __init__(self, directory: Union[str, Path] = None, public_uri_template: str = None):
-        self.directory = Path(directory) or Path.cwd()
+    def __init__(self, directory: Union[str, Path] = None):
+        self.directory = Path(directory) if directory is not None else Path.cwd()
         """Destination directory for the CSV file(s)"""
 
         self.rows_by_content_model = {}
@@ -351,7 +351,6 @@ class CSVSerializer:
 
         self.content_type = 'text/csv'
         self.file_extension = '.csv'
-        self.public_uri_template = public_uri_template
 
     def __enter__(self):
         self.rows = []
@@ -360,7 +359,13 @@ class CSVSerializer:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.finish()
 
-    def write(self, resource: RDFResourceBase, files: Iterable[BinaryResource] = None, binaries_dir=''):
+    def write(
+            self,
+            resource: RDFResource,
+            files: Iterable[BinaryResource] = None,
+            binaries_dir: str = '',
+            public_url: str = None,
+    ) -> Dict[str, str]:
         """
         Serializes the given resource as a CSV row using the `flatten()` function. The resulting row is
         added to an internal accumulator. The CSV file or files themselves are not actually written until
@@ -375,21 +380,24 @@ class CSVSerializer:
                 'rows': []
             }
 
-        graph = resource.graph
         row = {k: join_values(v) for k, v in flatten(resource, resource_class.HEADER_MAP).items()}
         row['URI'] = str(resource.uri)
         if files is not None:
             row['FILES'] = ';'.join(
                 os.path.join(binaries_dir, file.describe(PCDMFile).filename.value) for file in files)
-        row['CREATED'] = str(graph.value(resource.uri, fedora.created))
-        row['MODIFIED'] = str(graph.value(resource.uri, fedora.lastModified))
-        if self.public_uri_template is not None:
-            # TODO: more generic transform function than hardwired to look for a uuid
-            uri = urlparse(resource.uri)
-            uuid = os.path.basename(uri.path)
-            row['PUBLIC URI'] = self.public_uri_template.format(uuid=uuid)
+        fedora_resource = resource.redescribe(FedoraResource)
+        row['CREATED'] = str(fedora_resource.created.value)
+        row['MODIFIED'] = str(fedora_resource.last_modified.value)
+        if public_url is not None:
+            row['PUBLIC URI'] = public_url
+
+        # set publication and visibility state
+        row['PUBLISH'] = str(umdaccess.Published in resource.rdf_type.values)
+        row['HIDDEN'] = str(umdaccess.Hidden in resource.rdf_type.values)
 
         self.rows_by_content_model[resource_class]['rows'].append(row)
+
+        return row
 
     LANGUAGE_NAMES = {
         'ja': 'Japanese',

--- a/plastron-models/tests/serializers/test_csv.py
+++ b/plastron-models/tests/serializers/test_csv.py
@@ -1,0 +1,40 @@
+import pytest
+from rdflib import URIRef
+
+from plastron.models.umd import Item
+from plastron.namespaces import umdaccess
+from plastron.serializers import CSVSerializer
+
+
+@pytest.mark.parametrize(
+    ('resource', 'expected_values'),
+    [
+        (Item(), {'PUBLISH': 'False', 'HIDDEN': 'False', 'Presentation Set': ''}),
+        (Item(rdf_type=umdaccess.Published), {'PUBLISH': 'True', 'HIDDEN': 'False', 'Presentation Set': ''}),
+        (Item(rdf_type=umdaccess.Hidden), {'PUBLISH': 'False', 'HIDDEN': 'True', 'Presentation Set': ''}),
+        (
+            Item(rdf_type=[umdaccess.Published, umdaccess.Hidden]),
+            {'PUBLISH': 'True', 'HIDDEN': 'True', 'Presentation Set': ''},
+        ),
+        (
+            Item(presentation_set=URIRef('http://vocab.lib.umd.edu/set#test')),
+            {'PUBLISH': 'False', 'HIDDEN': 'False', 'Presentation Set': 'http://vocab.lib.umd.edu/set#test'},
+        ),
+        (
+                Item(rdf_type=umdaccess.Published, presentation_set=URIRef('http://vocab.lib.umd.edu/set#test')),
+                {'PUBLISH': 'True', 'HIDDEN': 'False', 'Presentation Set': 'http://vocab.lib.umd.edu/set#test'},
+        ),
+        (
+                Item(
+                    rdf_type=[umdaccess.Published, umdaccess.Hidden],
+                    presentation_set=URIRef('http://vocab.lib.umd.edu/set#test'),
+                ),
+                {'PUBLISH': 'True', 'HIDDEN': 'True', 'Presentation Set': 'http://vocab.lib.umd.edu/set#test'},
+        ),
+    ]
+)
+def test_write(resource, expected_values):
+    serializer = CSVSerializer()
+    row = serializer.write(resource=resource)
+    for key, expected_value in expected_values.items():
+        assert row[key] == expected_value

--- a/plastron-models/tests/serializers/test_csv.py
+++ b/plastron-models/tests/serializers/test_csv.py
@@ -21,15 +21,15 @@ from plastron.serializers import CSVSerializer
             {'PUBLISH': 'False', 'HIDDEN': 'False', 'Presentation Set': 'http://vocab.lib.umd.edu/set#test'},
         ),
         (
-                Item(rdf_type=umdaccess.Published, presentation_set=URIRef('http://vocab.lib.umd.edu/set#test')),
-                {'PUBLISH': 'True', 'HIDDEN': 'False', 'Presentation Set': 'http://vocab.lib.umd.edu/set#test'},
+            Item(rdf_type=umdaccess.Published, presentation_set=URIRef('http://vocab.lib.umd.edu/set#test')),
+            {'PUBLISH': 'True', 'HIDDEN': 'False', 'Presentation Set': 'http://vocab.lib.umd.edu/set#test'},
         ),
         (
-                Item(
-                    rdf_type=[umdaccess.Published, umdaccess.Hidden],
-                    presentation_set=URIRef('http://vocab.lib.umd.edu/set#test'),
-                ),
-                {'PUBLISH': 'True', 'HIDDEN': 'True', 'Presentation Set': 'http://vocab.lib.umd.edu/set#test'},
+            Item(
+                rdf_type=[umdaccess.Published, umdaccess.Hidden],
+                presentation_set=URIRef('http://vocab.lib.umd.edu/set#test'),
+            ),
+            {'PUBLISH': 'True', 'HIDDEN': 'True', 'Presentation Set': 'http://vocab.lib.umd.edu/set#test'},
         ),
     ]
 )

--- a/plastron-rdf/src/plastron/rdfmapping/resources.py
+++ b/plastron-rdf/src/plastron/rdfmapping/resources.py
@@ -151,6 +151,9 @@ class RDFResourceBase:
             results['_' + test.__name__] = test(self)
         return results
 
+    def redescribe(self, model: Type['RDFResourceType']) -> 'RDFResourceType':
+        return model(uri=self.uri, graph=self.graph)
+
 
 class RDFResource(RDFResourceBase):
     rdf_type = ObjectProperty(URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), repeatable=True)

--- a/plastron-repo/src/plastron/jobs/exportjob.py
+++ b/plastron-repo/src/plastron/jobs/exportjob.py
@@ -1,12 +1,12 @@
 import logging
 import os
-from pathlib import Path
 import re
 from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime
 from email.utils import parsedate
 from os.path import splitext, basename
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from time import mktime
 from typing import Optional, List, Generator, Dict, Any, Iterator
@@ -18,11 +18,12 @@ from paramiko import SFTPClient, SSHException
 from requests import ConnectionError
 
 from plastron.client import ClientError
+from plastron.context import PlastronContext
 from plastron.files import get_ssh_client
 from plastron.jobs import Job
 from plastron.models import Item
 from plastron.models.pcdm import PCDMFile
-from plastron.repo import DataReadError, Repository, BinaryResource
+from plastron.repo import DataReadError, BinaryResource
 from plastron.repo.pcdm import PCDMObjectResource, AggregationResource, PCDMFileBearingResource
 from plastron.serializers import SERIALIZER_CLASSES, detect_resource_class
 from plastron.serializers.csv import EmptyItemListError
@@ -84,7 +85,7 @@ class FileSize:
 
 @dataclass
 class ExportJob(Job):
-    repo: Repository
+    context: PlastronContext
     export_format: str
     export_binaries: bool
     binary_types: str
@@ -138,12 +139,12 @@ class ExportJob(Job):
         bag = make_bag(temp_dir.name)
 
         export_dir = os.path.join(temp_dir.name, 'data')
-        serializer = serializer_class(directory=export_dir, public_uri_template=self.uri_template)
+        serializer = serializer_class(directory=export_dir)
         for uri in self.uris:
             try:
                 logger.info(f'Exporting item {count["exported"] + 1}/{count["total"]}: {uri}')
 
-                resource = self.repo[uri:PCDMObjectResource].read()
+                resource = self.context.repo[uri:PCDMObjectResource].read()
                 # use a translated version of the repo path as the default item directory name
                 # e.g., "/dc/2023/1/de/84/37/0d/de84370d-f90a-444f-a87f-dd79e0438884" becomes
                 # "dc.2023.1.de.84.37.0d.de84370d-f90a-444f-a87f-dd79e0438884"
@@ -157,7 +158,12 @@ class ExportJob(Job):
                 # use the identifier field from the model as a better item directory name
                 if hasattr(obj, 'identifier'):
                     item_dir = str(obj.identifier.value or item_dir)
-                serializer.write(obj, files=binaries, binaries_dir=item_dir)
+                serializer.write(
+                    obj,
+                    files=binaries,
+                    binaries_dir=item_dir,
+                    public_url=self.context.get_public_url(resource),
+                )
 
                 if binaries is not None:
                     binaries_dir = Path(export_dir, item_dir)

--- a/plastron-stomp/src/plastron/stomp/commands/export.py
+++ b/plastron-stomp/src/plastron/stomp/commands/export.py
@@ -15,7 +15,7 @@ def export(
 ) -> Generator[Dict[str, Any], None, Dict[str, Any]]:
     ssh_key = context.config.get('COMMANDS', {}).get('EXPORT', {}).get('SSH_PRIVATE_KEY', None)
     export_job = ExportJob(
-        repo=context.repo,
+        context=context,
         export_binaries=bool(strtobool(message.args.get('export-binaries', 'false'))),
         binary_types=message.args.get('binary-types'),
         uris=message.body.strip().split('\n'),


### PR DESCRIPTION
- pass the entire PlastronContext to the ExportJob so it has access to the get_public_url() method
- added a `redescribe()` method to RDFResourceBase to create a new model object with the same graph and URI
- added more properties to the FedoraResource model class

https://umd-dit.atlassian.net/browse/LIBFCREPO-1346