### PR TITLE
LIBFCREPO-1342. Added "copyright_notice" field to models

### DIFF
--- a/plastron-models/src/plastron/models/letter.py
+++ b/plastron-models/src/plastron/models/letter.py
@@ -4,7 +4,7 @@ from plastron.rdfmapping.decorators import rdf_type
 from plastron.rdfmapping.descriptors import ObjectProperty, DataProperty
 from plastron.rdfmapping.resources import RDFResource
 from plastron.validation.rules import is_edtf_formatted, is_handle, is_from_vocabulary
-from plastron.namespaces import bibo, dc, dcmitype, dcterms, edm, geo, rel, skos, ore, owl, umd
+from plastron.namespaces import bibo, dc, dcmitype, dcterms, edm, geo, ore, owl, rel, schema, skos, umd
 
 umdtype = Namespace('http://vocab.lib.umd.edu/datatype#')
 
@@ -43,6 +43,7 @@ class Letter(RDFResource):
     place = ObjectProperty(dcterms.spatial, repeatable=True, embed=True, cls=Place)
     subject = ObjectProperty(dcterms.subject, repeatable=True, embed=True, cls=Concept)
     rights = ObjectProperty(dcterms.rights, required=True)
+    copyright_notice = DataProperty(schema.copyrightNotice)
     identifier = DataProperty(dcterms.identifier, required=True)
     type = DataProperty(edm.hasType, required=True)
     date = DataProperty(dc.date, validate=is_edtf_formatted)
@@ -68,6 +69,7 @@ class Letter(RDFResource):
         'date': 'Date',
         'type': 'Resource Type',
         'rights': 'Rights',
+        'copyright_notice': 'Copyright Notice',
         'subject': {
             'label': 'Subject',
         },

--- a/plastron-models/src/plastron/models/newspaper.py
+++ b/plastron-models/src/plastron/models/newspaper.py
@@ -2,7 +2,7 @@ from lxml.etree import parse, XMLSyntaxError
 
 from plastron.models.annotations import TextblockOnPage
 from plastron.models.pcdm import PCDMObject, PCDMFile
-from plastron.namespaces import bibo, carriers, dc, dcterms, fabio, ndnp, ore, pcdmuse, umdtype, pcdm, umd
+from plastron.namespaces import bibo, carriers, dc, dcterms, fabio, ndnp, ore, pcdm, pcdmuse, schema, umdtype, umd
 from plastron.rdf.ocr import ALTOResource
 from plastron.rdfmapping.decorators import rdf_type
 from plastron.rdfmapping.descriptors import DataProperty, ObjectProperty
@@ -24,6 +24,7 @@ class Issue(PCDMObject):
         repeatable=True,
         validate=is_from_vocabulary('http://vocab.lib.umd.edu/set#'),
     )
+    copyright_notice = DataProperty(schema.copyrightNotice)
 
     HEADER_MAP = {
         'title': 'Title',
@@ -33,6 +34,7 @@ class Issue(PCDMObject):
         'edition': 'Edition',
         'handle': 'Handle',
         'presentation_set': 'Presentation Set',
+        'copyright_notice': 'Copyright Notice',
     }
 
 

--- a/plastron-models/src/plastron/models/poster.py
+++ b/plastron-models/src/plastron/models/poster.py
@@ -1,7 +1,7 @@
 from rdflib import URIRef
 
 from plastron.models.pcdm import PCDMObject
-from plastron.namespaces import dcterms, dc, edm, bibo, geo, ore, umd, umdtype
+from plastron.namespaces import bibo, dcterms, dc, edm, geo, ore, schema, umd, umdtype
 from plastron.rdfmapping.decorators import rdf_type
 from plastron.rdfmapping.descriptors import ObjectProperty, DataProperty, Property
 from plastron.validation.rules import is_edtf_formatted, is_handle, is_from_vocabulary
@@ -29,6 +29,7 @@ class Poster(PCDMObject):
     latitude = DataProperty(geo.lat)
     subject = ObjectProperty(dc.subject)
     rights = ObjectProperty(dcterms.rights, required=True)
+    copyright_notice = DataProperty(schema.copyrightNotice)
     identifier = DataProperty(dcterms.identifier, required=True)
     handle = DataProperty(dcterms.identifier, validate=is_handle, datatype=umdtype.handle)
     place = ObjectProperty(dcterms.spatial)
@@ -56,6 +57,7 @@ class Poster(PCDMObject):
         'latitude': 'Latitude',
         'subject': 'Subject',
         'rights': 'Rights',
+        'copyright_notice': 'Copyright Notice',
         'identifier': 'Identifier',
         'handle': 'Handle',
         'presentation_set': 'Presentation Set',

--- a/plastron-models/src/plastron/models/umd.py
+++ b/plastron-models/src/plastron/models/umd.py
@@ -1,6 +1,6 @@
 from plastron.handles import HandleBearingResource
 from plastron.models.pcdm import PCDMObject
-from plastron.namespaces import dc, dcterms, edm, rdfs, owl, fabio, pcdm, ore, umdtype, umd
+from plastron.namespaces import dc, dcterms, edm, rdfs, owl, fabio, pcdm, ore, schema, umdtype, umd
 from plastron.rdfmapping.decorators import rdf_type
 from plastron.rdfmapping.descriptors import ObjectProperty, DataProperty
 from plastron.rdfmapping.resources import RDFResource
@@ -54,6 +54,7 @@ class Item(PCDMObject, HandleBearingResource):
     subject = ObjectProperty(dcterms.subject, repeatable=True, embed=True, cls=LabeledThing)
     language = DataProperty(dc.language, repeatable=True, validate=is_valid_iso639_code)
     rights_holder = ObjectProperty(dcterms.rightsHolder, repeatable=True, embed=True, cls=LabeledThing)
+    copyright_notice = DataProperty(schema.copyrightNotice)
     bibliographic_citation = DataProperty(dcterms.bibliographicCitation)
     accession_number = DataProperty(dcterms.identifier, datatype=umdtype.accessionNumber)
 
@@ -91,6 +92,7 @@ class Item(PCDMObject, HandleBearingResource):
         'rights_holder': {
             'label': 'Rights Holder',
         },
+        'copyright_notice': 'Copyright Notice',
         'bibliographic_citation': 'Collection Information',
         'accession_number': 'Accession Number',
         'handle': 'Handle',

--- a/plastron-models/tests/test_copyright_notice.py
+++ b/plastron-models/tests/test_copyright_notice.py
@@ -1,0 +1,38 @@
+from plastron.models.umd import Item
+from plastron.models.letter import Letter
+from plastron.models.newspaper import Issue
+from plastron.models.poster import Poster
+from plastron.namespaces import schema
+from rdflib import Graph, URIRef, Literal
+
+import pytest
+
+base_uri = 'http://example.com/xyz'
+
+
+@pytest.mark.parametrize("model_class", [Item, Letter, Poster, Issue])
+def test_model_with_copyright_notice(model_class):
+    copyright_text = 'Copyright 2024. All rights reserved.'
+    model = create_model_with_copyright_notice(model_class, base_uri, copyright_text)
+    assert str(model.copyright_notice.value) == copyright_text
+
+
+@pytest.mark.parametrize("model_class", [Item, Letter, Poster, Issue])
+def test_copyright_notice_can_be_set_on_model(model_class):
+    copyright_notice = 'Public Domain'
+
+    model = model_class(uri=base_uri)
+    model.copyright_notice = Literal(copyright_notice)
+
+    expected = (URIRef(base_uri), URIRef('http://schema.org/copyrightNotice'), Literal(copyright_notice))
+    assert expected in model.graph
+
+
+# Helper Functions
+
+def create_model_with_copyright_notice(model_class, item_uri, copyright_notice_text):
+    copyright_notice = f'<> <{schema.copyrightNotice}> \"{copyright_notice_text}\" .'
+    model_graph = Graph().parse(data=copyright_notice, format='turtle', publicID=item_uri)
+    model = model_class(graph=model_graph, uri=item_uri)
+
+    return model

--- a/plastron-utils/src/plastron/namespaces/__init__.py
+++ b/plastron-utils/src/plastron/namespaces/__init__.py
@@ -93,6 +93,9 @@ rel = Namespace('http://id.loc.gov/vocabulary/relators/')
 sc = Namespace('http://www.shared-canvas.org/ns/')
 """[Shared Canvas Data Model](https://iiif.io/api/model/shared-canvas/1.0/)"""
 
+schema = Namespace('http://schema.org/')
+"""[Schema.org](https://schema.org/)"""
+
 skos = Namespace('http://www.w3.org/2004/02/skos/core#')
 """[Simple Knowledge Organization System (SKOS)](https://www.w3.org/TR/skos-reference/)"""
 


### PR DESCRIPTION
Added an optional, non-repeatable "copyright_notice" DataProperty field to the "Issue", "Item", "Letter", and "Poster" models, that uses the "schema.copyrightNotice" predicate
(<https://schema.org/copyrightNotice>)

Added the "schema.org" namespace to
"plastron-utils/src/plastron/namespaces/__init__.py" as "schema".

Added tests.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1342