### PR TITLE
LIBFCREPO-1339. Add a “Terms of Use” field to the content models

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -23,5 +23,6 @@ def pytest_configure(config):
         'http://vocab.lib.umd.edu/collection#': 'collection.ttl',
         'http://vocab.lib.umd.edu/form#': 'form.ttl',
         'http://vocab.lib.umd.edu/rightsStatement#': 'rightsStatement.ttl',
-        'http://vocab.lib.umd.edu/set#': 'set.ttl'
+        'http://vocab.lib.umd.edu/set#': 'set.ttl',
+        'http://vocab.lib.umd.edu/termsOfUse#': 'termsOfUse.ttl'
     }

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,27 @@
+from os.path import abspath, dirname
+from pathlib import Path
+
+import plastron.validation.vocabularies
+
+# See "plastron-models/README.md" for more information about this file.
+
+
+def pytest_configure(config):
+    # Set VOCABULARIES_DIR and VOCABULARIES to point to local test files,
+    # so that tests run without making a network call, and to provide greater
+    # flexibility in defining the vocabularies used for testing.
+    #
+    # A network call will still be made if a vocabulary is not specified in the
+    # "VOCABULARIES" dictionary, because of the fallback behavior in the
+    # "get_vocabulary" method of
+    # plastron-models/src/plastron/validation/vocabularies/__init__.py
+    plastron.validation.vocabularies.VOCABULARIES_DIR = Path(
+        dirname(abspath(__file__)), 'plastron-models', 'tests', 'data', 'vocabularies'
+    )
+    plastron.validation.vocabularies.VOCABULARIES = {
+        'http://purl.org/dc/dcmitype/': 'dcmitype.ttl',
+        'http://vocab.lib.umd.edu/collection#': 'collection.ttl',
+        'http://vocab.lib.umd.edu/form#': 'form.ttl',
+        'http://vocab.lib.umd.edu/rightsStatement#': 'rightsStatement.ttl',
+        'http://vocab.lib.umd.edu/set#': 'set.ttl'
+    }

--- a/plastron-models/README.md
+++ b/plastron-models/README.md
@@ -4,13 +4,69 @@ Metadata content models based on RDF
 
 ## Model Packages
 
-* [annotations](src/plastron/models/annotations.py): Auxiliary model 
+* [annotations](src/plastron/models/annotations.py): Auxiliary model
   classes for Web Annotations
-* [letter](src/plastron/models/letter.py): Legacy content model for the 
+* [letter](src/plastron/models/letter.py): Legacy content model for the
   Katherine Anne Porter correspondence collection
-* [newspaper](src/plastron/models/newspaper.py): Content model for the 
+* [newspaper](src/plastron/models/newspaper.py): Content model for the
   Student Newspapers collection, based on the NDNP data format
-* [poster](src/plastron/models/poster.py): Legacy content model for the 
+* [poster](src/plastron/models/poster.py): Legacy content model for the
   Prange Posters and Wall Newspapers collection
-* [umd](src/plastron/models/umd.py): Standardized digital object content 
+* [umd](src/plastron/models/umd.py): Standardized digital object content
   model for current and future collections
+
+## Vocabulary Retrieval
+
+The `get_vocabulary` method in the
+`plastron-models/src/plastron/validation/vocabularies/__init__.py` module
+initializer controls how vocabularies used for validation are retrieved.
+
+Vocabularies used to validate models are retrieved either from the local
+filesystem, or from a vocabulary server on the network.
+
+The code uses two variables:
+
+* `VOCABULARIES_DIR` - The full filepath to the directory containing the local
+  vocabulary files
+* `VOCABULARIES` - A dictionary mapping a URI to the name of the file containing
+  the vocabulary.
+
+Vocabularies matching URIs in the `VOCABULARIES` dictionary are first looked
+up locally, with the local file being used, if found. If not, a network lookup
+using the URI as the vocabulary location is used.
+
+Vocabulary URIs not in the `VOCABULARIES` dictionary are always looked up via
+the network.
+
+### Vocabulary Retrieval for Tests
+
+In general, unit tests should be run without making calls to the network, as
+making a network call makes the tests slower and less reliable.
+
+The retrieval of the vocabularies via the `__init__.py` module initializer is
+problematic for the tests, because the module initialization occurs before a
+test is even run. This makes normal methods of overriding the network calls
+ineffective. For example, trying to intercept the network calls using the
+“httpretty” library doesn’t work, because by the time the
+“@httpretty.activate” decorator is accessed, the module has already been
+initialized. The same is true when attempting to “monkey patch” the module.
+
+One method that was found to work was to add a
+`conftest.py` file into the root directory of the project, with a
+`pytest_configure` method. It is necessary to have the `conftest.py` in the
+root directory, so that it will always be used when running pytests in any of
+the Plastron modules (as those tests may use one of the content models with a
+vocabulary). This method runs as soon as pytest starts, and before any modules
+are loaded, providing an opportunity to set the “VOCABULARIES_DIR” and
+“VOCABULARIES” variables to values that are suitable for testing.
+
+Any vocabularies needed for the tests should be added as follows:
+
+1) Add a file containing the vocabulary (in "turtle" format) to the
+  "plastron-models/tests/data/vocabularies/" directory.
+
+2) In the `conftest.py` file in the root directory, add the vocabulary URI and
+   filename to the `VOCABULARIES` dictionary.
+
+Note that if a vocabulary is not added, a network call will still be attempted,
+due to the fallback behavior of the `get_vocabularies` method.

--- a/plastron-models/README.md
+++ b/plastron-models/README.md
@@ -56,9 +56,10 @@ One method that was found to work was to add a
 `pytest_configure` method. It is necessary to have the `conftest.py` in the
 root directory, so that it will always be used when running pytests in any of
 the Plastron modules (as those tests may use one of the content models with a
-vocabulary). This method runs as soon as pytest starts, and before any modules
-are loaded, providing an opportunity to set the “VOCABULARIES_DIR” and
-“VOCABULARIES” variables to values that are suitable for testing.
+vocabulary). The `pytest_configure` method runs as soon as pytest starts, and
+before any modules are loaded, providing an opportunity to set the
+“VOCABULARIES_DIR” and “VOCABULARIES” variables to values that are suitable for
+testing.
 
 Any vocabularies needed for the tests should be added as follows:
 

--- a/plastron-models/src/plastron/models/letter.py
+++ b/plastron-models/src/plastron/models/letter.py
@@ -52,6 +52,10 @@ class Letter(RDFResource):
     bibliographic_citation = DataProperty(dcterms.bibliographicCitation, required=True)
     extent = DataProperty(dcterms.extent, required=True)
     rights_holder = DataProperty(dcterms.rightsHolder, required=True)
+    terms_of_use = ObjectProperty(
+        dcterms.license,
+        validate=is_from_vocabulary('http://vocab.lib.umd.edu/termsOfUse#')
+    )
     handle = DataProperty(dcterms.identifier, datatype=umdtype.handle, validate=is_handle)
     presentation_set = ObjectProperty(
         ore.isAggregatedBy,
@@ -69,6 +73,7 @@ class Letter(RDFResource):
         'date': 'Date',
         'type': 'Resource Type',
         'rights': 'Rights',
+        'terms_of_use': 'Terms of Use',
         'copyright_notice': 'Copyright Notice',
         'subject': {
             'label': 'Subject',

--- a/plastron-models/src/plastron/models/newspaper.py
+++ b/plastron-models/src/plastron/models/newspaper.py
@@ -25,6 +25,10 @@ class Issue(PCDMObject):
         validate=is_from_vocabulary('http://vocab.lib.umd.edu/set#'),
     )
     copyright_notice = DataProperty(schema.copyrightNotice)
+    terms_of_use = ObjectProperty(
+        dcterms.license,
+        validate=is_from_vocabulary('http://vocab.lib.umd.edu/termsOfUse#')
+    )
 
     HEADER_MAP = {
         'title': 'Title',
@@ -35,6 +39,7 @@ class Issue(PCDMObject):
         'handle': 'Handle',
         'presentation_set': 'Presentation Set',
         'copyright_notice': 'Copyright Notice',
+        'terms_of_use': 'Terms of Use',
     }
 
 

--- a/plastron-models/src/plastron/models/poster.py
+++ b/plastron-models/src/plastron/models/poster.py
@@ -29,6 +29,10 @@ class Poster(PCDMObject):
     latitude = DataProperty(geo.lat)
     subject = ObjectProperty(dc.subject)
     rights = ObjectProperty(dcterms.rights, required=True)
+    terms_of_use = ObjectProperty(
+        dcterms.license,
+        validate=is_from_vocabulary('http://vocab.lib.umd.edu/termsOfUse#')
+    )
     copyright_notice = DataProperty(schema.copyrightNotice)
     identifier = DataProperty(dcterms.identifier, required=True)
     handle = DataProperty(dcterms.identifier, validate=is_handle, datatype=umdtype.handle)
@@ -57,6 +61,7 @@ class Poster(PCDMObject):
         'latitude': 'Latitude',
         'subject': 'Subject',
         'rights': 'Rights',
+        'terms_of_use': 'Terms of Use',
         'copyright_notice': 'Copyright Notice',
         'identifier': 'Identifier',
         'handle': 'Handle',

--- a/plastron-models/src/plastron/models/umd.py
+++ b/plastron-models/src/plastron/models/umd.py
@@ -54,6 +54,10 @@ class Item(PCDMObject, HandleBearingResource):
     subject = ObjectProperty(dcterms.subject, repeatable=True, embed=True, cls=LabeledThing)
     language = DataProperty(dc.language, repeatable=True, validate=is_valid_iso639_code)
     rights_holder = ObjectProperty(dcterms.rightsHolder, repeatable=True, embed=True, cls=LabeledThing)
+    terms_of_use = ObjectProperty(
+        dcterms.license,
+        validate=is_from_vocabulary('http://vocab.lib.umd.edu/termsOfUse#')
+    )
     copyright_notice = DataProperty(schema.copyrightNotice)
     bibliographic_citation = DataProperty(dcterms.bibliographicCitation)
     accession_number = DataProperty(dcterms.identifier, datatype=umdtype.accessionNumber)
@@ -92,6 +96,7 @@ class Item(PCDMObject, HandleBearingResource):
         'rights_holder': {
             'label': 'Rights Holder',
         },
+        'terms_of_use': 'Terms of Use',
         'copyright_notice': 'Copyright Notice',
         'bibliographic_citation': 'Collection Information',
         'accession_number': 'Accession Number',

--- a/plastron-models/src/plastron/validation/vocabularies/__init__.py
+++ b/plastron-models/src/plastron/validation/vocabularies/__init__.py
@@ -12,10 +12,14 @@ from plastron.validation import ValidationError
 
 logger = logging.getLogger(__name__)
 
-VOCABULARIES_DIR = Path(dirname(abspath(__file__)))
-VOCABULARIES = {
-    'http://purl.org/dc/dcmitype/': 'dcmitype.ttl',
-}
+# Enable VOCABULARIES_DIR and VOCABULARIES to be overridden for tests
+if 'VOCABULARIES_DIR' not in globals():
+    VOCABULARIES_DIR = Path(dirname(abspath(__file__)))
+
+if 'VOCABULARIES' not in globals():
+    VOCABULARIES = {
+        'http://purl.org/dc/dcmitype/': 'dcmitype.ttl',
+    }
 
 
 def get_vocabulary(vocab_uri: str) -> Graph:

--- a/plastron-models/tests/data/vocabularies/collection.ttl
+++ b/plastron-models/tests/data/vocabularies/collection.ttl
@@ -1,0 +1,5503 @@
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://vocab.lib.umd.edu/collection#0001-GDOC> rdfs:label "United States Government Posters";
+  dc:identifier "0001-GDOC" .
+
+<http://vocab.lib.umd.edu/collection#0001-GWP> rdfs:label "Victor E. Delnore papers";
+  dc:identifier "0001-GWP";
+  owl:sameAs <http://hdl.handle.net/1903.1/42448> .
+
+<http://vocab.lib.umd.edu/collection#0001-IPAM> rdfs:label "Victor Babin Collection";
+  dc:identifier "0001-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/42744> .
+
+<http://vocab.lib.umd.edu/collection#0001-LBR-RG28-003> rdfs:label "AFL, AFL-CIO Organization and Field Services Department, International and National Union Charter files";
+  dc:identifier "0001-LBR-RG28-003";
+  owl:sameAs <http://hdl.handle.net/1903.1/42449> .
+
+<http://vocab.lib.umd.edu/collection#0001-LIT> rdfs:label "Harold Dudley papers";
+  dc:identifier "0001-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1493> .
+
+<http://vocab.lib.umd.edu/collection#0001-LIT-RARE> rdfs:label "African American and African Pamphlet collection";
+  dc:identifier "0001-LIT-RARE";
+  owl:sameAs <http://hdl.handle.net/1903.1/11241> .
+
+<http://vocab.lib.umd.edu/collection#0001-MD> rdfs:label "Marylandia";
+  dc:identifier "0001-MD" .
+
+<http://vocab.lib.umd.edu/collection#0001-MDHC> rdfs:label "Richard White collection";
+  dc:identifier "0001-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1207> .
+
+<http://vocab.lib.umd.edu/collection#0001-MDHC-NTL> rdfs:label "National Trust Library Historic Postcard collection";
+  dc:identifier "0001-MDHC-NTL";
+  owl:sameAs <http://hdl.handle.net/1903.1/11274> .
+
+<http://vocab.lib.umd.edu/collection#0001-MDMAP> rdfs:label "Maryland Map Collection";
+  dc:identifier "0001-MDMAP" .
+
+<http://vocab.lib.umd.edu/collection#0001-MMC-LAB> rdfs:label "Julie Stevens papers";
+  dc:identifier "0001-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/1483> .
+
+<http://vocab.lib.umd.edu/collection#0001-SCPA> rdfs:label "Victor Zajec papers";
+  dc:identifier "0001-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1209> .
+
+<http://vocab.lib.umd.edu/collection#0001-UA> rdfs:label "Department of Agricultural and Resource Economics records";
+  dc:identifier "0001-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1761> .
+
+<http://vocab.lib.umd.edu/collection#0002-GWP> rdfs:label "Virginia W. Beauchamp papers";
+  dc:identifier "0002-GWP";
+  owl:sameAs <http://hdl.handle.net/1903.1/42450> .
+
+<http://vocab.lib.umd.edu/collection#0002-IPAM> rdfs:label "Emil Danenberg Collection";
+  dc:identifier "0002-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/19359> .
+
+<http://vocab.lib.umd.edu/collection#0002-LBR-RG28-007> rdfs:label "Organization and Field Services Department, AFL Federal Local Union (FLU), CIO Local Industrial Union (LIU), and AFL-CIO Directly Affiliated Local Union (DALU) Charter Records";
+  dc:identifier "0002-LBR-RG28-007";
+  owl:sameAs <http://hdl.handle.net/1903.1/42451> .
+
+<http://vocab.lib.umd.edu/collection#0002-LIT> rdfs:label "Seymour Lawrence papers";
+  dc:identifier "0002-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1494> .
+
+<http://vocab.lib.umd.edu/collection#0002-LIT-RARE> rdfs:label "Carolyn Davis collection of Louisa May Alcott";
+  dc:identifier "0002-LIT-RARE";
+  owl:sameAs <http://hdl.handle.net/1903.1/11248> .
+
+<http://vocab.lib.umd.edu/collection#0002-MDHC> rdfs:label "Original Newspaper collection";
+  dc:identifier "0002-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/13186> .
+
+<http://vocab.lib.umd.edu/collection#0002-MMC-LAB> rdfs:label "Betty Garde Papers";
+  dc:identifier "0002-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/1484> .
+
+<http://vocab.lib.umd.edu/collection#0002-SCPA> rdfs:label "Asher G. Zlotnik papers";
+  dc:identifier "0002-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1210> .
+
+<http://vocab.lib.umd.edu/collection#0002-UA> rdfs:label "Office of the Chancellor records";
+  dc:identifier "0002-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1762> .
+
+<http://vocab.lib.umd.edu/collection#0003-GWP> rdfs:label "Lois Beno papers";
+  dc:identifier "0003-GWP";
+  owl:sameAs <http://hdl.handle.net/1903.1/42452> .
+
+<http://vocab.lib.umd.edu/collection#0003-IPAM> rdfs:label "Mark Hambourg Collection";
+  dc:identifier "0003-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/19360> .
+
+<http://vocab.lib.umd.edu/collection#0003-LBR-RG4-010> rdfs:label "Federation of Organized Trades and Labor Unions (FOTLU) of the United States and Canada, and American Federation of Labor (AFL), Early Federation records";
+  dc:identifier "0003-LBR-RG4-010";
+  owl:sameAs <http://hdl.handle.net/1903.1/42453> .
+
+<http://vocab.lib.umd.edu/collection#0003-LIT> rdfs:label "Laura Riding Jackson papers";
+  dc:identifier "0003-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1495> .
+
+<http://vocab.lib.umd.edu/collection#0003-LIT-RARE> rdfs:label "Stanbrook Abbey collection";
+  dc:identifier "0003-LIT-RARE";
+  owl:sameAs <http://hdl.handle.net/1903.1/13688> .
+
+<http://vocab.lib.umd.edu/collection#0003-MDHC> rdfs:label "Preservation Maryland records";
+  dc:identifier "0003-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/13395> .
+
+<http://vocab.lib.umd.edu/collection#0003-MMC-LAB> rdfs:label "The Helen Faith Keane collection";
+  dc:identifier "0003-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/1485> .
+
+<http://vocab.lib.umd.edu/collection#0003-SCPA> rdfs:label "Charles B. Fowler Papers";
+  dc:identifier "0003-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1211> .
+
+<http://vocab.lib.umd.edu/collection#0003-SCPA-505> rdfs:label "Myron Welch papers";
+  dc:identifier "0003-SCPA-505";
+  owl:sameAs <http://hdl.handle.net/1903.1/42203> .
+
+<http://vocab.lib.umd.edu/collection#0003-UA> rdfs:label "Council of Administration records";
+  dc:identifier "0003-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1763> .
+
+<http://vocab.lib.umd.edu/collection#0004-GWP> rdfs:label "Mark M. Biegel papers and photographs";
+  dc:identifier "0004-GWP";
+  owl:sameAs <http://hdl.handle.net/1903.1/42454> .
+
+<http://vocab.lib.umd.edu/collection#0004-IPAM> rdfs:label "Mario Braggiotti Collection";
+  dc:identifier "0004-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/19361> .
+
+<http://vocab.lib.umd.edu/collection#0004-LBR-RG4-009> rdfs:label "CIO Executive Board proceedings";
+  dc:identifier "0004-LBR-RG4-009";
+  owl:sameAs <http://hdl.handle.net/1903.1/42455> .
+
+<http://vocab.lib.umd.edu/collection#0004-LIT> rdfs:label "Jack Hoffenberg papers";
+  dc:identifier "0004-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1496> .
+
+<http://vocab.lib.umd.edu/collection#0004-LIT-RARE> rdfs:label "French Pamphlet collection";
+  dc:identifier "0004-LIT-RARE";
+  owl:sameAs <http://hdl.handle.net/1903.1/14175> .
+
+<http://vocab.lib.umd.edu/collection#0004-MDHC> rdfs:label "Grimes Family papers";
+  dc:identifier "0004-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1738> .
+
+<http://vocab.lib.umd.edu/collection#0004-MMC-LAB> rdfs:label "Gertrude Entenmann papers";
+  dc:identifier "0004-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/1486> .
+
+<http://vocab.lib.umd.edu/collection#0004-SCPA> rdfs:label "International Society for Music Education Archives";
+  dc:identifier "0004-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1212> .
+
+<http://vocab.lib.umd.edu/collection#0004-SCPA-CLAXTON> rdfs:label "Aaron Claxton collection on D.C. Hardcore";
+  dc:identifier "0004-SCPA-CLAXTON";
+  owl:sameAs <http://hdl.handle.net/1903.1/42417> .
+
+<http://vocab.lib.umd.edu/collection#0004-UA> rdfs:label "General Administrative Board records";
+  dc:identifier "0004-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1764> .
+
+<http://vocab.lib.umd.edu/collection#0005-GWP> rdfs:label "Emerson Chapin photographs and slides";
+  dc:identifier "0005-GWP";
+  owl:sameAs <http://hdl.handle.net/1903.1/42456> .
+
+<http://vocab.lib.umd.edu/collection#0005-IPAM> rdfs:label "Reginald Gerig Collection";
+  dc:identifier "0005-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/19378> .
+
+<http://vocab.lib.umd.edu/collection#0005-LBR-RG95-004> rdfs:label "Trades Union Congress papers";
+  dc:identifier "0005-LBR-RG95-004";
+  owl:sameAs <http://hdl.handle.net/1903.1/42457> .
+
+<http://vocab.lib.umd.edu/collection#0005-LIT> rdfs:label "Ann Heintze papers";
+  dc:identifier "0005-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1497> .
+
+<http://vocab.lib.umd.edu/collection#0005-LIT-RARE> rdfs:label "Robert Frost Book collection";
+  dc:identifier "0005-LIT-RARE";
+  owl:sameAs <http://hdl.handle.net/1903.1/13765> .
+
+<http://vocab.lib.umd.edu/collection#0005-MMC-LAB> rdfs:label "Mona Kent papers";
+  dc:identifier "0005-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/1487> .
+
+<http://vocab.lib.umd.edu/collection#0005-SCPA> rdfs:label "Lester Cowan and Ann Ronell \"Trial of Billie Holiday\" collection";
+  dc:identifier "0005-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1213> .
+
+<http://vocab.lib.umd.edu/collection#0005-UA> rdfs:label "Farmers' Institutes records";
+  dc:identifier "0005-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1765> .
+
+<http://vocab.lib.umd.edu/collection#0006-GWP> rdfs:label "Kenneth E. Colton papers";
+  dc:identifier "0006-GWP";
+  owl:sameAs <http://hdl.handle.net/1903.1/42458> .
+
+<http://vocab.lib.umd.edu/collection#0006-IPAM> rdfs:label "Solveig Lunde Madsen Collection";
+  dc:identifier "0006-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/19379> .
+
+<http://vocab.lib.umd.edu/collection#0006-LBR-RG2-010> rdfs:label "AFL and AFL-CIO Secretary-Treasurer's Office, Charter Books";
+  dc:identifier "0006-LBR-RG2-010";
+  owl:sameAs <http://hdl.handle.net/1903.1/42459> .
+
+<http://vocab.lib.umd.edu/collection#0006-LIT-RARE> rdfs:label "George Levitine Book collection";
+  dc:identifier "0006-LIT-RARE";
+  owl:sameAs <http://hdl.handle.net/1903.1/13955> .
+
+<http://vocab.lib.umd.edu/collection#0006-MDHC> rdfs:label "Brooke Family papers";
+  dc:identifier "0006-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1740> .
+
+<http://vocab.lib.umd.edu/collection#0006-MMC-LAB> rdfs:label "Lee Lawrence papers";
+  dc:identifier "0006-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/1488> .
+
+<http://vocab.lib.umd.edu/collection#0006-SCPA> rdfs:label "Patrick Gilmore collection";
+  dc:identifier "0006-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1214> .
+
+<http://vocab.lib.umd.edu/collection#0006-UA> rdfs:label "Faculty Meetings records";
+  dc:identifier "0006-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1415> .
+
+<http://vocab.lib.umd.edu/collection#0007-GWP> rdfs:label "Owen Cunningham papers";
+  dc:identifier "0007-GWP";
+  owl:sameAs <http://hdl.handle.net/1903.1/42680> .
+
+<http://vocab.lib.umd.edu/collection#0007-IPAM> rdfs:label "Theodore Lettvin Collection";
+  dc:identifier "0007-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/19398> .
+
+<http://vocab.lib.umd.edu/collection#0007-LBR-RG13-004> rdfs:label "CIO Research Department, Everett Kassalow papers";
+  dc:identifier "0007-LBR-RG13-004";
+  owl:sameAs <http://hdl.handle.net/1903.1/42681> .
+
+<http://vocab.lib.umd.edu/collection#0007-LIT> rdfs:label "Thom Gunn papers";
+  dc:identifier "0007-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1499> .
+
+<http://vocab.lib.umd.edu/collection#0007-LIT-RARE> rdfs:label "First Appearances collection";
+  dc:identifier "0007-LIT-RARE";
+  owl:sameAs <http://hdl.handle.net/1903.1/13957> .
+
+<http://vocab.lib.umd.edu/collection#0007-MDHC> rdfs:label "Institute of American Deltiology Postcard collection";
+  dc:identifier "0007-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/13264> .
+
+<http://vocab.lib.umd.edu/collection#0007-MMC-NPBA> rdfs:label "Luke F. Lamb Papers";
+  dc:identifier "0007-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1559> .
+
+<http://vocab.lib.umd.edu/collection#0007-SCPA> rdfs:label "Lowell Mason Collection";
+  dc:identifier "0007-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1215> .
+
+<http://vocab.lib.umd.edu/collection#0007-UA> rdfs:label "Epsilon Sigma Phi records";
+  dc:identifier "0007-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1416> .
+
+<http://vocab.lib.umd.edu/collection#0008-GWP> rdfs:label "John R. Harold papers";
+  dc:identifier "0008-GWP";
+  owl:sameAs <http://hdl.handle.net/1903.1/42682> .
+
+<http://vocab.lib.umd.edu/collection#0008-IPAM> rdfs:label "Tobias Matthay Collection";
+  dc:identifier "0008-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/19399> .
+
+<http://vocab.lib.umd.edu/collection#0008-LBR-RG4-005> rdfs:label "AFL Executive Council, Samuel Gompers Memorial Committee records";
+  dc:identifier "0008-LBR-RG4-005";
+  owl:sameAs <http://hdl.handle.net/1903.1/42684> .
+
+<http://vocab.lib.umd.edu/collection#0008-LIT> rdfs:label "Albert Gross papers";
+  dc:identifier "0008-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1500> .
+
+<http://vocab.lib.umd.edu/collection#0008-MDHC> rdfs:label "Davis Family papers";
+  dc:identifier "0008-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1742> .
+
+<http://vocab.lib.umd.edu/collection#0008-MMC-LAB> rdfs:label "Pegeen Fitzgerald papers";
+  dc:identifier "0008-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/1489> .
+
+<http://vocab.lib.umd.edu/collection#0008-SCPA> rdfs:label "James J. Taylor Collection of the Washington Area Performing Arts Video Archive";
+  dc:identifier "0008-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1216> .
+
+<http://vocab.lib.umd.edu/collection#0008-UA> rdfs:label "Department of Entomology records";
+  dc:identifier "0008-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1417> .
+
+<http://vocab.lib.umd.edu/collection#0009-GWP> rdfs:label "Albert W. Hilberg Atomic Bomb Casualty Commission collection";
+  dc:identifier "0009-GWP";
+  owl:sameAs <http://hdl.handle.net/1903.1/42460> .
+
+<http://vocab.lib.umd.edu/collection#0009-IPAM> rdfs:label "Walter Robert Collection";
+  dc:identifier "0009-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/19400> .
+
+<http://vocab.lib.umd.edu/collection#0009-LBR-RG4-008> rdfs:label "American Federation of Labor (AFL), Executive Council minutes";
+  dc:identifier "0009-LBR-RG4-008";
+  owl:sameAs <http://hdl.handle.net/1903.1/42462> .
+
+<http://vocab.lib.umd.edu/collection#0009-LIT> rdfs:label "Elsa von Freytag-Loringhoven papers";
+  dc:identifier "0009-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1501> .
+
+<http://vocab.lib.umd.edu/collection#0009-MDHC> rdfs:label "Work Projects Administration in Maryland records";
+  dc:identifier "0009-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1743> .
+
+<http://vocab.lib.umd.edu/collection#0009-MMC-NPBA> rdfs:label "Susan Stamberg papers";
+  dc:identifier "0009-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/4604> .
+
+<http://vocab.lib.umd.edu/collection#0009-SCPA> rdfs:label "Jim Henson collection";
+  dc:identifier "0009-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1217> .
+
+<http://vocab.lib.umd.edu/collection#0009-UA> rdfs:label "College of Education records";
+  dc:identifier "0009-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1418> .
+
+<http://vocab.lib.umd.edu/collection#0010-GWP> rdfs:label "Charles L. Kades papers";
+  dc:identifier "0010-GWP";
+  owl:sameAs <http://hdl.handle.net/1903.1/42463> .
+
+<http://vocab.lib.umd.edu/collection#0010-IPAM> rdfs:label "Yarbrough and Cowan Collection";
+  dc:identifier "0010-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/19425> .
+
+<http://vocab.lib.umd.edu/collection#0010-LBR-RG2-001> rdfs:label "AFL Secretary-Treasurer's Office, Gabriel Edmonston papers";
+  dc:identifier "0010-LBR-RG2-001";
+  owl:sameAs <http://hdl.handle.net/1903.1/42464> .
+
+<http://vocab.lib.umd.edu/collection#0010-MDHC> rdfs:label "Spiro T. Agnew papers";
+  dc:identifier "0010-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1744> .
+
+<http://vocab.lib.umd.edu/collection#0010-MMC-NPBA> rdfs:label "Mary Aladj papers";
+  dc:identifier "0010-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1560> .
+
+<http://vocab.lib.umd.edu/collection#0010-SCPA> rdfs:label "Daniel Bonade papers";
+  dc:identifier "0010-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1218> .
+
+<http://vocab.lib.umd.edu/collection#0010-UA> rdfs:label "Committee on Courses of Study records";
+  dc:identifier "0010-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1419> .
+
+<http://vocab.lib.umd.edu/collection#0011-GWP> rdfs:label "Mead Smith Karras papers";
+  dc:identifier "0011-GWP";
+  owl:sameAs <http://hdl.handle.net/1903.1/42470> .
+
+<http://vocab.lib.umd.edu/collection#0011-IPAM> rdfs:label "Balint Vazsonyi Collection";
+  dc:identifier "0011-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/19604> .
+
+<http://vocab.lib.umd.edu/collection#0011-LBR-RG95-013> rdfs:label "National Capital Area Trade Union Retirees Club, Paul A. Wagner Oral History Project records";
+  dc:identifier "0011-LBR-RG95-013";
+  owl:sameAs <http://hdl.handle.net/1903.1/42471> .
+
+<http://vocab.lib.umd.edu/collection#0011-LIT> rdfs:label "Maurice Annenberg papers";
+  dc:identifier "0011-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1503> .
+
+<http://vocab.lib.umd.edu/collection#0011-MDHC> rdfs:label "Adelphi Citizens Association records";
+  dc:identifier "0011-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1745> .
+
+<http://vocab.lib.umd.edu/collection#0011-MMC-LAB> rdfs:label "Inga Rundvold papers";
+  dc:identifier "0011-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/3300> .
+
+<http://vocab.lib.umd.edu/collection#0011-SCPA> rdfs:label "Liz Lerman Dance Exchange official records";
+  dc:identifier "0011-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1219> .
+
+<http://vocab.lib.umd.edu/collection#0011-UA> rdfs:label "Counseling Center records";
+  dc:identifier "0011-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1420> .
+
+<http://vocab.lib.umd.edu/collection#0012-GWP> rdfs:label "Mary Koehler slides";
+  dc:identifier "0012-GWP";
+  owl:sameAs <http://hdl.handle.net/1903.1/42472> .
+
+<http://vocab.lib.umd.edu/collection#0012-IPAM> rdfs:label "Earl Wild Collection";
+  dc:identifier "0012-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/19605> .
+
+<http://vocab.lib.umd.edu/collection#0012-LBR-RG98-005> rdfs:label "AFL-CIO Merger Oral History Project collection";
+  dc:identifier "0012-LBR-RG98-005";
+  owl:sameAs <http://hdl.handle.net/1903.1/42473> .
+
+<http://vocab.lib.umd.edu/collection#0012-LIT> rdfs:label "Donald Elder papers";
+  dc:identifier "0012-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1504> .
+
+<http://vocab.lib.umd.edu/collection#0012-MDHC> rdfs:label "Felix Agnus papers";
+  dc:identifier "0012-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1746> .
+
+<http://vocab.lib.umd.edu/collection#0012-MMC-LAB> rdfs:label "Martha Brooks papers";
+  dc:identifier "0012-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/1491> .
+
+<http://vocab.lib.umd.edu/collection#0012-SCPA> rdfs:label "Maryland Dance Theater records";
+  dc:identifier "0012-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1220> .
+
+<http://vocab.lib.umd.edu/collection#0012-UA> rdfs:label "Cooperative Extension Service (CES) records";
+  dc:identifier "0012-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1421> .
+
+<http://vocab.lib.umd.edu/collection#0013-GWP> rdfs:label "Robert P. Schuster photographs and negatives";
+  dc:identifier "0013-GWP";
+  owl:sameAs <http://hdl.handle.net/1903.1/42474> .
+
+<http://vocab.lib.umd.edu/collection#0013-IPAM> rdfs:label "Lee Luvisi Collection";
+  dc:identifier "0013-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/24334> .
+
+<http://vocab.lib.umd.edu/collection#0013-LBR-RG1-040> rdfs:label "AFL Office of the President, Building Cornerstone collection";
+  dc:identifier "0013-LBR-RG1-040";
+  owl:sameAs <http://hdl.handle.net/1903.1/42475> .
+
+<http://vocab.lib.umd.edu/collection#0013-LIT> rdfs:label "Louise Malloy papers";
+  dc:identifier "0013-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1505> .
+
+<http://vocab.lib.umd.edu/collection#0013-MDHC> rdfs:label "John H. Alexander papers";
+  dc:identifier "0013-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1747> .
+
+<http://vocab.lib.umd.edu/collection#0013-MMC-LAB> rdfs:label "Fran Harris-Tuchman papers";
+  dc:identifier "0013-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/1492> .
+
+<http://vocab.lib.umd.edu/collection#0013-SCPA> rdfs:label "Claude T. Smith Collection";
+  dc:identifier "0013-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1221> .
+
+<http://vocab.lib.umd.edu/collection#0013-UA> rdfs:label "Office of the Comptroller records";
+  dc:identifier "0013-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1422> .
+
+<http://vocab.lib.umd.edu/collection#0014-GWP> rdfs:label "Leora Smith photographs";
+  dc:identifier "0014-GWP";
+  owl:sameAs <http://hdl.handle.net/1903.1/42476> .
+
+<http://vocab.lib.umd.edu/collection#0014-IPAM> rdfs:label "Louis Crowder Collection";
+  dc:identifier "0014-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/24317> .
+
+<http://vocab.lib.umd.edu/collection#0014-LBR-RG18-008> rdfs:label "AFL and AFL-CIO International Affairs Department, AFL Advisors to the United Nations Economic and Social Council records";
+  dc:identifier "0014-LBR-RG18-008";
+  owl:sameAs <http://hdl.handle.net/1903.1/42477> .
+
+<http://vocab.lib.umd.edu/collection#0014-LIT> rdfs:label "Dryad Press records";
+  dc:identifier "0014-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1506> .
+
+<http://vocab.lib.umd.edu/collection#0014-MDHC> rdfs:label "Maryland Division of the American Association of University Women (AAUW) records";
+  dc:identifier "0014-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1748> .
+
+<http://vocab.lib.umd.edu/collection#0014-MMC-LAB> rdfs:label "Helen Sioussat papers";
+  dc:identifier "0014-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/3298> .
+
+<http://vocab.lib.umd.edu/collection#0014-SCPA> rdfs:label "The Charles H. Eisenhardt Jr. papers";
+  dc:identifier "0014-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1754> .
+
+<http://vocab.lib.umd.edu/collection#0014-UA> rdfs:label "Morris Freedman papers";
+  dc:identifier "0014-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1502> .
+
+<http://vocab.lib.umd.edu/collection#0015-GWP> rdfs:label "Marlene J. Mayo oral histories";
+  dc:identifier "0015-GWP";
+  owl:sameAs <http://hdl.handle.net/1903.1/42478> .
+
+<http://vocab.lib.umd.edu/collection#0015-IPAM> rdfs:label "Helen McGraw Collection";
+  dc:identifier "0015-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/24316> .
+
+<http://vocab.lib.umd.edu/collection#0015-LBR-RG1-010> rdfs:label "AFL Office of the President, Rosa Lee Guard papers";
+  dc:identifier "0015-LBR-RG1-010";
+  owl:sameAs <http://hdl.handle.net/1903.1/42480> .
+
+<http://vocab.lib.umd.edu/collection#0015-LIT> rdfs:label "Mary Louis Doherty papers";
+  dc:identifier "0015-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1507> .
+
+<http://vocab.lib.umd.edu/collection#0015-MDHC> rdfs:label "Clara Barton papers";
+  dc:identifier "0015-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1749> .
+
+<http://vocab.lib.umd.edu/collection#0015-MMC-LAB> rdfs:label "American Women in Radio and Television (AWRT) records";
+  dc:identifier "0015-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/3299> .
+
+<http://vocab.lib.umd.edu/collection#0015-SCPA> rdfs:label "Lynn Steele papers";
+  dc:identifier "0015-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1755> .
+
+<http://vocab.lib.umd.edu/collection#0015-UA> rdfs:label "College Park Senate records";
+  dc:identifier "0015-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1424> .
+
+<http://vocab.lib.umd.edu/collection#0016-GWP> rdfs:label "Justin Williams papers";
+  dc:identifier "0016-GWP";
+  owl:sameAs <http://hdl.handle.net/1903.1/42481> .
+
+<http://vocab.lib.umd.edu/collection#0016-IPAM> rdfs:label "Robert Casadesus Collection";
+  dc:identifier "0016-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/24319> .
+
+<http://vocab.lib.umd.edu/collection#0016-LBR-RG28-001> rdfs:label "AFL Federal Local Unions (FLUs) and AFL-CIO Directly Affiliated Local Unions (DALUs) Charter records";
+  dc:identifier "0016-LBR-RG28-001";
+  owl:sameAs <http://hdl.handle.net/1903.1/42483> .
+
+<http://vocab.lib.umd.edu/collection#0016-LIT> rdfs:label "Irwin Cohen collection";
+  dc:identifier "0016-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1508> .
+
+<http://vocab.lib.umd.edu/collection#0016-MMC> rdfs:label "Mark Olds Papers";
+  dc:identifier "0016-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42482> .
+
+<http://vocab.lib.umd.edu/collection#0016-MMC-LAB> rdfs:label "<title>Housewives' Protective League</title> collection";
+  dc:identifier "0016-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/4587> .
+
+<http://vocab.lib.umd.edu/collection#0016-SCPA> rdfs:label "American Bandmasters Association official records";
+  dc:identifier "0016-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1756> .
+
+<http://vocab.lib.umd.edu/collection#0016-UA> rdfs:label "Graduate Faculty records";
+  dc:identifier "0016-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1425> .
+
+<http://vocab.lib.umd.edu/collection#0017-IPAM> rdfs:label "Abram Chasins Collection";
+  dc:identifier "0017-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/24318> .
+
+<http://vocab.lib.umd.edu/collection#0017-LBR-RG41-001> rdfs:label "Industrial Union Department publications";
+  dc:identifier "0017-LBR-RG41-001";
+  owl:sameAs <http://hdl.handle.net/1903.1/42484> .
+
+<http://vocab.lib.umd.edu/collection#0017-LIT> rdfs:label "Vincent Godfrey Burns papers";
+  dc:identifier "0017-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1509> .
+
+<http://vocab.lib.umd.edu/collection#0017-MMC> rdfs:label "National Association of Broadcasters (NAB) records";
+  dc:identifier "0017-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42110> .
+
+<http://vocab.lib.umd.edu/collection#0017-SCPA> rdfs:label "National Association for Music Education Historical Center";
+  dc:identifier "0017-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1757> .
+
+<http://vocab.lib.umd.edu/collection#0017-UA> rdfs:label "Bureau of Business and Economic Research records";
+  dc:identifier "0017-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1426> .
+
+<http://vocab.lib.umd.edu/collection#0018-IPAM> rdfs:label "William Kapell Collection";
+  dc:identifier "0018-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/24321> .
+
+<http://vocab.lib.umd.edu/collection#0018-LBR-RG1-039> rdfs:label "AFL-CIO Office of the President, Joint Minimum Wage Committee records";
+  dc:identifier "0018-LBR-RG1-039";
+  owl:sameAs <http://hdl.handle.net/1903.1/42485> .
+
+<http://vocab.lib.umd.edu/collection#0018-LIT> rdfs:label "George Barker papers";
+  dc:identifier "0018-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/7432> .
+
+<http://vocab.lib.umd.edu/collection#0018-MMC> rdfs:label "Jeff Krulik papers";
+  dc:identifier "0018-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42144> .
+
+<http://vocab.lib.umd.edu/collection#0018-MMC-LAB> rdfs:label "WRKL Station records";
+  dc:identifier "0018-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/5401> .
+
+<http://vocab.lib.umd.edu/collection#0018-SCPA> rdfs:label "International Clarinet Association Research Center";
+  dc:identifier "0018-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1758> .
+
+<http://vocab.lib.umd.edu/collection#0018-UA> rdfs:label "Administrative Board records";
+  dc:identifier "0018-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1675> .
+
+<http://vocab.lib.umd.edu/collection#0019-IPAM> rdfs:label "Carl Friedberg Collection";
+  dc:identifier "0019-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/24320> .
+
+<http://vocab.lib.umd.edu/collection#0019-LBR-RG1-028> rdfs:label "AFL-CIO Office of the President, State and Local Central Bodies Merger records";
+  dc:identifier "0019-LBR-RG1-028";
+  owl:sameAs <http://hdl.handle.net/1903.1/42486> .
+
+<http://vocab.lib.umd.edu/collection#0019-MDHC> rdfs:label "Paul Dennis Brown Family papers";
+  dc:identifier "0019-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1721> .
+
+<http://vocab.lib.umd.edu/collection#0019-MMC-LAB> rdfs:label "Deena Clark papers";
+  dc:identifier "0019-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/42487> .
+
+<http://vocab.lib.umd.edu/collection#0019-SCPA> rdfs:label "John Curwen Manuscripts";
+  dc:identifier "0019-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1759> .
+
+<http://vocab.lib.umd.edu/collection#0019-UA> rdfs:label "Maryland Agricultural Experiment Station records";
+  dc:identifier "0019-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1676> .
+
+<http://vocab.lib.umd.edu/collection#0020-IPAM> rdfs:label "Ivan Wyschnegradsky Collection";
+  dc:identifier "0020-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/24331> .
+
+<http://vocab.lib.umd.edu/collection#0020-LBR-RG1-041> rdfs:label "AFL and AFL-CIO Office of the President, Jurisdiction Books";
+  dc:identifier "0020-LBR-RG1-041";
+  owl:sameAs <http://hdl.handle.net/1903.1/42488> .
+
+<http://vocab.lib.umd.edu/collection#0020-LIT> rdfs:label "Saxon Barnes papers";
+  dc:identifier "0020-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1511> .
+
+<http://vocab.lib.umd.edu/collection#0020-MDHC> rdfs:label "Chapman Family papers";
+  dc:identifier "0020-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1722> .
+
+<http://vocab.lib.umd.edu/collection#0020-MMC-NPBA> rdfs:label "Kenneth J. Garry Papers";
+  dc:identifier "0020-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1570> .
+
+<http://vocab.lib.umd.edu/collection#0020-SCPA> rdfs:label "Edwin Franko Goldman papers";
+  dc:identifier "0020-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1760> .
+
+<http://vocab.lib.umd.edu/collection#0021-IPAM> rdfs:label "Ada Richter Collection";
+  dc:identifier "0021-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/24330> .
+
+<http://vocab.lib.umd.edu/collection#0021-LBR-RG28-005> rdfs:label "AFL and AFL-CIO Organization and Field Services Department, State Charter records";
+  dc:identifier "0021-LBR-RG28-005";
+  owl:sameAs <http://hdl.handle.net/1903.1/42489> .
+
+<http://vocab.lib.umd.edu/collection#0021-LIT> rdfs:label "Djuna Barnes papers";
+  dc:identifier "0021-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1512> .
+
+<http://vocab.lib.umd.edu/collection#0021-MMC-LAB> rdfs:label "Roger Bower papers";
+  dc:identifier "0021-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/4921> .
+
+<http://vocab.lib.umd.edu/collection#0021-MMC-NPBA> rdfs:label "Ralph W. Steetle Papers";
+  dc:identifier "0021-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1571> .
+
+<http://vocab.lib.umd.edu/collection#0021-SCPA> rdfs:label "Madeleine Bartfeld Sigel collection of autographs and performing arts memorabilia";
+  dc:identifier "0021-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1766> .
+
+<http://vocab.lib.umd.edu/collection#0021-UA> rdfs:label "Alumni Office records";
+  dc:identifier "0021-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1678> .
+
+<http://vocab.lib.umd.edu/collection#0022-IPAM> rdfs:label "William Masselos Collection";
+  dc:identifier "0022-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/24322> .
+
+<http://vocab.lib.umd.edu/collection#0022-LBR-RG28-008> rdfs:label "AFL-CIO Organization and Field Services Department, Local Central Body Constitutions and Bylaws records";
+  dc:identifier "0022-LBR-RG28-008";
+  owl:sameAs <http://hdl.handle.net/1903.1/42490> .
+
+<http://vocab.lib.umd.edu/collection#0022-LIT> rdfs:label "Barnes Family papers";
+  dc:identifier "0022-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1513> .
+
+<http://vocab.lib.umd.edu/collection#0022-MDHC> rdfs:label "Charles Wallace Collins papers";
+  dc:identifier "0022-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1724> .
+
+<http://vocab.lib.umd.edu/collection#0022-SCPA> rdfs:label "George C. Wilson papers";
+  dc:identifier "0022-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/20550> .
+
+<http://vocab.lib.umd.edu/collection#0022-UA> rdfs:label "Associated Women Students records";
+  dc:identifier "0022-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1679> .
+
+<http://vocab.lib.umd.edu/collection#0023-IPAM> rdfs:label "Joseph Bloch Collection";
+  dc:identifier "0023-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/24332> .
+
+<http://vocab.lib.umd.edu/collection#0023-LBR-RG98-001> rdfs:label "Union Labels, Letterheads and Logo collection";
+  dc:identifier "0023-LBR-RG98-001";
+  owl:sameAs <http://hdl.handle.net/1903.1/42491> .
+
+<http://vocab.lib.umd.edu/collection#0023-LIT> rdfs:label "Edna Frederikson papers";
+  dc:identifier "0023-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1514> .
+
+<http://vocab.lib.umd.edu/collection#0023-MDHC> rdfs:label "Colt and Donaldson records";
+  dc:identifier "0023-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1725> .
+
+<http://vocab.lib.umd.edu/collection#0023-SCPA> rdfs:label "Paul V. Yoder papers";
+  dc:identifier "0023-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1768> .
+
+<http://vocab.lib.umd.edu/collection#0023-UA> rdfs:label "College Park Faculty Assembly records";
+  dc:identifier "0023-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1680> .
+
+<http://vocab.lib.umd.edu/collection#0024-IPAM> rdfs:label "Jorge Bolet Collection";
+  dc:identifier "0024-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/24325> .
+
+<http://vocab.lib.umd.edu/collection#0024-LBR-RG5-001> rdfs:label "AFL-CIO Office of the General Counsel, Lawyers Coordinating Committee Oral History Project records";
+  dc:identifier "0024-LBR-RG5-001";
+  owl:sameAs <http://hdl.handle.net/1903.1/42493> .
+
+<http://vocab.lib.umd.edu/collection#0024-LIT> rdfs:label "Mary Carter Roberts papers";
+  dc:identifier "0024-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1515> .
+
+<http://vocab.lib.umd.edu/collection#0024-MMC-LAB> rdfs:label "Norman R. Glenn papers";
+  dc:identifier "0024-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/20700> .
+
+<http://vocab.lib.umd.edu/collection#0024-SCPA> rdfs:label "21st Century Consort records";
+  dc:identifier "0024-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1771> .
+
+<http://vocab.lib.umd.edu/collection#0024-UA> rdfs:label "Department of Botany records";
+  dc:identifier "0024-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1681> .
+
+<http://vocab.lib.umd.edu/collection#0025-IPAM> rdfs:label "Katherine Bacon Collection";
+  dc:identifier "0025-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/24324> .
+
+<http://vocab.lib.umd.edu/collection#0025-LBR-RG1-011> rdfs:label "AFL Office of the President, Samuel Gompers' letterbooks";
+  dc:identifier "0025-LBR-RG1-011";
+  owl:sameAs <http://hdl.handle.net/1903.1/42494> .
+
+<http://vocab.lib.umd.edu/collection#0025-LIT> rdfs:label "Authors and Poets collection";
+  dc:identifier "0025-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1516> .
+
+<http://vocab.lib.umd.edu/collection#0025-MMC> rdfs:label "INSPIRE Records";
+  dc:identifier "0025-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/21271> .
+
+<http://vocab.lib.umd.edu/collection#0025-SCPA> rdfs:label "Frances Elliott Clark papers";
+  dc:identifier "0025-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1772> .
+
+<http://vocab.lib.umd.edu/collection#0025-UA> rdfs:label "College Park Campus Senate records";
+  dc:identifier "0025-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1682> .
+
+<http://vocab.lib.umd.edu/collection#0026-IPAM> rdfs:label "Alexander Siloti Collection";
+  dc:identifier "0026-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/24333> .
+
+<http://vocab.lib.umd.edu/collection#0026-LBR-RG95-006> rdfs:label "William Baillie Baird papers";
+  dc:identifier "0026-LBR-RG95-006";
+  owl:sameAs <http://hdl.handle.net/1903.1/42497> .
+
+<http://vocab.lib.umd.edu/collection#0026-LIT> rdfs:label "Herbert Schaumann papers";
+  dc:identifier "0026-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1517> .
+
+<http://vocab.lib.umd.edu/collection#0026-MDHC> rdfs:label "Hamilton Family papers";
+  dc:identifier "0026-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1728> .
+
+<http://vocab.lib.umd.edu/collection#0026-SCPA> rdfs:label "Archives of The Midwest Clinic, An International Band and Orchestra Conference";
+  dc:identifier "0026-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/2988> .
+
+<http://vocab.lib.umd.edu/collection#0026-UA> rdfs:label "College of Business and Public Administration records";
+  dc:identifier "0026-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1683> .
+
+<http://vocab.lib.umd.edu/collection#0027-IPAM> rdfs:label "Ralph Berkowitz Collection";
+  dc:identifier "0027-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/24323> .
+
+<http://vocab.lib.umd.edu/collection#0027-LBR-RG13-007> rdfs:label "AFL Research Department, Convention Meeting records";
+  dc:identifier "0027-LBR-RG13-007";
+  owl:sameAs <http://hdl.handle.net/1903.1/42499> .
+
+<http://vocab.lib.umd.edu/collection#0027-LIT> rdfs:label "George and Toni Willison papers";
+  dc:identifier "0027-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1518> .
+
+<http://vocab.lib.umd.edu/collection#0027-MDHC> rdfs:label "Hyattsville Horticultural Society scrapbooks";
+  dc:identifier "0027-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1729> .
+
+<http://vocab.lib.umd.edu/collection#0027-MMC-NPBA> rdfs:label "Robert D.B. Carlisle papers";
+  dc:identifier "0027-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1577> .
+
+<http://vocab.lib.umd.edu/collection#0027-SCPA> rdfs:label "College Band Directors National Association records";
+  dc:identifier "0027-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/2989> .
+
+<http://vocab.lib.umd.edu/collection#0027-UA> rdfs:label "Committee on Catalogue, Registration, and Entrance records";
+  dc:identifier "0027-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1684> .
+
+<http://vocab.lib.umd.edu/collection#0028-IPAM> rdfs:label "Jerome Lowenthal Collection";
+  dc:identifier "0028-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/24328> .
+
+<http://vocab.lib.umd.edu/collection#0028-LBR-RG95-003> rdfs:label "Virginia Tehas Oral History interview";
+  dc:identifier "0028-LBR-RG95-003";
+  owl:sameAs <http://hdl.handle.net/1903.1/42500> .
+
+<http://vocab.lib.umd.edu/collection#0028-MMC-LAB> rdfs:label "William S. Hedges papers";
+  dc:identifier "0028-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/4923> .
+
+<http://vocab.lib.umd.edu/collection#0028-SCPA> rdfs:label "Music Library Association records";
+  dc:identifier "0028-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/2990> .
+
+<http://vocab.lib.umd.edu/collection#0028-UA> rdfs:label "Committee on Catalogue, Student Enrollment, and Entrance records";
+  dc:identifier "0028-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1685> .
+
+<http://vocab.lib.umd.edu/collection#0029-IPAM> rdfs:label "Jan Smeterlin Collection";
+  dc:identifier "0029-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/24327> .
+
+<http://vocab.lib.umd.edu/collection#0029-LBR-RG1-013> rdfs:label "AFL Office of the President, Samuel Gompers and Woodrow Wilson correspondence";
+  dc:identifier "0029-LBR-RG1-013";
+  owl:sameAs <http://hdl.handle.net/1903.1/42502> .
+
+<http://vocab.lib.umd.edu/collection#0029-LIT> rdfs:label "Thomas Walsh papers";
+  dc:identifier "0029-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1520> .
+
+<http://vocab.lib.umd.edu/collection#0029-MDHC> rdfs:label "Livestock Sanitary Board records";
+  dc:identifier "0029-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1731> .
+
+<http://vocab.lib.umd.edu/collection#0029-SCPA> rdfs:label "National Association of College Wind and Percussion Instructors Research Center Score Collection";
+  dc:identifier "0029-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/2991> .
+
+<http://vocab.lib.umd.edu/collection#0029-UA> rdfs:label "Committee on Catalogue, Student Enrollment, and College Entrance records";
+  dc:identifier "0029-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1686> .
+
+<http://vocab.lib.umd.edu/collection#0030-IPAM> rdfs:label "Sylvia Rabinof Collection";
+  dc:identifier "0030-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/24326> .
+
+<http://vocab.lib.umd.edu/collection#0030-LBR-RG95-005> rdfs:label "United Labor Policy Committee records";
+  dc:identifier "0030-LBR-RG95-005";
+  owl:sameAs <http://hdl.handle.net/1903.1/42504> .
+
+<http://vocab.lib.umd.edu/collection#0030-LIT> rdfs:label "Turret Books records";
+  dc:identifier "0030-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1521> .
+
+<http://vocab.lib.umd.edu/collection#0030-MMC-LAB> rdfs:label "Robert L. Coe papers";
+  dc:identifier "0030-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/4928> .
+
+<http://vocab.lib.umd.edu/collection#0030-SCPA> rdfs:label "The Howe Collection of Musical Instrument Literature";
+  dc:identifier "0030-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42745> .
+
+<http://vocab.lib.umd.edu/collection#0030-UA> rdfs:label "Chancellor's Commission on Women's Affairs records";
+  dc:identifier "0030-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1687> .
+
+<http://vocab.lib.umd.edu/collection#0031-IPAM> rdfs:label "Jane Carlson Collection";
+  dc:identifier "0031-IPAM";
+  owl:sameAs <http://hdl.handle.net/1903.1/24329> .
+
+<http://vocab.lib.umd.edu/collection#0031-LBR-RG2-003> rdfs:label "AFL Secretary-Treasurer's Office, Frank Morrison papers";
+  dc:identifier "0031-LBR-RG2-003";
+  owl:sameAs <http://hdl.handle.net/1903.1/42506> .
+
+<http://vocab.lib.umd.edu/collection#0031-LIT> rdfs:label "James Stern papers";
+  dc:identifier "0031-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1522> .
+
+<http://vocab.lib.umd.edu/collection#0031-MDHC> rdfs:label "Celia M. Holland papers";
+  dc:identifier "0031-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1733> .
+
+<http://vocab.lib.umd.edu/collection#0031-MMC-LAB> rdfs:label "Thad Holt papers";
+  dc:identifier "0031-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/4926> .
+
+<http://vocab.lib.umd.edu/collection#0031-SCPA> rdfs:label "J.E. Roach Banda Mexicana Music Collection";
+  dc:identifier "0031-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/2993> .
+
+<http://vocab.lib.umd.edu/collection#0031-UA> rdfs:label "Graduate School records";
+  dc:identifier "0031-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1688> .
+
+<http://vocab.lib.umd.edu/collection#0032-LBR-RG1-012> rdfs:label "AFL Office of the President, political correspondence";
+  dc:identifier "0032-LBR-RG1-012";
+  owl:sameAs <http://hdl.handle.net/1903.1/42508> .
+
+<http://vocab.lib.umd.edu/collection#0032-LIT> rdfs:label "Gertrude Stein and Her Circle papers";
+  dc:identifier "0032-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1523> .
+
+<http://vocab.lib.umd.edu/collection#0032-MMC-LAB> rdfs:label "Philip James papers";
+  dc:identifier "0032-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/4927> .
+
+<http://vocab.lib.umd.edu/collection#0032-SCPA> rdfs:label "Frank Bencriscutto papers";
+  dc:identifier "0032-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/2994> .
+
+<http://vocab.lib.umd.edu/collection#0032-UA> rdfs:label "Division of Behavioral and Social Sciences records";
+  dc:identifier "0032-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1661> .
+
+<http://vocab.lib.umd.edu/collection#0033-LBR-RG13-002> rdfs:label "AFL-CIO Research Department, Frank Fernbach papers";
+  dc:identifier "0033-LBR-RG13-002";
+  owl:sameAs <http://hdl.handle.net/1903.1/42509> .
+
+<http://vocab.lib.umd.edu/collection#0033-LIT> rdfs:label "Grace Delafield Day Spier papers";
+  dc:identifier "0033-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1524> .
+
+<http://vocab.lib.umd.edu/collection#0033-MDHC> rdfs:label "William James papers";
+  dc:identifier "0033-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1735> .
+
+<http://vocab.lib.umd.edu/collection#0033-SCPA> rdfs:label "Arthur Brandenburg papers";
+  dc:identifier "0033-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/2995> .
+
+<http://vocab.lib.umd.edu/collection#0033-UA> rdfs:label "University Faculty Assembly records";
+  dc:identifier "0033-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1662> .
+
+<http://vocab.lib.umd.edu/collection#0034-LBR-RG1-026> rdfs:label "AFL-CIO Office of the President, George Meany papers";
+  dc:identifier "0034-LBR-RG1-026";
+  owl:sameAs <http://hdl.handle.net/1903.1/42510> .
+
+<http://vocab.lib.umd.edu/collection#0034-MMC-LAB> rdfs:label "Shirley Povich papers";
+  dc:identifier "0034-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/11074> .
+
+<http://vocab.lib.umd.edu/collection#0034-SCPA> rdfs:label "Patrick Conway collection";
+  dc:identifier "0034-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/2996> .
+
+<http://vocab.lib.umd.edu/collection#0034-UA> rdfs:label "General Council records";
+  dc:identifier "0034-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1663> .
+
+<http://vocab.lib.umd.edu/collection#0035-LBR-RG95-008> rdfs:label "Larry Rogin papers";
+  dc:identifier "0035-LBR-RG95-008";
+  owl:sameAs <http://hdl.handle.net/1903.1/42511> .
+
+<http://vocab.lib.umd.edu/collection#0035-LIT> rdfs:label "Karl Shapiro papers";
+  dc:identifier "0035-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1526> .
+
+<http://vocab.lib.umd.edu/collection#0035-MDHC> rdfs:label "International Student Service, American Committee records";
+  dc:identifier "0035-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1736> .
+
+<http://vocab.lib.umd.edu/collection#0035-MMC-LAB> rdfs:label "Arthur Godfrey papers";
+  dc:identifier "0035-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/15706> .
+
+<http://vocab.lib.umd.edu/collection#0035-SCPA> rdfs:label "Raymond F. Dvorak papers";
+  dc:identifier "0035-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/2997> .
+
+<http://vocab.lib.umd.edu/collection#0035-UA> rdfs:label "Division of Student Affairs records";
+  dc:identifier "0035-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1664> .
+
+<http://vocab.lib.umd.edu/collection#0036-LBR-RG95-011> rdfs:label "George Delaney papers";
+  dc:identifier "0036-LBR-RG95-011";
+  owl:sameAs <http://hdl.handle.net/1903.1/42512> .
+
+<http://vocab.lib.umd.edu/collection#0036-LIT> rdfs:label "Edward Lucie-Smith papers";
+  dc:identifier "0036-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1527> .
+
+<http://vocab.lib.umd.edu/collection#0036-MMC-LAB> rdfs:label "Edwin B. Dooley WLW collection";
+  dc:identifier "0036-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/15189> .
+
+<http://vocab.lib.umd.edu/collection#0036-SCPA> rdfs:label "Herbert Hazelman papers";
+  dc:identifier "0036-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/2998> .
+
+<http://vocab.lib.umd.edu/collection#0036-UA> rdfs:label "Student Grade records";
+  dc:identifier "0036-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1665> .
+
+<http://vocab.lib.umd.edu/collection#0037-LBR-RG97-004> rdfs:label "AFL-CIO Education Department Film Productions, Americans at Work";
+  dc:identifier "0037-LBR-RG97-004";
+  owl:sameAs <http://hdl.handle.net/1903.1/42513> .
+
+<http://vocab.lib.umd.edu/collection#0037-LIT> rdfs:label "Ferdinand Reyher papers";
+  dc:identifier "0037-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1528> .
+
+<http://vocab.lib.umd.edu/collection#0037-MDHC> rdfs:label "William C. Kerr papers";
+  dc:identifier "0037-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1706> .
+
+<http://vocab.lib.umd.edu/collection#0037-MMC-NPBA> rdfs:label "Frank W. Lloyd papers";
+  dc:identifier "0037-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1586> .
+
+<http://vocab.lib.umd.edu/collection#0037-SCPA> rdfs:label "John Heney papers";
+  dc:identifier "0037-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/2999> .
+
+<http://vocab.lib.umd.edu/collection#0037-UA> rdfs:label "Student Union records";
+  dc:identifier "0037-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1666> .
+
+<http://vocab.lib.umd.edu/collection#0038-LBR-RG40-001> rdfs:label "Union Label and Service Trades Department, Secretary-Treasurer's records";
+  dc:identifier "0038-LBR-RG40-001";
+  owl:sameAs <http://hdl.handle.net/1903.1/42514> .
+
+<http://vocab.lib.umd.edu/collection#0038-LIT> rdfs:label "Mr. and Mrs. John A. and Catherine Prince papers";
+  dc:identifier "0038-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1529> .
+
+<http://vocab.lib.umd.edu/collection#0038-MMC-LAB> rdfs:label "Edward Kirby papers";
+  dc:identifier "0038-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/42515> .
+
+<http://vocab.lib.umd.edu/collection#0038-SCPA> rdfs:label "Frank Mancini papers";
+  dc:identifier "0038-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3000> .
+
+<http://vocab.lib.umd.edu/collection#0038-UA> rdfs:label "Committee on Undergraduate Women's Education records";
+  dc:identifier "0038-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1667> .
+
+<http://vocab.lib.umd.edu/collection#0039-LBR-RG2-006> rdfs:label "AFL Office of the Secretary-Treasurer, George Meany records";
+  dc:identifier "0039-LBR-RG2-006";
+  owl:sameAs <http://hdl.handle.net/1903.1/42516> .
+
+<http://vocab.lib.umd.edu/collection#0039-LIT> rdfs:label "E. Barrett Prettyman papers";
+  dc:identifier "0039-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1530> .
+
+<http://vocab.lib.umd.edu/collection#0039-MDHC> rdfs:label "Marjorie Sewell Holt papers";
+  dc:identifier "0039-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1708> .
+
+<http://vocab.lib.umd.edu/collection#0039-MMC-LAB> rdfs:label "Dick Dorrance papers";
+  dc:identifier "0039-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/21270> .
+
+<http://vocab.lib.umd.edu/collection#0039-MMC-NPBA> rdfs:label "Chalmers Marquis papers";
+  dc:identifier "0039-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1588> .
+
+<http://vocab.lib.umd.edu/collection#0039-SCPA> rdfs:label "Lynn L. Sams papers";
+  dc:identifier "0039-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3001> .
+
+<http://vocab.lib.umd.edu/collection#0039-UA> rdfs:label "Shuttle-UM records";
+  dc:identifier "0039-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1668> .
+
+<http://vocab.lib.umd.edu/collection#0040-LBR-RG95-007> rdfs:label "Lane Kirkland papers";
+  dc:identifier "0040-LBR-RG95-007";
+  owl:sameAs <http://hdl.handle.net/1903.1/42517> .
+
+<http://vocab.lib.umd.edu/collection#0040-LIT> rdfs:label "Paul Porter papers";
+  dc:identifier "0040-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1531> .
+
+<http://vocab.lib.umd.edu/collection#0040-MDHC> rdfs:label "Robert Horne papers";
+  dc:identifier "0040-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1709> .
+
+<http://vocab.lib.umd.edu/collection#0040-MMC-LAB> rdfs:label "Jerry \"Tucker\" Schatz papers";
+  dc:identifier "0040-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/16405> .
+
+<http://vocab.lib.umd.edu/collection#0040-SCPA> rdfs:label "Kenneth Slater papers";
+  dc:identifier "0040-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3002> .
+
+<http://vocab.lib.umd.edu/collection#0040-UA> rdfs:label "University Council records";
+  dc:identifier "0040-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1669> .
+
+<http://vocab.lib.umd.edu/collection#0041-LBR-RG13-006> rdfs:label "AFL-CIO Economic Research Department, Office of Wage and Industrial Relations Records, Anne Draper records";
+  dc:identifier "0041-LBR-RG13-006";
+  owl:sameAs <http://hdl.handle.net/1903.1/42518> .
+
+<http://vocab.lib.umd.edu/collection#0041-LIT> rdfs:label "Katherine Anne Porter papers";
+  dc:identifier "0041-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1532> .
+
+<http://vocab.lib.umd.edu/collection#0041-MDHC> rdfs:label "Charles Hosmer papers";
+  dc:identifier "0041-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1710> .
+
+<http://vocab.lib.umd.edu/collection#0041-MMC-NPBA> rdfs:label "Richard J. Meyer papers";
+  dc:identifier "0041-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42520> .
+
+<http://vocab.lib.umd.edu/collection#0041-SCPA> rdfs:label "Earl Slocum papers";
+  dc:identifier "0041-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3003> .
+
+<http://vocab.lib.umd.edu/collection#0041-UA> rdfs:label "Office of Registration records";
+  dc:identifier "0041-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1670> .
+
+<http://vocab.lib.umd.edu/collection#0042-LBR-RG96-003> rdfs:label "Keystone Lantern photographic slide collection";
+  dc:identifier "0042-LBR-RG96-003";
+  owl:sameAs <http://hdl.handle.net/1903.1/42521> .
+
+<http://vocab.lib.umd.edu/collection#0042-LIT> rdfs:label "Poetry Book Society records";
+  dc:identifier "0042-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1533> .
+
+<http://vocab.lib.umd.edu/collection#0042-MDHC> rdfs:label "Jesse Hughes papers";
+  dc:identifier "0042-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1711> .
+
+<http://vocab.lib.umd.edu/collection#0042-MMC-LAB> rdfs:label "Caroline Francke Scripts collection";
+  dc:identifier "0042-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/15517> .
+
+<http://vocab.lib.umd.edu/collection#0042-SCPA> rdfs:label "Ernest S. Williams papers";
+  dc:identifier "0042-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3004> .
+
+<http://vocab.lib.umd.edu/collection#0042-UA> rdfs:label "University Senate (1920-1970) records";
+  dc:identifier "0042-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1671> .
+
+<http://vocab.lib.umd.edu/collection#0043-LBR-RG18-010> rdfs:label "AFL-CIO International Affairs Department, Country Files";
+  dc:identifier "0043-LBR-RG18-010";
+  owl:sameAs <http://hdl.handle.net/1903.1/42522> .
+
+<http://vocab.lib.umd.edu/collection#0043-LIT> rdfs:label "Harry C. Perry, Jr. papers";
+  dc:identifier "0043-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1534> .
+
+<http://vocab.lib.umd.edu/collection#0043-UA> rdfs:label "Robert O. Felter Class of 1966 collection";
+  dc:identifier "0043-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/8811> .
+
+<http://vocab.lib.umd.edu/collection#0044-LBR-RG9-001> rdfs:label "AFL, CIO, and AFL-CIO Civil Rights Department records";
+  dc:identifier "0044-LBR-RG9-001";
+  owl:sameAs <http://hdl.handle.net/1903.1/42524> .
+
+<http://vocab.lib.umd.edu/collection#0044-LIT> rdfs:label "Lady Ottoline Morrell papers";
+  dc:identifier "0044-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1535> .
+
+<http://vocab.lib.umd.edu/collection#0044-MDHC> rdfs:label "Hendricks and Hamilton Families papers";
+  dc:identifier "0044-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1713> .
+
+<http://vocab.lib.umd.edu/collection#0044-SCPA> rdfs:label "Lilla Belle Pitts papers";
+  dc:identifier "0044-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3006> .
+
+<http://vocab.lib.umd.edu/collection#0044-UA> rdfs:label "Women's League records";
+  dc:identifier "0044-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1672> .
+
+<http://vocab.lib.umd.edu/collection#0045-LBR-RG18-009> rdfs:label "AFL-CIO International Affairs Department, Serafino Romualdi records";
+  dc:identifier "0045-LBR-RG18-009";
+  owl:sameAs <http://hdl.handle.net/1903.1/42526> .
+
+<http://vocab.lib.umd.edu/collection#0045-LIT> rdfs:label "Hope Mirrlees papers";
+  dc:identifier "0045-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1536> .
+
+<http://vocab.lib.umd.edu/collection#0045-MDHC> rdfs:label "Leonidas Dodson papers";
+  dc:identifier "0045-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1714> .
+
+<http://vocab.lib.umd.edu/collection#0045-MMC-LAB> rdfs:label "Norman Sweetser papers";
+  dc:identifier "0045-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/16406> .
+
+<http://vocab.lib.umd.edu/collection#0045-SCPA> rdfs:label "Jerry Pierce papers";
+  dc:identifier "0045-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3008> .
+
+<http://vocab.lib.umd.edu/collection#0045-UA> rdfs:label "President's Commission on Women's Issues records";
+  dc:identifier "0045-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1673> .
+
+<http://vocab.lib.umd.edu/collection#0046-LIT> rdfs:label "Cyrilly Abels papers";
+  dc:identifier "0046-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1537> .
+
+<http://vocab.lib.umd.edu/collection#0046-MDHC> rdfs:label "Maryland Municipal League records";
+  dc:identifier "0046-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1715> .
+
+<http://vocab.lib.umd.edu/collection#0046-RG13-003-LBR> rdfs:label "CIO and AFL-CIO Research Department, Nathaniel Goldfinger records";
+  dc:identifier "0046-RG13-003-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/42528> .
+
+<http://vocab.lib.umd.edu/collection#0046-SCPA> rdfs:label "Contemporary Music Project records";
+  dc:identifier "0046-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3023> .
+
+<http://vocab.lib.umd.edu/collection#0046-UA> rdfs:label "Tau Beta Pi records";
+  dc:identifier "0046-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1674> .
+
+<http://vocab.lib.umd.edu/collection#0047-LBR-RG1-015> rdfs:label "AFL Office of the President, William Green papers";
+  dc:identifier "0047-LBR-RG1-015";
+  owl:sameAs <http://hdl.handle.net/1903.1/42529> .
+
+<http://vocab.lib.umd.edu/collection#0047-LIT> rdfs:label "Naomi Duff Smith papers";
+  dc:identifier "0047-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1538> .
+
+<http://vocab.lib.umd.edu/collection#0047-MDHC> rdfs:label "Maryland Manuscripts collection";
+  dc:identifier "0047-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1716> .
+
+<http://vocab.lib.umd.edu/collection#0047-SCPA> rdfs:label "Clara Rockmore papers";
+  dc:identifier "0047-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3289> .
+
+<http://vocab.lib.umd.edu/collection#0047-UA> rdfs:label "College of Agriculture records";
+  dc:identifier "0047-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1647> .
+
+<http://vocab.lib.umd.edu/collection#0048-LBR-RG20-003> rdfs:label "CIO and AFL-CIO Information Department, Press Releases";
+  dc:identifier "0048-LBR-RG20-003";
+  owl:sameAs <http://hdl.handle.net/1903.1/42531> .
+
+<http://vocab.lib.umd.edu/collection#0048-LIT> rdfs:label "Mollee Coppel Kruger papers";
+  dc:identifier "0048-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1539> .
+
+<http://vocab.lib.umd.edu/collection#0048-MDHC> rdfs:label "Maryland Library Association records";
+  dc:identifier "0048-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1717> .
+
+<http://vocab.lib.umd.edu/collection#0048-MMC-LAB> rdfs:label "Rudy Bretz Papers";
+  dc:identifier "0048-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/42532> .
+
+<http://vocab.lib.umd.edu/collection#0048-MMC-NPBA> rdfs:label "Louisa A. Nielsen papers";
+  dc:identifier "0048-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1598> .
+
+<http://vocab.lib.umd.edu/collection#0048-SCPA> rdfs:label "Teddy McRae Papers";
+  dc:identifier "0048-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3287> .
+
+<http://vocab.lib.umd.edu/collection#0049-LBR-RG95-012> rdfs:label "Anthony Wayne Smith papers";
+  dc:identifier "0049-LBR-RG95-012";
+  owl:sameAs <http://hdl.handle.net/1903.1/42533> .
+
+<http://vocab.lib.umd.edu/collection#0049-LIT> rdfs:label "Isabel Bayley papers";
+  dc:identifier "0049-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1540> .
+
+<http://vocab.lib.umd.edu/collection#0049-MDHC> rdfs:label "Maryland Horse Breeders Association records";
+  dc:identifier "0049-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1718> .
+
+<http://vocab.lib.umd.edu/collection#0049-MMC-LAB> rdfs:label "Parks Johnson collection of Vox Pop";
+  dc:identifier "0049-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/42534> .
+
+<http://vocab.lib.umd.edu/collection#0049-MMC-NPBA> rdfs:label "Morris S. Novik papers";
+  dc:identifier "0049-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1599> .
+
+<http://vocab.lib.umd.edu/collection#0049-SCPA> rdfs:label "Donald Pond Collection";
+  dc:identifier "0049-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3288> .
+
+<http://vocab.lib.umd.edu/collection#0049-UA> rdfs:label "Susan Harman papers";
+  dc:identifier "0049-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1498> .
+
+<http://vocab.lib.umd.edu/collection#0050-LBR-RG28-002> rdfs:label "AFL and AFL-CIO Organizing Department records";
+  dc:identifier "0050-LBR-RG28-002";
+  owl:sameAs <http://hdl.handle.net/1903.1/42535> .
+
+<http://vocab.lib.umd.edu/collection#0050-LIT> rdfs:label "Glenway Wescott collection";
+  dc:identifier "0050-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1541> .
+
+<http://vocab.lib.umd.edu/collection#0050-MDHC> rdfs:label "Maryland Home Economics Association records";
+  dc:identifier "0050-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1719> .
+
+<http://vocab.lib.umd.edu/collection#0050-SCPA> rdfs:label "Edward Bailey Birge Papers";
+  dc:identifier "0050-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/12592> .
+
+<http://vocab.lib.umd.edu/collection#0050-UA> rdfs:label "Graduate Student Association records";
+  dc:identifier "0050-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1650> .
+
+<http://vocab.lib.umd.edu/collection#0051-LBR-RG98-002> rdfs:label "George Meany Memorial Archives, Vertical File collection";
+  dc:identifier "0051-LBR-RG98-002";
+  owl:sameAs <http://hdl.handle.net/1903.1/42537> .
+
+<http://vocab.lib.umd.edu/collection#0051-LIT> rdfs:label "Chester Page Collection";
+  dc:identifier "0051-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1542> .
+
+<http://vocab.lib.umd.edu/collection#0051-MDHC> rdfs:label "Maryland Conservation Council records";
+  dc:identifier "0051-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1720> .
+
+<http://vocab.lib.umd.edu/collection#0051-MMC-NPBA> rdfs:label "Zoel J. Parenteau papers";
+  dc:identifier "0051-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1601> .
+
+<http://vocab.lib.umd.edu/collection#0051-SCPA> rdfs:label "Alfred Reed manuscript scores";
+  dc:identifier "0051-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3961> .
+
+<http://vocab.lib.umd.edu/collection#0051-UA> rdfs:label "Department of Horticulture records";
+  dc:identifier "0051-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1651> .
+
+<http://vocab.lib.umd.edu/collection#0052-LBR-RG21-002> rdfs:label "AFL-CIO Legislation Department, Testimony";
+  dc:identifier "0052-LBR-RG21-002";
+  owl:sameAs <http://hdl.handle.net/1903.1/42538> .
+
+<http://vocab.lib.umd.edu/collection#0052-LIT> rdfs:label "Jackson R. Bryer papers";
+  dc:identifier "0052-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1543> .
+
+<http://vocab.lib.umd.edu/collection#0052-MDHC> rdfs:label "Magon de la Ballus letterbook";
+  dc:identifier "0052-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1689> .
+
+<http://vocab.lib.umd.edu/collection#0052-MMC-NPBA> rdfs:label "Arthur A. Paul papers";
+  dc:identifier "0052-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1602> .
+
+<http://vocab.lib.umd.edu/collection#0052-SCPA> rdfs:label "Rose Marie Grentzer papers";
+  dc:identifier "0052-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3962> .
+
+<http://vocab.lib.umd.edu/collection#0052-UA> rdfs:label "Department of Intercollegiate Athletics records";
+  dc:identifier "0052-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1652> .
+
+<http://vocab.lib.umd.edu/collection#0053-LBR-RG34-002> rdfs:label "AFL-CIO Support Services Department, Publication collection";
+  dc:identifier "0053-LBR-RG34-002";
+  owl:sameAs <http://hdl.handle.net/1903.1/42540> .
+
+<http://vocab.lib.umd.edu/collection#0053-LIT> rdfs:label "Lawrence J. McCrank collection";
+  dc:identifier "0053-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1544> .
+
+<http://vocab.lib.umd.edu/collection#0053-MDHC> rdfs:label "Esther Gelman papers";
+  dc:identifier "0053-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1690> .
+
+<http://vocab.lib.umd.edu/collection#0053-MMC-NPBA> rdfs:label "John S. Porter papers";
+  dc:identifier "0053-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1603> .
+
+<http://vocab.lib.umd.edu/collection#0053-SCPA> rdfs:label "Mary E. Hoffman Papers";
+  dc:identifier "0053-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3963> .
+
+<http://vocab.lib.umd.edu/collection#0053-UA> rdfs:label "Interim College Park Senate records";
+  dc:identifier "0053-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1653> .
+
+<http://vocab.lib.umd.edu/collection#0054-LBR-RG9-002> rdfs:label "AFL, CIO, and AFL-CIO Civil Rights Department, Discrimination Case Files";
+  dc:identifier "0054-LBR-RG9-002";
+  owl:sameAs <http://hdl.handle.net/1903.1/42541> .
+
+<http://vocab.lib.umd.edu/collection#0054-MDHC> rdfs:label "Hervey Machen papers";
+  dc:identifier "0054-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1691> .
+
+<http://vocab.lib.umd.edu/collection#0054-MMC-NPBA> rdfs:label "David S. Prowitt papers";
+  dc:identifier "0054-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1604> .
+
+<http://vocab.lib.umd.edu/collection#0054-SCPA> rdfs:label "Society for Ethnomusicology records";
+  dc:identifier "0054-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3967> .
+
+<http://vocab.lib.umd.edu/collection#0054-UA> rdfs:label "College of Journalism records";
+  dc:identifier "0054-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1654> .
+
+<http://vocab.lib.umd.edu/collection#0055-LBR-RG21-001> rdfs:label "AFL-CIO Legislation Department records";
+  dc:identifier "0055-LBR-RG21-001";
+  owl:sameAs <http://hdl.handle.net/1903.1/42542> .
+
+<http://vocab.lib.umd.edu/collection#0055-LIT> rdfs:label "Arthur J. Gutman Collection of Menckeniana";
+  dc:identifier "0055-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1546> .
+
+<http://vocab.lib.umd.edu/collection#0055-MDHC> rdfs:label "American Association of University Women, College Park Branch (AAUW) records";
+  dc:identifier "0055-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1692> .
+
+<http://vocab.lib.umd.edu/collection#0055-MMC-NPBA> rdfs:label "Bill Reed papers";
+  dc:identifier "0055-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1605> .
+
+<http://vocab.lib.umd.edu/collection#0055-SCPA> rdfs:label "Merle Evans Papers";
+  dc:identifier "0055-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3968> .
+
+<http://vocab.lib.umd.edu/collection#0055-UA> rdfs:label "State Board of Agriculture records";
+  dc:identifier "0055-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1655> .
+
+<http://vocab.lib.umd.edu/collection#0056-LBR> rdfs:label "Gordon H. Cole papers";
+  dc:identifier "0056-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/19437> .
+
+<http://vocab.lib.umd.edu/collection#0056-MDHC> rdfs:label "Association for Childhood Education International (ACEI) records";
+  dc:identifier "0056-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1693> .
+
+<http://vocab.lib.umd.edu/collection#0056-MMC-NPBA> rdfs:label "Robert M. Reed papers";
+  dc:identifier "0056-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1606> .
+
+<http://vocab.lib.umd.edu/collection#0056-SCPA> rdfs:label "Improvisations Unlimited Collection";
+  dc:identifier "0056-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3969> .
+
+<http://vocab.lib.umd.edu/collection#0056-UA> rdfs:label "Office of the Director of Libraries records";
+  dc:identifier "0056-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1656> .
+
+<http://vocab.lib.umd.edu/collection#0057-LBR> rdfs:label "<title>Samuel Gompers Papers</title> Project collection";
+  dc:identifier "0057-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/19640> .
+
+<http://vocab.lib.umd.edu/collection#0057-LIT> rdfs:label "Atlantic Monthly records";
+  dc:identifier "0057-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1547> .
+
+<http://vocab.lib.umd.edu/collection#0057-MMC-NPBA> rdfs:label "Frederick M. Remley papers";
+  dc:identifier "0057-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1607> .
+
+<http://vocab.lib.umd.edu/collection#0057-SCPA> rdfs:label "American College Dance Festival Association (ACDFA) Archives";
+  dc:identifier "0057-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3970> .
+
+<http://vocab.lib.umd.edu/collection#0057-UA> rdfs:label "University Senate (2000 - Present) records";
+  dc:identifier "0057-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1657> .
+
+<http://vocab.lib.umd.edu/collection#0058-LBR> rdfs:label "George Harris papers";
+  dc:identifier "0058-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/19639> .
+
+<http://vocab.lib.umd.edu/collection#0058-LIT> rdfs:label "Janis P. Stout papers";
+  dc:identifier "0058-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1549> .
+
+<http://vocab.lib.umd.edu/collection#0058-MDHC> rdfs:label "Georgia K. Benjamin papers";
+  dc:identifier "0058-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1695> .
+
+<http://vocab.lib.umd.edu/collection#0058-MMC-NPBA> rdfs:label "Jim Robertson papers";
+  dc:identifier "0058-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1608> .
+
+<http://vocab.lib.umd.edu/collection#0058-SCPA> rdfs:label "The Hubert P. Henderson Collection";
+  dc:identifier "0058-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3972> .
+
+<http://vocab.lib.umd.edu/collection#0058-UA> rdfs:label "Mercer Literary Society records";
+  dc:identifier "0058-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1658> .
+
+<http://vocab.lib.umd.edu/collection#0059-LBR-RG1-019> rdfs:label "AFL Office of the President, President's Files, William Green";
+  dc:identifier "0059-LBR-RG1-019";
+  owl:sameAs <http://hdl.handle.net/1903.1/42543> .
+
+<http://vocab.lib.umd.edu/collection#0059-LIT> rdfs:label "Andrew Field papers";
+  dc:identifier "0059-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/43400> .
+
+<http://vocab.lib.umd.edu/collection#0059-MDHC> rdfs:label "Berwyn Heights Elementary School Parent-Teacher Association (PTA) records";
+  dc:identifier "0059-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1696> .
+
+<http://vocab.lib.umd.edu/collection#0059-MMC-NPBA> rdfs:label "Ralph B. Rogers papers";
+  dc:identifier "0059-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1609> .
+
+<http://vocab.lib.umd.edu/collection#0059-SCPA> rdfs:label "The Hugo Keesing Collection on Popular Music and Culture";
+  dc:identifier "0059-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3973> .
+
+<http://vocab.lib.umd.edu/collection#0059-UA> rdfs:label "Personnel Department records";
+  dc:identifier "0059-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1659> .
+
+<http://vocab.lib.umd.edu/collection#0060-LBR-RG1-023> rdfs:label "AFL Office of the President, President's Files, William Green";
+  dc:identifier "0060-LBR-RG1-023";
+  owl:sameAs <http://hdl.handle.net/1903.1/42544> .
+
+<http://vocab.lib.umd.edu/collection#0060-LIT> rdfs:label "Phillip Herring papers";
+  dc:identifier "0060-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1551> .
+
+<http://vocab.lib.umd.edu/collection#0060-MDHC> rdfs:label "R. Howard Bland papers";
+  dc:identifier "0060-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1697> .
+
+<http://vocab.lib.umd.edu/collection#0060-MMC-NPBA> rdfs:label "Frank E. Schooley papers";
+  dc:identifier "0060-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1610> .
+
+<http://vocab.lib.umd.edu/collection#0060-SCPA> rdfs:label "The Harold Bachman Collection";
+  dc:identifier "0060-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/4277> .
+
+<http://vocab.lib.umd.edu/collection#0060-UA> rdfs:label "Phi Mu Fraternity records";
+  dc:identifier "0060-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1660> .
+
+<http://vocab.lib.umd.edu/collection#0061-LBR-RG1-027> rdfs:label "AFL-CIO Office of the President, President's Files, George Meany";
+  dc:identifier "0061-LBR-RG1-027";
+  owl:sameAs <http://hdl.handle.net/1903.1/42545> .
+
+<http://vocab.lib.umd.edu/collection#0061-LIT> rdfs:label "Clara and Robert Vambery papers";
+  dc:identifier "0061-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/1552> .
+
+<http://vocab.lib.umd.edu/collection#0061-MDHC> rdfs:label "Bock Ark papers";
+  dc:identifier "0061-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1698> .
+
+<http://vocab.lib.umd.edu/collection#0061-MMC-NPBA> rdfs:label "John C. Schwarzwalder papers";
+  dc:identifier "0061-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1611> .
+
+<http://vocab.lib.umd.edu/collection#0061-SCPA> rdfs:label "Mark Hindsley Collection";
+  dc:identifier "0061-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/4278> .
+
+<http://vocab.lib.umd.edu/collection#0061-UA> rdfs:label "Department of Physical Plant records";
+  dc:identifier "0061-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1633> .
+
+<http://vocab.lib.umd.edu/collection#0062-LBR-RG1-038> rdfs:label "AFL and AFL-CIO Office of the President, George Meany papers";
+  dc:identifier "0062-LBR-RG1-038";
+  owl:sameAs <http://hdl.handle.net/1903.1/42546> .
+
+<http://vocab.lib.umd.edu/collection#0062-MDHC> rdfs:label "Mary Eliza Bradbury papers";
+  dc:identifier "0062-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1699> .
+
+<http://vocab.lib.umd.edu/collection#0062-MMC-NPBA> rdfs:label "Warren F. Seibert papers";
+  dc:identifier "0062-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1612> .
+
+<http://vocab.lib.umd.edu/collection#0062-SCPA> rdfs:label "James E. Moore papers";
+  dc:identifier "0062-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/4583> .
+
+<http://vocab.lib.umd.edu/collection#0062-UA> rdfs:label "Office of the President, University of Maryland records";
+  dc:identifier "0062-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1634> .
+
+<http://vocab.lib.umd.edu/collection#0063-LBR-RG2-002> rdfs:label "AFL Secretary-Treasurer's Office, Frank Morrison letterbooks";
+  dc:identifier "0063-LBR-RG2-002";
+  owl:sameAs <http://hdl.handle.net/1903.1/42547> .
+
+<http://vocab.lib.umd.edu/collection#0063-LIT> rdfs:label "Jesse Glass papers";
+  dc:identifier "0063-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/3010> .
+
+<http://vocab.lib.umd.edu/collection#0063-MDHC> rdfs:label "Thomas Bray papers";
+  dc:identifier "0063-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1700> .
+
+<http://vocab.lib.umd.edu/collection#0063-MMC-NPBA> rdfs:label "Gerald Slater papers";
+  dc:identifier "0063-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1613> .
+
+<http://vocab.lib.umd.edu/collection#0063-SCPA> rdfs:label "Leopold Stokowski collection";
+  dc:identifier "0063-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/4585> .
+
+<http://vocab.lib.umd.edu/collection#0063-UA> rdfs:label "Board of Regents records";
+  dc:identifier "0063-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1635> .
+
+<http://vocab.lib.umd.edu/collection#0064-LBR-RG2-007> rdfs:label "AFL and AFL-CIO Office of the Secretary-Treasurer, William F. Schnitzler files";
+  dc:identifier "0064-LBR-RG2-007";
+  owl:sameAs <http://hdl.handle.net/1903.1/42548> .
+
+<http://vocab.lib.umd.edu/collection#0064-LIT> rdfs:label "Maryland Folklore collection";
+  dc:identifier "0064-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/3964> .
+
+<http://vocab.lib.umd.edu/collection#0064-MDHC> rdfs:label "Daniel Brewster papers";
+  dc:identifier "0064-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1701> .
+
+<http://vocab.lib.umd.edu/collection#0064-MMC-NPBA> rdfs:label "Roger P. Smith papers";
+  dc:identifier "0064-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1614> .
+
+<http://vocab.lib.umd.edu/collection#0064-SCPA> rdfs:label "Robert Gerle Papers";
+  dc:identifier "0064-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42746> .
+
+<http://vocab.lib.umd.edu/collection#0064-UA> rdfs:label "University of Maryland Legal Documents collection";
+  dc:identifier "0064-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1636> .
+
+<http://vocab.lib.umd.edu/collection#0065-LBR-RG2-009> rdfs:label "AFL Office of the Secretary-Treasurer, Account Books";
+  dc:identifier "0065-LBR-RG2-009";
+  owl:sameAs <http://hdl.handle.net/1903.1/42549> .
+
+<http://vocab.lib.umd.edu/collection#0065-LIT> rdfs:label "Ernest Hemingway collection";
+  dc:identifier "0065-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/4586> .
+
+<http://vocab.lib.umd.edu/collection#0065-MDHC> rdfs:label "James Bruce papers";
+  dc:identifier "0065-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1702> .
+
+<http://vocab.lib.umd.edu/collection#0065-MMC-NPBA> rdfs:label "David C. Stewart papers";
+  dc:identifier "0065-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1615> .
+
+<http://vocab.lib.umd.edu/collection#0065-SCPA> rdfs:label "Henry L. Cady Papers";
+  dc:identifier "0065-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/5858> .
+
+<http://vocab.lib.umd.edu/collection#0065-UA> rdfs:label "Department of Animal Science records";
+  dc:identifier "0065-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1637> .
+
+<http://vocab.lib.umd.edu/collection#0066-LBR-RG4-004> rdfs:label "AFL Executive Council Correspondence, Minutes, and Vote Books";
+  dc:identifier "0066-LBR-RG4-004";
+  owl:sameAs <http://hdl.handle.net/1903.1/42550> .
+
+<http://vocab.lib.umd.edu/collection#0066-LIT> rdfs:label "T. S. Eliot collection";
+  dc:identifier "0066-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/4600> .
+
+<http://vocab.lib.umd.edu/collection#0066-MDHC> rdfs:label "Bureau of Social Science Research records";
+  dc:identifier "0066-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1703> .
+
+<http://vocab.lib.umd.edu/collection#0066-MMC-NPBA> rdfs:label "Duane G. Straub papers";
+  dc:identifier "0066-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1616> .
+
+<http://vocab.lib.umd.edu/collection#0066-SCPA> rdfs:label "Arthur L. Williams papers";
+  dc:identifier "0066-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/4590> .
+
+<http://vocab.lib.umd.edu/collection#0066-UA> rdfs:label "College of Engineering records";
+  dc:identifier "0066-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1638> .
+
+<http://vocab.lib.umd.edu/collection#0067-LIT> rdfs:label "Roy Hoopes papers";
+  dc:identifier "0067-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/4596> .
+
+<http://vocab.lib.umd.edu/collection#0067-MMC-NPBA> rdfs:label "Paul K. Taff papers";
+  dc:identifier "0067-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1617> .
+
+<http://vocab.lib.umd.edu/collection#0067-SCPA> rdfs:label "The Hugo Keesing Collection on Elvis Presley";
+  dc:identifier "0067-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/4592> .
+
+<http://vocab.lib.umd.edu/collection#0067-UA> rdfs:label "Invitations collection";
+  dc:identifier "0067-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1639> .
+
+<http://vocab.lib.umd.edu/collection#0068-LBR-RG9-003> rdfs:label "AFL-CIO Civil Rights Department records";
+  dc:identifier "0068-LBR-RG9-003";
+  owl:sameAs <http://hdl.handle.net/1903.1/42551> .
+
+<http://vocab.lib.umd.edu/collection#0068-LIT> rdfs:label "Roland Flint papers";
+  dc:identifier "0068-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/4597> .
+
+<http://vocab.lib.umd.edu/collection#0068-MDHC> rdfs:label "Burhaus Family papers";
+  dc:identifier "0068-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1222> .
+
+<http://vocab.lib.umd.edu/collection#0068-MMC-NPBA> rdfs:label "John F. White papers";
+  dc:identifier "0068-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1618> .
+
+<http://vocab.lib.umd.edu/collection#0068-SCPA> rdfs:label "The Hugo Keesing Collection on The Beatles";
+  dc:identifier "0068-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/4593> .
+
+<http://vocab.lib.umd.edu/collection#0068-UA> rdfs:label "Scrapbook collection";
+  dc:identifier "0068-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1640> .
+
+<http://vocab.lib.umd.edu/collection#0069-LBR-RG13-001> rdfs:label "AFL and AFL-CIO Research Department, Boris Shishkin papers";
+  dc:identifier "0069-LBR-RG13-001";
+  owl:sameAs <http://hdl.handle.net/1903.1/42552> .
+
+<http://vocab.lib.umd.edu/collection#0069-LIT> rdfs:label "Myra Sklarew papers";
+  dc:identifier "0069-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/4598> .
+
+<http://vocab.lib.umd.edu/collection#0069-MMC-NPBA> rdfs:label "Harold E. Wigren papers";
+  dc:identifier "0069-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1619> .
+
+<http://vocab.lib.umd.edu/collection#0069-SCPA> rdfs:label "The Hugo Keesing Collection on Roy Orbison";
+  dc:identifier "0069-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/4595> .
+
+<http://vocab.lib.umd.edu/collection#0069-UA> rdfs:label "Sigma Delta Chi records";
+  dc:identifier "0069-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1641> .
+
+<http://vocab.lib.umd.edu/collection#0070-LBR-RG13-005> rdfs:label "CIO and AFL-CIO Research Department, Stanley H. Ruttenberg papers";
+  dc:identifier "0070-LBR-RG13-005";
+  owl:sameAs <http://hdl.handle.net/1903.1/42553> .
+
+<http://vocab.lib.umd.edu/collection#0070-LIT> rdfs:label "Gianni DeVincent-Hayes papers";
+  dc:identifier "0070-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/4599> .
+
+<http://vocab.lib.umd.edu/collection#0070-MMC-NPBA> rdfs:label "Frank E. Withrow papers";
+  dc:identifier "0070-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1620> .
+
+<http://vocab.lib.umd.edu/collection#0070-SCPA> rdfs:label "The Wouter Keesing Collection on Fats Domino and New Orleans R&B";
+  dc:identifier "0070-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/4608> .
+
+<http://vocab.lib.umd.edu/collection#0070-UA> rdfs:label "Sigma Alpha Epsilon collection";
+  dc:identifier "0070-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1642> .
+
+<http://vocab.lib.umd.edu/collection#0071-LBR-RG18-001> rdfs:label "AFL and AFL-CIO International Affairs Department, Country Files";
+  dc:identifier "0071-LBR-RG18-001";
+  owl:sameAs <http://hdl.handle.net/1903.1/42554> .
+
+<http://vocab.lib.umd.edu/collection#0071-LIT> rdfs:label "Frances McCullough papers";
+  dc:identifier "0071-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/4603> .
+
+<http://vocab.lib.umd.edu/collection#0071-MDHC> rdfs:label "Central Atlantic Environment Center records";
+  dc:identifier "0071-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1225> .
+
+<http://vocab.lib.umd.edu/collection#0071-SCPA> rdfs:label "Eldon A. Janzen Papers";
+  dc:identifier "0071-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/4602> .
+
+<http://vocab.lib.umd.edu/collection#0071-UA> rdfs:label "University Commuters Association records";
+  dc:identifier "0071-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1643> .
+
+<http://vocab.lib.umd.edu/collection#0072-LBR-RG18-002> rdfs:label "CIO International Affairs Department, Michael H. S. Ross files";
+  dc:identifier "0072-LBR-RG18-002";
+  owl:sameAs <http://hdl.handle.net/1903.1/42556> .
+
+<http://vocab.lib.umd.edu/collection#0072-LIT> rdfs:label "Clark Dobson collection";
+  dc:identifier "0072-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/4932> .
+
+<http://vocab.lib.umd.edu/collection#0072-MDHC> rdfs:label "Chesapeake and Ohio Canal Company records";
+  dc:identifier "0072-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1226> .
+
+<http://vocab.lib.umd.edu/collection#0072-SCPA> rdfs:label "Al Wright Papers";
+  dc:identifier "0072-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/4601> .
+
+<http://vocab.lib.umd.edu/collection#0072-UA> rdfs:label "Department of Poultry Science records";
+  dc:identifier "0072-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1644> .
+
+<http://vocab.lib.umd.edu/collection#0073-LBR-RG18-003> rdfs:label "AFL and AFL-CIO International Affairs Department, Jay Lovestone Files";
+  dc:identifier "0073-LBR-RG18-003";
+  owl:sameAs <http://hdl.handle.net/1903.1/42557> .
+
+<http://vocab.lib.umd.edu/collection#0073-LIT> rdfs:label "Louis Auchincloss papers";
+  dc:identifier "0073-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/7414> .
+
+<http://vocab.lib.umd.edu/collection#0073-MDHC> rdfs:label "Chesapeake Bay Foundation records";
+  dc:identifier "0073-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1227> .
+
+<http://vocab.lib.umd.edu/collection#0073-MMC-NPBA> rdfs:label "Children's Television Workshop records";
+  dc:identifier "0073-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42558> .
+
+<http://vocab.lib.umd.edu/collection#0073-SCPA> rdfs:label "Will Earhart Papers";
+  dc:identifier "0073-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/6044> .
+
+<http://vocab.lib.umd.edu/collection#0073-UA> rdfs:label "Carl Bode papers";
+  dc:identifier "0073-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1510> .
+
+<http://vocab.lib.umd.edu/collection#0074-LBR-RG18-004> rdfs:label "AFL and AFL-CIO International Affairs Department, Irving Brown papers";
+  dc:identifier "0074-LBR-RG18-004";
+  owl:sameAs <http://hdl.handle.net/1903.1/42559> .
+
+<http://vocab.lib.umd.edu/collection#0074-LIT> rdfs:label "Marianne Moore papers";
+  dc:identifier "0074-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/7415> .
+
+<http://vocab.lib.umd.edu/collection#0074-MDHC> rdfs:label "Marilyn Church Collection";
+  dc:identifier "0074-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1228> .
+
+<http://vocab.lib.umd.edu/collection#0074-MMC-NPBA> rdfs:label "WAMU archives";
+  dc:identifier "0074-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1208> .
+
+<http://vocab.lib.umd.edu/collection#0074-SCPA> rdfs:label "Frederic W. Boots Papers";
+  dc:identifier "0074-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/4938> .
+
+<http://vocab.lib.umd.edu/collection#0074-UA> rdfs:label "Reed Whittemore papers";
+  dc:identifier "0074-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1519> .
+
+<http://vocab.lib.umd.edu/collection#0075-LBR-RG18-005> rdfs:label "AFL and AFL-CIO International Affairs Department, George Delaney papers";
+  dc:identifier "0075-LBR-RG18-005";
+  owl:sameAs <http://hdl.handle.net/1903.1/42560> .
+
+<http://vocab.lib.umd.edu/collection#0075-LIT> rdfs:label "Robert Carlton Brown papers";
+  dc:identifier "0075-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/7416> .
+
+<http://vocab.lib.umd.edu/collection#0075-SCPA> rdfs:label "Arthur Wise Papers";
+  dc:identifier "0075-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/4966> .
+
+<http://vocab.lib.umd.edu/collection#0076-LIT> rdfs:label "William Faulkner papers";
+  dc:identifier "0076-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/7417> .
+
+<http://vocab.lib.umd.edu/collection#0076-MDHC> rdfs:label "Claude-Gray-Hughes-Tuck-Whittington Family papers";
+  dc:identifier "0076-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1230> .
+
+<http://vocab.lib.umd.edu/collection#0076-MMC-NPBA> rdfs:label "David M. Davis papers";
+  dc:identifier "0076-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/9217> .
+
+<http://vocab.lib.umd.edu/collection#0076-SCPA> rdfs:label "Harry M. Bagdasian Theatre Posters Collection";
+  dc:identifier "0076-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/4943> .
+
+<http://vocab.lib.umd.edu/collection#0076-UA> rdfs:label "Executive Assistant to the Chancellor records";
+  dc:identifier "0076-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1622> .
+
+<http://vocab.lib.umd.edu/collection#0077-LBR-RG18-007> rdfs:label "AFL and AFL-CIO International Affairs Department records, International Labor Organizations";
+  dc:identifier "0077-LBR-RG18-007";
+  owl:sameAs <http://hdl.handle.net/1903.1/42564> .
+
+<http://vocab.lib.umd.edu/collection#0077-LIT> rdfs:label "Jupiter Recordings Ltd. records";
+  dc:identifier "0077-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/7418> .
+
+<http://vocab.lib.umd.edu/collection#0077-MDHC> rdfs:label "Leon Washington Condol papers";
+  dc:identifier "0077-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1231> .
+
+<http://vocab.lib.umd.edu/collection#0077-SCPA> rdfs:label "Elizabeth V. Beach Papers";
+  dc:identifier "0077-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/6421> .
+
+<http://vocab.lib.umd.edu/collection#0077-UA> rdfs:label "Office of Institutional Advancement records";
+  dc:identifier "0077-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1623> .
+
+<http://vocab.lib.umd.edu/collection#0078-LBR-RG20-001> rdfs:label "AFL, CIO, and AFL-CIO Information Department records, Major News Publications";
+  dc:identifier "0078-LBR-RG20-001";
+  owl:sameAs <http://hdl.handle.net/1903.1/42565> .
+
+<http://vocab.lib.umd.edu/collection#0078-LIT> rdfs:label "John Dos Passos papers";
+  dc:identifier "0078-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/7433> .
+
+<http://vocab.lib.umd.edu/collection#0078-MDHC> rdfs:label "Gustave Courbet papers";
+  dc:identifier "0078-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1232> .
+
+<http://vocab.lib.umd.edu/collection#0078-MMC-NPBA> rdfs:label "Edwin G. Cohen papers";
+  dc:identifier "0078-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/10355> .
+
+<http://vocab.lib.umd.edu/collection#0078-SCPA> rdfs:label "American Society for Theatre Research Archives";
+  dc:identifier "0078-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/7534> .
+
+<http://vocab.lib.umd.edu/collection#0078-UA> rdfs:label "College of Library and Information Services (CLIS) records";
+  dc:identifier "0078-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1624> .
+
+<http://vocab.lib.umd.edu/collection#0079-LBR-RG20-004> rdfs:label "AFL-CIO Information Department, <title>AFL-CIO News</title> Cartoons";
+  dc:identifier "0079-LBR-RG20-004";
+  owl:sameAs <http://hdl.handle.net/1903.1/43686> .
+
+<http://vocab.lib.umd.edu/collection#0079-MMC-NPBA> rdfs:label "Bernard Mayes papers";
+  dc:identifier "0079-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3971> .
+
+<http://vocab.lib.umd.edu/collection#0079-SCPA> rdfs:label "William J. Stannard Papers";
+  dc:identifier "0079-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/7667> .
+
+<http://vocab.lib.umd.edu/collection#0079-UA> rdfs:label "President's Legal Office records";
+  dc:identifier "0079-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1625> .
+
+<http://vocab.lib.umd.edu/collection#0080-LBR-RG22-001> rdfs:label "AFL, CIO, and AFL-CIO Committee on Political Education, Research Division records";
+  dc:identifier "0080-LBR-RG22-001";
+  owl:sameAs <http://hdl.handle.net/1903.1/42566> .
+
+<http://vocab.lib.umd.edu/collection#0080-LIT> rdfs:label "Robert Frost papers";
+  dc:identifier "0080-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/7435> .
+
+<http://vocab.lib.umd.edu/collection#0080-MDHC> rdfs:label "Dawkins Family papers";
+  dc:identifier "0080-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1234> .
+
+<http://vocab.lib.umd.edu/collection#0080-SCPA> rdfs:label "Gilbert H. Mitchell Collection";
+  dc:identifier "0080-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/7968> .
+
+<http://vocab.lib.umd.edu/collection#0080-UA> rdfs:label "Sports Information Office records";
+  dc:identifier "0080-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1626> .
+
+<http://vocab.lib.umd.edu/collection#0081-LBR-RG28-006> rdfs:label "AFL, CIO, and AFL-CIO Department of Organization and Field Services, Local Central Body Charter records";
+  dc:identifier "0081-LBR-RG28-006";
+  owl:sameAs <http://hdl.handle.net/1903.1/42568> .
+
+<http://vocab.lib.umd.edu/collection#0081-LIT> rdfs:label "German Expressionism collection";
+  dc:identifier "0081-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/7436> .
+
+<http://vocab.lib.umd.edu/collection#0081-MDHC> rdfs:label "William Emory papers";
+  dc:identifier "0081-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1235> .
+
+<http://vocab.lib.umd.edu/collection#0081-SCPA> rdfs:label "Robert Sherman Collection";
+  dc:identifier "0081-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/9381> .
+
+<http://vocab.lib.umd.edu/collection#0081-UA> rdfs:label "Maryland 4-H Center records";
+  dc:identifier "0081-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1627> .
+
+<http://vocab.lib.umd.edu/collection#0082-LBR-RG50-001> rdfs:label "Frontlash records";
+  dc:identifier "0082-LBR-RG50-001";
+  owl:sameAs <http://hdl.handle.net/1903.1/42570> .
+
+<http://vocab.lib.umd.edu/collection#0082-LIT> rdfs:label "Audre Hanneman papers";
+  dc:identifier "0082-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/7437> .
+
+<http://vocab.lib.umd.edu/collection#0082-MDHC> rdfs:label "Geary Eppley papers";
+  dc:identifier "0082-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1236> .
+
+<http://vocab.lib.umd.edu/collection#0082-MMC-NPBA> rdfs:label "Karin Ades papers";
+  dc:identifier "0082-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/4581> .
+
+<http://vocab.lib.umd.edu/collection#0082-SCPA> rdfs:label "Records of the Madrigal Singers";
+  dc:identifier "0082-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1649> .
+
+<http://vocab.lib.umd.edu/collection#0082-UA> rdfs:label "Records of Extension Home Economics";
+  dc:identifier "0082-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1628> .
+
+<http://vocab.lib.umd.edu/collection#0083-LBR-RG52-001> rdfs:label "American Federation of Women's Auxiliaries of Labor records";
+  dc:identifier "0083-LBR-RG52-001";
+  owl:sameAs <http://hdl.handle.net/1903.1/42571> .
+
+<http://vocab.lib.umd.edu/collection#0083-LIT> rdfs:label "George Margoulies papers";
+  dc:identifier "0083-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/7438> .
+
+<http://vocab.lib.umd.edu/collection#0083-MDHC> rdfs:label "Joseph Irwin France papers";
+  dc:identifier "0083-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1237> .
+
+<http://vocab.lib.umd.edu/collection#0083-MMC-NPBA> rdfs:label "James Armsey Papers";
+  dc:identifier "0083-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/18756> .
+
+<http://vocab.lib.umd.edu/collection#0083-SCPA> rdfs:label "Meriam Rosen Papers";
+  dc:identifier "0083-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/10731> .
+
+<http://vocab.lib.umd.edu/collection#0083-UA> rdfs:label "Campus Mediation Services records";
+  dc:identifier "0083-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1629> .
+
+<http://vocab.lib.umd.edu/collection#0084-LBR-RG95-001> rdfs:label "Morris S. Novik papers";
+  dc:identifier "0084-LBR-RG95-001";
+  owl:sameAs <http://hdl.handle.net/1903.1/42572> .
+
+<http://vocab.lib.umd.edu/collection#0084-LIT> rdfs:label "John Pauker papers";
+  dc:identifier "0084-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/7439> .
+
+<http://vocab.lib.umd.edu/collection#0084-MDHC> rdfs:label "Gilbert Fraser papers";
+  dc:identifier "0084-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1238> .
+
+<http://vocab.lib.umd.edu/collection#0084-SCPA> rdfs:label "Mabel Rosenthal Collection on Edwin Franko Goldman";
+  dc:identifier "0084-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/11506> .
+
+<http://vocab.lib.umd.edu/collection#0084-UA> rdfs:label "Records of Alpha Lambda Delta, Adele H. Stamp Chapter";
+  dc:identifier "0084-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1630> .
+
+<http://vocab.lib.umd.edu/collection#0085-LBR-RG95-002> rdfs:label "Vanni Buscemi Montana collection";
+  dc:identifier "0085-LBR-RG95-002";
+  owl:sameAs <http://hdl.handle.net/1903.1/42574> .
+
+<http://vocab.lib.umd.edu/collection#0085-LIT> rdfs:label "Sound and Color of Poetry (SCOP) Publications, Inc. records";
+  dc:identifier "0085-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/7440> .
+
+<http://vocab.lib.umd.edu/collection#0085-SCPA> rdfs:label "Potomac Stages theatre reviews";
+  dc:identifier "0085-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/11983> .
+
+<http://vocab.lib.umd.edu/collection#0085-UA> rdfs:label "University of Maryland Print File photographs";
+  dc:identifier "0085-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/9348> .
+
+<http://vocab.lib.umd.edu/collection#0086-LBR-RG95-009> rdfs:label "Alan Kistler papers";
+  dc:identifier "0086-LBR-RG95-009";
+  owl:sameAs <http://hdl.handle.net/1903.1/42575> .
+
+<http://vocab.lib.umd.edu/collection#0086-LIT> rdfs:label "International Brecht Society records";
+  dc:identifier "0086-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/7849> .
+
+<http://vocab.lib.umd.edu/collection#0086-MMC-NPBA> rdfs:label "Elizabeth P. Campbell Papers";
+  dc:identifier "0086-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42576> .
+
+<http://vocab.lib.umd.edu/collection#0086-SCPA> rdfs:label "Clarence E. Sawhill Papers";
+  dc:identifier "0086-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/11994> .
+
+<http://vocab.lib.umd.edu/collection#0087-LBR-RG95-014> rdfs:label "<i>The Trades Unionist</i> Labor Newspaper";
+  dc:identifier "0087-LBR-RG95-014";
+  owl:sameAs <http://hdl.handle.net/1903.1/42577> .
+
+<http://vocab.lib.umd.edu/collection#0087-MDHC> rdfs:label "Robert Garrett and Sons records";
+  dc:identifier "0087-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1241> .
+
+<http://vocab.lib.umd.edu/collection#0087-MMC> rdfs:label "Maryland Public Television Records";
+  dc:identifier "0087-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/32974> .
+
+<http://vocab.lib.umd.edu/collection#0087-SCPA> rdfs:label "Michel-Dmitri Calvocoressi manuscripts collection";
+  dc:identifier "0087-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/12673> .
+
+<http://vocab.lib.umd.edu/collection#0087-UA> rdfs:label "Maryland Food Collective records";
+  dc:identifier "0087-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1631> .
+
+<http://vocab.lib.umd.edu/collection#0088-LBR-RG96-001> rdfs:label "AFL-CIO Information Department, Photographic Prints collection";
+  dc:identifier "0088-LBR-RG96-001";
+  owl:sameAs <http://hdl.handle.net/1903.1/42579> .
+
+<http://vocab.lib.umd.edu/collection#0088-MDHC> rdfs:label "League of Women Voters of Maryland records";
+  dc:identifier "0088-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1242> .
+
+<http://vocab.lib.umd.edu/collection#0088-MMC> rdfs:label "Robert D. Swezey Papers";
+  dc:identifier "0088-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42580> .
+
+<http://vocab.lib.umd.edu/collection#0088-MMC-NPBA> rdfs:label "George E. Probst Papers";
+  dc:identifier "0088-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/4582> .
+
+<http://vocab.lib.umd.edu/collection#0088-SCPA> rdfs:label "African Continuum Theatre Company archives";
+  dc:identifier "0088-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/12720> .
+
+<http://vocab.lib.umd.edu/collection#0088-UA> rdfs:label "Memorial Chapel records";
+  dc:identifier "0088-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/9350> .
+
+<http://vocab.lib.umd.edu/collection#0089-LIT> rdfs:label "Walter Howard Kerr papers";
+  dc:identifier "0089-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/7851> .
+
+<http://vocab.lib.umd.edu/collection#0089-MDHC> rdfs:label "John Timberlake Gibson papers";
+  dc:identifier "0089-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1243> .
+
+<http://vocab.lib.umd.edu/collection#0089-MMC> rdfs:label "Donald Quayle Collection";
+  dc:identifier "0089-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42582> .
+
+<http://vocab.lib.umd.edu/collection#0089-SCPA> rdfs:label "Jacob M. Coopersmith Collection";
+  dc:identifier "0089-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/13402> .
+
+<http://vocab.lib.umd.edu/collection#0089-UA> rdfs:label "Athletic Media Relations records";
+  dc:identifier "0089-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3011> .
+
+<http://vocab.lib.umd.edu/collection#0090-LBR-RG96-004> rdfs:label "Morris B. Schnapper collection";
+  dc:identifier "0090-LBR-RG96-004";
+  owl:sameAs <http://hdl.handle.net/1903.1/42583> .
+
+<http://vocab.lib.umd.edu/collection#0090-LIT> rdfs:label "Faith Reyher Jackson papers";
+  dc:identifier "0090-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/8667> .
+
+<http://vocab.lib.umd.edu/collection#0090-MDHC> rdfs:label "Giles-Johnson Defense Committee records";
+  dc:identifier "0090-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1244> .
+
+<http://vocab.lib.umd.edu/collection#0090-MMC> rdfs:label "George L. Glotzbach QSL collection";
+  dc:identifier "0090-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42584> .
+
+<http://vocab.lib.umd.edu/collection#0090-SCPA> rdfs:label "Philip Gordon papers";
+  dc:identifier "0090-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/13712> .
+
+<http://vocab.lib.umd.edu/collection#0090-UA> rdfs:label "University of Maryland Band records";
+  dc:identifier "0090-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3012> .
+
+<http://vocab.lib.umd.edu/collection#0091-LBR-RG97-002> rdfs:label "AFL and AFL-CIO Information Department, Audio Recordings";
+  dc:identifier "0091-LBR-RG97-002";
+  owl:sameAs <http://hdl.handle.net/1903.1/42650> .
+
+<http://vocab.lib.umd.edu/collection#0091-LIT> rdfs:label "Robert Morris papers";
+  dc:identifier "0091-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/7852> .
+
+<http://vocab.lib.umd.edu/collection#0091-MDHC> rdfs:label "Knights of the Ku Klux Klan, Klan No. 51 records, Mt. Rainier, Maryland";
+  dc:identifier "0091-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1245> .
+
+<http://vocab.lib.umd.edu/collection#0091-MMC-NPBA> rdfs:label "Barbara Cole Papers";
+  dc:identifier "0091-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/8967> .
+
+<http://vocab.lib.umd.edu/collection#0091-SCPA> rdfs:label "Michael Mark Papers";
+  dc:identifier "0091-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/13899> .
+
+<http://vocab.lib.umd.edu/collection#0091-UA> rdfs:label "Cobey Family collection";
+  dc:identifier "0091-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3013> .
+
+<http://vocab.lib.umd.edu/collection#0092-LIT> rdfs:label "William Morris papers";
+  dc:identifier "0092-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/7853> .
+
+<http://vocab.lib.umd.edu/collection#0092-MDHC> rdfs:label "Lafayette Family papers";
+  dc:identifier "0092-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1246> .
+
+<http://vocab.lib.umd.edu/collection#0092-MMC> rdfs:label "John Couric papers";
+  dc:identifier "0092-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42585> .
+
+<http://vocab.lib.umd.edu/collection#0092-SCPA> rdfs:label "Vanett Lawler ISME Papers";
+  dc:identifier "0092-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/14897> .
+
+<http://vocab.lib.umd.edu/collection#0092-UA> rdfs:label "Queen's Game collection";
+  dc:identifier "0092-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3014> .
+
+<http://vocab.lib.umd.edu/collection#0093-LIT> rdfs:label "John Steinbeck papers";
+  dc:identifier "0093-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/7854> .
+
+<http://vocab.lib.umd.edu/collection#0093-MDHC> rdfs:label "Aubrey Land papers";
+  dc:identifier "0093-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1247> .
+
+<http://vocab.lib.umd.edu/collection#0093-MMC-NPBA> rdfs:label "Jeane R. Young Papers";
+  dc:identifier "0093-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/9314> .
+
+<http://vocab.lib.umd.edu/collection#0093-SCPA> rdfs:label "Vanett Lawler MENC papers";
+  dc:identifier "0093-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/14899> .
+
+<http://vocab.lib.umd.edu/collection#0093-UA> rdfs:label "University Relations records";
+  dc:identifier "0093-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3021> .
+
+<http://vocab.lib.umd.edu/collection#0094-LBR-RG98-004> rdfs:label "AFL, CIO, and AFL-CIO Scrapbook collection";
+  dc:identifier "0094-LBR-RG98-004";
+  owl:sameAs <http://hdl.handle.net/1903.1/42586> .
+
+<http://vocab.lib.umd.edu/collection#0094-LIT> rdfs:label "Mr. and Mrs. William R. Wilkins papers";
+  dc:identifier "0094-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/7855> .
+
+<http://vocab.lib.umd.edu/collection#0094-SCPA> rdfs:label "Vanett Lawler UNESCO Papers";
+  dc:identifier "0094-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/14900> .
+
+<http://vocab.lib.umd.edu/collection#0094-UA> rdfs:label "University of Maryland Vertical File Collection";
+  dc:identifier "0094-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/4617> .
+
+<http://vocab.lib.umd.edu/collection#0095-LBR-RG99-001> rdfs:label "Labor Posters, Broadsides, and Art collection";
+  dc:identifier "0095-LBR-RG99-001";
+  owl:sameAs <http://hdl.handle.net/1903.1/42588> .
+
+<http://vocab.lib.umd.edu/collection#0095-LIT> rdfs:label "Katherine Anne Porter at 100 records";
+  dc:identifier "0095-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/7856> .
+
+<http://vocab.lib.umd.edu/collection#0095-MDHC> rdfs:label "William Preston Lane papers";
+  dc:identifier "0095-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1249> .
+
+<http://vocab.lib.umd.edu/collection#0095-SCPA> rdfs:label "Polly H. Carder Collection on George F. Root";
+  dc:identifier "0095-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/15028> .
+
+<http://vocab.lib.umd.edu/collection#0095-UA> rdfs:label "American Association of University Professors, College Park Chapter (AAUP) records";
+  dc:identifier "0095-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/9351> .
+
+<http://vocab.lib.umd.edu/collection#0096-LBR> rdfs:label "Industrial Union of Marine and Shipbuilding Workers of America (IUMSWA) records";
+  dc:identifier "0096-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/1707> .
+
+<http://vocab.lib.umd.edu/collection#0096-LIT> rdfs:label "Leacy-Naylor Green-Leach papers";
+  dc:identifier "0096-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/7857> .
+
+<http://vocab.lib.umd.edu/collection#0096-MDHC> rdfs:label "Isaiah and Martha Lang papers";
+  dc:identifier "0096-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1250> .
+
+<http://vocab.lib.umd.edu/collection#0096-SCPA> rdfs:label "American Handel Society Archives";
+  dc:identifier "0096-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/15119> .
+
+<http://vocab.lib.umd.edu/collection#0096-UA> rdfs:label "Anna Dorsey Cooke Allison collection";
+  dc:identifier "0096-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/7703> .
+
+<http://vocab.lib.umd.edu/collection#0097-LBR> rdfs:label "Cigar Makers' International Union of America records";
+  dc:identifier "0097-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/43622> .
+
+<http://vocab.lib.umd.edu/collection#0097-LIT> rdfs:label "Arnold Yates Paper collection";
+  dc:identifier "0097-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/8637> .
+
+<http://vocab.lib.umd.edu/collection#0097-MDHC> rdfs:label "Charles Lanman papers";
+  dc:identifier "0097-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1251> .
+
+<http://vocab.lib.umd.edu/collection#0097-SCPA> rdfs:label "Irving Lowens Papers";
+  dc:identifier "0097-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/16692> .
+
+<http://vocab.lib.umd.edu/collection#0097-UA> rdfs:label "Joe F. Blair collection";
+  dc:identifier "0097-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/7704> .
+
+<http://vocab.lib.umd.edu/collection#0098-LBR> rdfs:label "Galaxy, Inc. records";
+  dc:identifier "0098-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/1240> .
+
+<http://vocab.lib.umd.edu/collection#0098-LIT> rdfs:label "Barbara Goldberg papers";
+  dc:identifier "0098-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/11397> .
+
+<http://vocab.lib.umd.edu/collection#0098-MDHC> rdfs:label "Richard P. Newton Family papers";
+  dc:identifier "0098-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1252> .
+
+<http://vocab.lib.umd.edu/collection#0098-SCPA> rdfs:label "Milton Stevens Papers";
+  dc:identifier "0098-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/18549> .
+
+<http://vocab.lib.umd.edu/collection#0098-UA> rdfs:label "Elizabeth Ady Garrabrant papers";
+  dc:identifier "0098-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/7705> .
+
+<http://vocab.lib.umd.edu/collection#0099-LBR> rdfs:label "Andrew Pettis papers";
+  dc:identifier "0099-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/1273> .
+
+<http://vocab.lib.umd.edu/collection#0099-LIT> rdfs:label "Desmond Willson papers";
+  dc:identifier "0099-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/14077> .
+
+<http://vocab.lib.umd.edu/collection#0099-MDHC> rdfs:label "League of Women Voters of Prince George's County records";
+  dc:identifier "0099-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1253> .
+
+<http://vocab.lib.umd.edu/collection#0099-SCPA> rdfs:label "Kenneth G. Bloomquist Collection";
+  dc:identifier "0099-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19184> .
+
+<http://vocab.lib.umd.edu/collection#0099-UA> rdfs:label "Philip Geraci photographs";
+  dc:identifier "0099-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/7706> .
+
+<http://vocab.lib.umd.edu/collection#0100-LBR> rdfs:label "Joseph Uehlein papers";
+  dc:identifier "0100-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/42593> .
+
+<http://vocab.lib.umd.edu/collection#0100-LIT> rdfs:label "Robert A. Beach papers";
+  dc:identifier "0100-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/42594> .
+
+<http://vocab.lib.umd.edu/collection#0100-MDHC> rdfs:label "Catherine Mackin papers";
+  dc:identifier "0100-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1254> .
+
+<http://vocab.lib.umd.edu/collection#0100-MMC-NPBA> rdfs:label "Nazaret Cherkezian papers";
+  dc:identifier "0100-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/12687> .
+
+<http://vocab.lib.umd.edu/collection#0100-SCPA> rdfs:label "Ephraim Goldberg collection on Benny Goodman";
+  dc:identifier "0100-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19133> .
+
+<http://vocab.lib.umd.edu/collection#0100-UA> rdfs:label "John B. Gray, Jr. papers";
+  dc:identifier "0100-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/7707> .
+
+<http://vocab.lib.umd.edu/collection#0101-LBR> rdfs:label "Bakery, Confectionery, Tobacco Workers and Grain Millers International Union (BCTGM) records";
+  dc:identifier "0101-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/1694> .
+
+<http://vocab.lib.umd.edu/collection#0101-LIT> rdfs:label "Iranian Politican History collection";
+  dc:identifier "0101-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/17452> .
+
+<http://vocab.lib.umd.edu/collection#0101-MDHC> rdfs:label "Maryland State Grange of the Patrons of Husbandry records";
+  dc:identifier "0101-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1255> .
+
+<http://vocab.lib.umd.edu/collection#0101-MMC-NPBA> rdfs:label "William J. McCarter papers";
+  dc:identifier "0101-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42596> .
+
+<http://vocab.lib.umd.edu/collection#0101-SCPA> rdfs:label "Viola da Gamba Society of America (VdGSA) Archives";
+  dc:identifier "0101-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19148> .
+
+<http://vocab.lib.umd.edu/collection#0101-UA> rdfs:label "Emory A. Harman, Sr. collection";
+  dc:identifier "0101-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/7708> .
+
+<http://vocab.lib.umd.edu/collection#0102-LIT> rdfs:label "William Addison Dwiggins collection";
+  dc:identifier "0102-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/13508> .
+
+<http://vocab.lib.umd.edu/collection#0102-MDHC> rdfs:label "Maryland Veterinary Medical Association records";
+  dc:identifier "0102-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1256> .
+
+<http://vocab.lib.umd.edu/collection#0102-SCPA> rdfs:label "The Stanley F. Michalski Jr. collection";
+  dc:identifier "0102-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19134> .
+
+<http://vocab.lib.umd.edu/collection#0102-UA> rdfs:label "Hugo Keesing collection";
+  dc:identifier "0102-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/7709> .
+
+<http://vocab.lib.umd.edu/collection#0103-LBR> rdfs:label "International Association of Siderographers records";
+  dc:identifier "0103-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/1705> .
+
+<http://vocab.lib.umd.edu/collection#0103-LIT> rdfs:label "Linda Pastan papers";
+  dc:identifier "0103-LIT";
+  owl:sameAs <http://hdl.handle.net/1903.1/43401> .
+
+<http://vocab.lib.umd.edu/collection#0103-MDHC> rdfs:label "Maryland Wilderness Association records";
+  dc:identifier "0103-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1257> .
+
+<http://vocab.lib.umd.edu/collection#0103-MMC> rdfs:label "Don West <title>Broadcasting &amp; Cable</title> collection";
+  dc:identifier "0103-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42598> .
+
+<http://vocab.lib.umd.edu/collection#0103-MMC-NPBA> rdfs:label "Oscar Reed, Jr. Papers";
+  dc:identifier "0103-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/21268> .
+
+<http://vocab.lib.umd.edu/collection#0103-SCPA> rdfs:label "Edward L. Rainbow Papers";
+  dc:identifier "0103-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19135> .
+
+<http://vocab.lib.umd.edu/collection#0103-UA> rdfs:label "Nick Kovalakides collection";
+  dc:identifier "0103-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/7710> .
+
+<http://vocab.lib.umd.edu/collection#0104-LBR> rdfs:label "Cuba Company records";
+  dc:identifier "0104-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/1233> .
+
+<http://vocab.lib.umd.edu/collection#0104-MDHC> rdfs:label "John McDowell papers";
+  dc:identifier "0104-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1258> .
+
+<http://vocab.lib.umd.edu/collection#0104-MMC-NPBA> rdfs:label "WNET records";
+  dc:identifier "0104-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/21032> .
+
+<http://vocab.lib.umd.edu/collection#0104-UA> rdfs:label "Lee R. Pennington scrapbook";
+  dc:identifier "0104-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/7711> .
+
+<http://vocab.lib.umd.edu/collection#0105-LBR> rdfs:label "Tobacco Workers International Union (TWIU) records";
+  dc:identifier "0105-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/1300> .
+
+<http://vocab.lib.umd.edu/collection#0105-MDHC> rdfs:label "Theodore R. McKeldin papers";
+  dc:identifier "0105-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1259> .
+
+<http://vocab.lib.umd.edu/collection#0105-SCPA> rdfs:label "Congress on Research in Dance Archives";
+  dc:identifier "0105-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19224> .
+
+<http://vocab.lib.umd.edu/collection#0105-UA> rdfs:label "Edwin Powell photographs";
+  dc:identifier "0105-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/7712> .
+
+<http://vocab.lib.umd.edu/collection#0106-LBR> rdfs:label "Stuart Kaufman collection";
+  dc:identifier "0106-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/1353> .
+
+<http://vocab.lib.umd.edu/collection#0106-MDHC> rdfs:label "Memorabilia collection";
+  dc:identifier "0106-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1260> .
+
+<http://vocab.lib.umd.edu/collection#0106-MMC> rdfs:label "American Center for Children's Television (ACCT) records";
+  dc:identifier "0106-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42601> .
+
+<http://vocab.lib.umd.edu/collection#0106-SCPA> rdfs:label "Myra Wykes Rigor Selvadurai Collection";
+  dc:identifier "0106-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19168> .
+
+<http://vocab.lib.umd.edu/collection#0106-UA> rdfs:label "Hotsy Alperstein papers";
+  dc:identifier "0106-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/7713> .
+
+<http://vocab.lib.umd.edu/collection#0107-LBR> rdfs:label "United Farm Workers publications";
+  dc:identifier "0107-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/1394> .
+
+<http://vocab.lib.umd.edu/collection#0107-MDHC> rdfs:label "Pauline Menes papers";
+  dc:identifier "0107-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1261> .
+
+<http://vocab.lib.umd.edu/collection#0107-MMC> rdfs:label "Television and Radio Station Files Collection";
+  dc:identifier "0107-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/16916> .
+
+<http://vocab.lib.umd.edu/collection#0107-SCPA> rdfs:label "American Musical Instrument Society Archives";
+  dc:identifier "0107-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19486> .
+
+<http://vocab.lib.umd.edu/collection#0107-UA> rdfs:label "Betty Bloom collection";
+  dc:identifier "0107-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/7714> .
+
+<http://vocab.lib.umd.edu/collection#0108-LBR> rdfs:label "Baltimore Federation of Labor records";
+  dc:identifier "0108-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/1320> .
+
+<http://vocab.lib.umd.edu/collection#0108-MDHC> rdfs:label "Mid-Atlantic Regional Archives Conference (MARAC) records";
+  dc:identifier "0108-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1262> .
+
+<http://vocab.lib.umd.edu/collection#0108-MMC> rdfs:label "Elizabeth Smith Brownstein papers";
+  dc:identifier "0108-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42602> .
+
+<http://vocab.lib.umd.edu/collection#0108-SCPA> rdfs:label "Cleon E. Dalby papers";
+  dc:identifier "0108-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19209> .
+
+<http://vocab.lib.umd.edu/collection#0108-UA> rdfs:label "Howard F. Bridges photographs";
+  dc:identifier "0108-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/7715> .
+
+<http://vocab.lib.umd.edu/collection#0109-LBR> rdfs:label "Bureau of Business Practice records";
+  dc:identifier "0109-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/1343> .
+
+<http://vocab.lib.umd.edu/collection#0109-MMC> rdfs:label "Beth E. Burrows papers";
+  dc:identifier "0109-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42603> .
+
+<http://vocab.lib.umd.edu/collection#0109-SCPA> rdfs:label "Loren Geiger Papers";
+  dc:identifier "0109-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19211> .
+
+<http://vocab.lib.umd.edu/collection#0109-UA> rdfs:label "Levin Broughton photographs";
+  dc:identifier "0109-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/7716> .
+
+<http://vocab.lib.umd.edu/collection#0110-LBR> rdfs:label "International Labor Communications Association records";
+  dc:identifier "0110-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/1464> .
+
+<http://vocab.lib.umd.edu/collection#0110-MDHC> rdfs:label "Montgomery County Committee for Fair Representation records";
+  dc:identifier "0110-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1264> .
+
+<http://vocab.lib.umd.edu/collection#0110-MMC> rdfs:label "Max Morath papers";
+  dc:identifier "0110-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42604> .
+
+<http://vocab.lib.umd.edu/collection#0110-SCPA> rdfs:label "Robert Hawkins Collection";
+  dc:identifier "0110-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19212> .
+
+<http://vocab.lib.umd.edu/collection#0110-UA> rdfs:label "Virginie and William Brown collection";
+  dc:identifier "0110-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/7717> .
+
+<http://vocab.lib.umd.edu/collection#0111-LBR> rdfs:label "George Du Bois Collection of Maryland Labor History";
+  dc:identifier "0111-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/1359> .
+
+<http://vocab.lib.umd.edu/collection#0111-MMC> rdfs:label "Shane Media Services records";
+  dc:identifier "0111-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42605> .
+
+<http://vocab.lib.umd.edu/collection#0111-SCPA> rdfs:label "Robert Hoe Collection";
+  dc:identifier "0111-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19199> .
+
+<http://vocab.lib.umd.edu/collection#0112-LBR> rdfs:label "National Organizers Alliance records";
+  dc:identifier "0112-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/1472> .
+
+<http://vocab.lib.umd.edu/collection#0112-MDHC> rdfs:label "Walter Mulligan papers";
+  dc:identifier "0112-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1266> .
+
+<http://vocab.lib.umd.edu/collection#0112-MMC> rdfs:label "John D. Silva papers";
+  dc:identifier "0112-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42606> .
+
+<http://vocab.lib.umd.edu/collection#0112-SCPA> rdfs:label "Robert L. Hoffman Papers";
+  dc:identifier "0112-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19200> .
+
+<http://vocab.lib.umd.edu/collection#0112-UA> rdfs:label "Virginia Burnside Cox collection";
+  dc:identifier "0112-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/7719> .
+
+<http://vocab.lib.umd.edu/collection#0113-LBR> rdfs:label "Robert W. Pemberton papers";
+  dc:identifier "0113-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/9060> .
+
+<http://vocab.lib.umd.edu/collection#0113-MDHC> rdfs:label "National Information Standards Organization (NISO) records";
+  dc:identifier "0113-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1267> .
+
+<http://vocab.lib.umd.edu/collection#0113-MMC> rdfs:label "Fred Bohen papers";
+  dc:identifier "0113-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42607> .
+
+<http://vocab.lib.umd.edu/collection#0113-SCPA> rdfs:label "Colonel George S. Howard Papers";
+  dc:identifier "0113-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19219> .
+
+<http://vocab.lib.umd.edu/collection#0113-UA> rdfs:label "Al Danegger photographs";
+  dc:identifier "0113-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/7720> .
+
+<http://vocab.lib.umd.edu/collection#0114-LBR> rdfs:label "A. G. Delman papers";
+  dc:identifier "0114-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/9063> .
+
+<http://vocab.lib.umd.edu/collection#0114-MDHC> rdfs:label "National Student Federation of America records";
+  dc:identifier "0114-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1268> .
+
+<http://vocab.lib.umd.edu/collection#0114-MMC> rdfs:label "Jack Davis NET video collection";
+  dc:identifier "0114-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42608> .
+
+<http://vocab.lib.umd.edu/collection#0114-SCPA> rdfs:label "Richard V. Madden Collection";
+  dc:identifier "0114-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19201> .
+
+<http://vocab.lib.umd.edu/collection#0114-UA> rdfs:label "Ralph Davis collection";
+  dc:identifier "0114-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/7721> .
+
+<http://vocab.lib.umd.edu/collection#0115-LBR> rdfs:label "Labor Heritage Foundation records";
+  dc:identifier "0115-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/43402> .
+
+<http://vocab.lib.umd.edu/collection#0115-MMC> rdfs:label "W. Lawrence Patrick Scripts collection";
+  dc:identifier "0115-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42609> .
+
+<http://vocab.lib.umd.edu/collection#0115-SCPA> rdfs:label "Frank McGrann Collection";
+  dc:identifier "0115-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19213> .
+
+<http://vocab.lib.umd.edu/collection#0115-UA> rdfs:label "Elise Dorsey collection";
+  dc:identifier "0115-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/7722> .
+
+<http://vocab.lib.umd.edu/collection#0116-MDHC> rdfs:label "Jo-Ann Orlinsky papers";
+  dc:identifier "0116-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1270> .
+
+<http://vocab.lib.umd.edu/collection#0116-MMC-NPBA> rdfs:label "Dean W. Coston papers";
+  dc:identifier "0116-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1553> .
+
+<http://vocab.lib.umd.edu/collection#0116-SCPA> rdfs:label "Jack Wainwright Collection";
+  dc:identifier "0116-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19203> .
+
+<http://vocab.lib.umd.edu/collection#0116-UA> rdfs:label "Julie Andrews photographs";
+  dc:identifier "0116-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/8871> .
+
+<http://vocab.lib.umd.edu/collection#0117-LBR> rdfs:label "United Brotherhood of Carpenters and Joiners of America (UBCJA), Local 132 archives";
+  dc:identifier "0117-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/15544> .
+
+<http://vocab.lib.umd.edu/collection#0117-MDHC> rdfs:label "Osburn Family papers";
+  dc:identifier "0117-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1271> .
+
+<http://vocab.lib.umd.edu/collection#0117-MMC-NPBA> rdfs:label "C. Scott Fletcher papers";
+  dc:identifier "0117-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1554> .
+
+<http://vocab.lib.umd.edu/collection#0117-SCPA> rdfs:label "George Tremblay papers";
+  dc:identifier "0117-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19198> .
+
+<http://vocab.lib.umd.edu/collection#0117-UA> rdfs:label "Helen Bewley collection";
+  dc:identifier "0117-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/8872> .
+
+<http://vocab.lib.umd.edu/collection#0118-LBR> rdfs:label "Albert Herling memorabilia";
+  dc:identifier "0118-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/9068> .
+
+<http://vocab.lib.umd.edu/collection#0118-MMC-NPBA> rdfs:label "James Day papers";
+  dc:identifier "0118-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1555> .
+
+<http://vocab.lib.umd.edu/collection#0118-SCPA> rdfs:label "Society for Music Theory Archives";
+  dc:identifier "0118-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19223> .
+
+<http://vocab.lib.umd.edu/collection#0118-UA> rdfs:label "Charles E. Bishop photographs";
+  dc:identifier "0118-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/8873> .
+
+<http://vocab.lib.umd.edu/collection#0119-LBR> rdfs:label "Patricia Cooper papers";
+  dc:identifier "0119-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/9064> .
+
+<http://vocab.lib.umd.edu/collection#0119-MMC-NPBA> rdfs:label "William G. Harley papers";
+  dc:identifier "0119-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1556> .
+
+<http://vocab.lib.umd.edu/collection#0119-SCPA> rdfs:label "Don Wilcox Collection";
+  dc:identifier "0119-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19226> .
+
+<http://vocab.lib.umd.edu/collection#0119-UA> rdfs:label "Charles R. Hayleck, Jr. film reels";
+  dc:identifier "0119-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/8874> .
+
+<http://vocab.lib.umd.edu/collection#0120-LBR> rdfs:label "United Brotherhood of Carpenters and Joiners of America (UBCJA) archives";
+  dc:identifier "0120-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/1393> .
+
+<http://vocab.lib.umd.edu/collection#0120-MMC-NPBA> rdfs:label "Samuel C.O. Holt papers";
+  dc:identifier "0120-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1557> .
+
+<http://vocab.lib.umd.edu/collection#0120-SCPA> rdfs:label "International Tuba Euphonium Association (ITEA) Archive";
+  dc:identifier "0120-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19229> .
+
+<http://vocab.lib.umd.edu/collection#0120-UA> rdfs:label "William P. Gottlieb negatives";
+  dc:identifier "0120-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/8875> .
+
+<http://vocab.lib.umd.edu/collection#0121-MMC> rdfs:label "Jeffrey Kadet TV Guide collection";
+  dc:identifier "0121-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42610> .
+
+<http://vocab.lib.umd.edu/collection#0121-SCPA> rdfs:label "Concert Society at Maryland Archives";
+  dc:identifier "0121-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19225> .
+
+<http://vocab.lib.umd.edu/collection#0121-UA> rdfs:label "Betty Quirk Clarke memorabilia and photographs";
+  dc:identifier "0121-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/8876> .
+
+<http://vocab.lib.umd.edu/collection#0122-LBR> rdfs:label "Word H. Mills papers";
+  dc:identifier "0122-LBR";
+  owl:sameAs <http://hdl.handle.net/1903.1/1263> .
+
+<http://vocab.lib.umd.edu/collection#0122-MDHC> rdfs:label "Louis Pocquet papers";
+  dc:identifier "0122-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1276> .
+
+<http://vocab.lib.umd.edu/collection#0122-MMC> rdfs:label "<emph>DX News </emph>collection";
+  dc:identifier "0122-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42611> .
+
+<http://vocab.lib.umd.edu/collection#0122-SCPA> rdfs:label "Records of the National Association of Teachers of Singing (NATS)";
+  dc:identifier "0122-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19269> .
+
+<http://vocab.lib.umd.edu/collection#0123-MDHC> rdfs:label "Willis A. Pomeroy papers";
+  dc:identifier "0123-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1277> .
+
+<http://vocab.lib.umd.edu/collection#0123-MMC-NPBA> rdfs:label "Jim Karayn Papers";
+  dc:identifier "0123-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1558> .
+
+<http://vocab.lib.umd.edu/collection#0123-SCPA> rdfs:label "Nora Davenport Collection on Drum Set Methods";
+  dc:identifier "0123-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19426> .
+
+<http://vocab.lib.umd.edu/collection#0123-UA> rdfs:label "Fred Demarr collection";
+  dc:identifier "0123-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/8878> .
+
+<http://vocab.lib.umd.edu/collection#0124-MDHC> rdfs:label "Preston Family papers";
+  dc:identifier "0124-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1278> .
+
+<http://vocab.lib.umd.edu/collection#0124-MMC-LAB> rdfs:label "Edythe Meserand papers";
+  dc:identifier "0124-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/3297> .
+
+<http://vocab.lib.umd.edu/collection#0124-SCPA> rdfs:label "Harold Brown Collection";
+  dc:identifier "0124-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19427> .
+
+<http://vocab.lib.umd.edu/collection#0124-UA> rdfs:label "Francis S. Mastropietro collection";
+  dc:identifier "0124-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24646> .
+
+<http://vocab.lib.umd.edu/collection#0125-MDHC> rdfs:label "Prince George's Community Council records";
+  dc:identifier "0125-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1279> .
+
+<http://vocab.lib.umd.edu/collection#0125-MMC-LAB> rdfs:label "Mildred Funnell papers";
+  dc:identifier "0125-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/1490> .
+
+<http://vocab.lib.umd.edu/collection#0125-SCPA> rdfs:label "James Felton Papers";
+  dc:identifier "0125-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19428> .
+
+<http://vocab.lib.umd.edu/collection#0125-UA> rdfs:label "William F. Dove photographs";
+  dc:identifier "0125-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/8879> .
+
+<http://vocab.lib.umd.edu/collection#0126-MDHC> rdfs:label "Warner B. Ragsdale papers";
+  dc:identifier "0126-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1280> .
+
+<http://vocab.lib.umd.edu/collection#0126-MMC-NPBA> rdfs:label "Douglas F. Bodwell papers";
+  dc:identifier "0126-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1561> .
+
+<http://vocab.lib.umd.edu/collection#0126-SCPA> rdfs:label "Judith Lynne Hanna Collection";
+  dc:identifier "0126-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19429> .
+
+<http://vocab.lib.umd.edu/collection#0126-UA> rdfs:label "Mylo S. Downey papers";
+  dc:identifier "0126-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/8880> .
+
+<http://vocab.lib.umd.edu/collection#0127-MDHC> rdfs:label "Milton Reckord papers";
+  dc:identifier "0127-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1281> .
+
+<http://vocab.lib.umd.edu/collection#0127-MMC-NPBA> rdfs:label "Christopher Buchanan papers";
+  dc:identifier "0127-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1562> .
+
+<http://vocab.lib.umd.edu/collection#0127-SCPA> rdfs:label "Marguerite V. Hood Papers";
+  dc:identifier "0127-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19430> .
+
+<http://vocab.lib.umd.edu/collection#0127-UA> rdfs:label "Wilson H. Elkins papers";
+  dc:identifier "0127-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/8881> .
+
+<http://vocab.lib.umd.edu/collection#0128-MDHC> rdfs:label "Albert Ritchie papers";
+  dc:identifier "0128-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1282> .
+
+<http://vocab.lib.umd.edu/collection#0128-MMC-NPBA> rdfs:label "A. James Ebel papers";
+  dc:identifier "0128-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1563> .
+
+<http://vocab.lib.umd.edu/collection#0128-SCPA> rdfs:label "Stephen Albert papers";
+  dc:identifier "0128-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19431> .
+
+<http://vocab.lib.umd.edu/collection#0128-UA> rdfs:label "C. Walter England scrapbook and photographs";
+  dc:identifier "0128-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/8870> .
+
+<http://vocab.lib.umd.edu/collection#0129-MMC-NPBA> rdfs:label "Burt Harrison collection of public radio oral histories";
+  dc:identifier "0129-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1565> .
+
+<http://vocab.lib.umd.edu/collection#0129-SCPA> rdfs:label "Edward L. Longley papers";
+  dc:identifier "0129-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19432> .
+
+<http://vocab.lib.umd.edu/collection#0130-MDHC> rdfs:label "Women in Development collection";
+  dc:identifier "0130-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1284> .
+
+<http://vocab.lib.umd.edu/collection#0130-MMC-NPBA> rdfs:label "Barton L. Griffith papers";
+  dc:identifier "0130-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1564> .
+
+<http://vocab.lib.umd.edu/collection#0130-SCPA> rdfs:label "Robert Klotman Papers";
+  dc:identifier "0130-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19476> .
+
+<http://vocab.lib.umd.edu/collection#0130-UA> rdfs:label "Alma H. Preinkert publication";
+  dc:identifier "0130-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24653> .
+
+<http://vocab.lib.umd.edu/collection#0131-MDHC> rdfs:label "William Sebald papers";
+  dc:identifier "0131-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1285> .
+
+<http://vocab.lib.umd.edu/collection#0131-MMC-LAB> rdfs:label "<title>Wisdom</title> records";
+  dc:identifier "0131-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/20693> .
+
+<http://vocab.lib.umd.edu/collection#0131-SCPA> rdfs:label "Paul Lehman papers";
+  dc:identifier "0131-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19477> .
+
+<http://vocab.lib.umd.edu/collection#0131-UA> rdfs:label "David Field Gymkana collection";
+  dc:identifier "0131-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/15549> .
+
+<http://vocab.lib.umd.edu/collection#0132-MDHC> rdfs:label "Charles Seib papers";
+  dc:identifier "0132-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1286> .
+
+<http://vocab.lib.umd.edu/collection#0132-MMC> rdfs:label "Mary Kelly papers";
+  dc:identifier "0132-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42612> .
+
+<http://vocab.lib.umd.edu/collection#0132-SCPA> rdfs:label "Russell V. Morgan Papers";
+  dc:identifier "0132-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19478> .
+
+<http://vocab.lib.umd.edu/collection#0133-MDHC> rdfs:label "John Shank papers";
+  dc:identifier "0133-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1287> .
+
+<http://vocab.lib.umd.edu/collection#0133-MMC> rdfs:label "Rhea G. Sikes papers";
+  dc:identifier "0133-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42613> .
+
+<http://vocab.lib.umd.edu/collection#0133-SCPA> rdfs:label "Hazel N. Morgan Papers";
+  dc:identifier "0133-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19479> .
+
+<http://vocab.lib.umd.edu/collection#0134-MDHC> rdfs:label "E. Roderick and Arthur Shipley papers";
+  dc:identifier "0134-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1288> .
+
+<http://vocab.lib.umd.edu/collection#0134-SCPA> rdfs:label "Larry Warren Papers";
+  dc:identifier "0134-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19480> .
+
+<http://vocab.lib.umd.edu/collection#0134-UA> rdfs:label "Herb Hartnett memorabilia";
+  dc:identifier "0134-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/15548> .
+
+<http://vocab.lib.umd.edu/collection#0135-MMC> rdfs:label "Kate Kunz Kogler papers";
+  dc:identifier "0135-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42614> .
+
+<http://vocab.lib.umd.edu/collection#0135-SCPA> rdfs:label "Allen Perdue Britton Papers";
+  dc:identifier "0135-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19481> .
+
+<http://vocab.lib.umd.edu/collection#0135-UA> rdfs:label "Records of Student Entertainment Events (SEE) records";
+  dc:identifier "0135-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/8101> .
+
+<http://vocab.lib.umd.edu/collection#0136-MMC> rdfs:label "Karen Leggett WMAL audio tapes";
+  dc:identifier "0136-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42615> .
+
+<http://vocab.lib.umd.edu/collection#0136-SCPA> rdfs:label "The Stanford Barouh Collection";
+  dc:identifier "0136-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19483> .
+
+<http://vocab.lib.umd.edu/collection#0136-UA> rdfs:label "Richard Hill collection";
+  dc:identifier "0136-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24059> .
+
+<http://vocab.lib.umd.edu/collection#0137-MDHC> rdfs:label "Sierra Club, Maryland Chapter records";
+  dc:identifier "0137-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1291> .
+
+<http://vocab.lib.umd.edu/collection#0137-MMC> rdfs:label "United States Marine Band transcription discs";
+  dc:identifier "0137-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42616> .
+
+<http://vocab.lib.umd.edu/collection#0137-SCPA> rdfs:label "Gillian Anderson papers";
+  dc:identifier "0137-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19488> .
+
+<http://vocab.lib.umd.edu/collection#0137-UA> rdfs:label "Milton M. Holden collection";
+  dc:identifier "0137-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24060> .
+
+<http://vocab.lib.umd.edu/collection#0138-MDHC> rdfs:label "Lathrop Smith papers";
+  dc:identifier "0138-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1292> .
+
+<http://vocab.lib.umd.edu/collection#0138-MMC> rdfs:label "Craig B. Fisher papers";
+  dc:identifier "0138-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42617> .
+
+<http://vocab.lib.umd.edu/collection#0138-SCPA> rdfs:label "Thomas DeLio papers";
+  dc:identifier "0138-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19489> .
+
+<http://vocab.lib.umd.edu/collection#0139-MDHC> rdfs:label "Maryland State Board of Agriculture Leaf Tobacco Sold monthly reports";
+  dc:identifier "0139-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1293> .
+
+<http://vocab.lib.umd.edu/collection#0139-MMC-LAB> rdfs:label "Irene Beasley papers";
+  dc:identifier "0139-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/3295> .
+
+<http://vocab.lib.umd.edu/collection#0139-SCPA> rdfs:label "Becky Dukes Collection";
+  dc:identifier "0139-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19490> .
+
+<http://vocab.lib.umd.edu/collection#0139-UA> rdfs:label "Leonard G. Mathias collection";
+  dc:identifier "0139-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24647> .
+
+<http://vocab.lib.umd.edu/collection#0140-MDHC> rdfs:label "James F. Stepter and the Steptoe Family papers";
+  dc:identifier "0140-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1294> .
+
+<http://vocab.lib.umd.edu/collection#0140-MMC-NPBA> rdfs:label "George Geesey papers";
+  dc:identifier "0140-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1567> .
+
+<http://vocab.lib.umd.edu/collection#0140-SCPA> rdfs:label "New Playwrights' Theatre Collection";
+  dc:identifier "0140-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19491> .
+
+<http://vocab.lib.umd.edu/collection#0141-MDHC> rdfs:label "Sterling Family papers";
+  dc:identifier "0141-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1295> .
+
+<http://vocab.lib.umd.edu/collection#0141-MMC-NPBA> rdfs:label "John C. Crabbe Papers";
+  dc:identifier "0141-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1566> .
+
+<http://vocab.lib.umd.edu/collection#0141-SCPA> rdfs:label "Bennett Reimer Papers";
+  dc:identifier "0141-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19492> .
+
+<http://vocab.lib.umd.edu/collection#0141-UA> rdfs:label "Harriet Husted McGinnis collection";
+  dc:identifier "0141-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24648> .
+
+<http://vocab.lib.umd.edu/collection#0142-MDHC> rdfs:label "William Stone papers";
+  dc:identifier "0142-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1296> .
+
+<http://vocab.lib.umd.edu/collection#0142-MMC> rdfs:label "Corporation for Public Broadcasting records";
+  dc:identifier "0142-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42145> .
+
+<http://vocab.lib.umd.edu/collection#0142-SCPA> rdfs:label "Clifford V. Buttelman Papers";
+  dc:identifier "0142-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19493> .
+
+<http://vocab.lib.umd.edu/collection#0142-UA> rdfs:label "Patrick M. Olmert collection";
+  dc:identifier "0142-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24654> .
+
+<http://vocab.lib.umd.edu/collection#0143-MDHC> rdfs:label "Thomson Francis Mason and Thomas Swann Families papers";
+  dc:identifier "0143-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1297> .
+
+<http://vocab.lib.umd.edu/collection#0143-MMC> rdfs:label "Douglas Gomery papers";
+  dc:identifier "0143-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42418> .
+
+<http://vocab.lib.umd.edu/collection#0143-SCPA> rdfs:label "Charles L. Gary Papers";
+  dc:identifier "0143-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19494> .
+
+<http://vocab.lib.umd.edu/collection#0143-UA> rdfs:label "Samuel Regester collection";
+  dc:identifier "0143-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24655> .
+
+<http://vocab.lib.umd.edu/collection#0144-MDHC> rdfs:label "Thomas B. Symons papers";
+  dc:identifier "0144-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1298> .
+
+<http://vocab.lib.umd.edu/collection#0144-MMC-NPBA> rdfs:label "James Leaders Loper Papers";
+  dc:identifier "0144-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1568> .
+
+<http://vocab.lib.umd.edu/collection#0144-SCPA> rdfs:label "Howard Serwer Papers";
+  dc:identifier "0144-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19495> .
+
+<http://vocab.lib.umd.edu/collection#0144-UA> rdfs:label "Charles Ross collection";
+  dc:identifier "0144-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24127> .
+
+<http://vocab.lib.umd.edu/collection#0145-MDHC> rdfs:label "Thomas Family papers";
+  dc:identifier "0145-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1299> .
+
+<http://vocab.lib.umd.edu/collection#0145-MMC-NPBA> rdfs:label "Margaret Chisholm Papers";
+  dc:identifier "0145-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1569> .
+
+<http://vocab.lib.umd.edu/collection#0145-SCPA> rdfs:label "Jackson R. Bryer Interviews Collection";
+  dc:identifier "0145-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19556> .
+
+<http://vocab.lib.umd.edu/collection#0145-UA> rdfs:label "Oswald Hurt Saunders collection";
+  dc:identifier "0145-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24114> .
+
+<http://vocab.lib.umd.edu/collection#0146-SCPA> rdfs:label "Studio Theatre Archives, The";
+  dc:identifier "0146-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19638> .
+
+<http://vocab.lib.umd.edu/collection#0146-UA> rdfs:label "H. Burton Shipley papers";
+  dc:identifier "0146-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24115> .
+
+<http://vocab.lib.umd.edu/collection#0147-MDHC> rdfs:label "Robert Gilmor and William Trippe papers";
+  dc:identifier "0147-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1301> .
+
+<http://vocab.lib.umd.edu/collection#0147-MMC-NPBA> rdfs:label "Edmund F. Ball papers";
+  dc:identifier "0147-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1572> .
+
+<http://vocab.lib.umd.edu/collection#0147-SCPA> rdfs:label "William H. Hill Collection";
+  dc:identifier "0147-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/20845> .
+
+<http://vocab.lib.umd.edu/collection#0148-MMC-NPBA> rdfs:label "William M. Brish papers";
+  dc:identifier "0148-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1573> .
+
+<http://vocab.lib.umd.edu/collection#0148-SCPA> rdfs:label "The Robert Parris Papers";
+  dc:identifier "0148-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/21142> .
+
+<http://vocab.lib.umd.edu/collection#0149-MDHC> rdfs:label "Joseph D. Tydings papers";
+  dc:identifier "0149-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1303> .
+
+<http://vocab.lib.umd.edu/collection#0149-MMC-NPBA> rdfs:label "David L. Crippens papers";
+  dc:identifier "0149-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1574> .
+
+<http://vocab.lib.umd.edu/collection#0149-SCPA> rdfs:label "Karl Wilson Gehrkens papers";
+  dc:identifier "0149-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/21141> .
+
+<http://vocab.lib.umd.edu/collection#0149-UA> rdfs:label "Alumni Association records";
+  dc:identifier "0149-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/10900> .
+
+<http://vocab.lib.umd.edu/collection#0150-MDHC> rdfs:label "Millard E. Tydings papers";
+  dc:identifier "0150-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1304> .
+
+<http://vocab.lib.umd.edu/collection#0150-MMC-NPBA> rdfs:label "Donley F. Feddersen papers";
+  dc:identifier "0150-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1575> .
+
+<http://vocab.lib.umd.edu/collection#0150-SCPA> rdfs:label "Glenn Gildersleeve Papers";
+  dc:identifier "0150-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/21140> .
+
+<http://vocab.lib.umd.edu/collection#0150-UA> rdfs:label "School of Architecture records";
+  dc:identifier "0150-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/10366> .
+
+<http://vocab.lib.umd.edu/collection#0151-MDHC> rdfs:label "Murray Vandiver papers";
+  dc:identifier "0151-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1305> .
+
+<http://vocab.lib.umd.edu/collection#0151-MMC-NPBA> rdfs:label "Edwin G. Burrows papers";
+  dc:identifier "0151-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1576> .
+
+<http://vocab.lib.umd.edu/collection#0151-SCPA> rdfs:label "Robert A. Choate Papers";
+  dc:identifier "0151-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/21138> .
+
+<http://vocab.lib.umd.edu/collection#0151-UA> rdfs:label "Department of Architecture, Engineering, and Construction records";
+  dc:identifier "0151-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/10364> .
+
+<http://vocab.lib.umd.edu/collection#0152-MDHC> rdfs:label "Vansville Farmers Club records";
+  dc:identifier "0152-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1306> .
+
+<http://vocab.lib.umd.edu/collection#0152-MMC-NPBA> rdfs:label "Susan Fratkin papers";
+  dc:identifier "0152-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1578> .
+
+<http://vocab.lib.umd.edu/collection#0152-SCPA> rdfs:label "Frances M. Andrews Papers";
+  dc:identifier "0152-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/21139> .
+
+<http://vocab.lib.umd.edu/collection#0152-UA> rdfs:label "College of Arts and Humanities records";
+  dc:identifier "0152-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/10901> .
+
+<http://vocab.lib.umd.edu/collection#0153-MDHC> rdfs:label "Fletcher Pearre Veitch papers";
+  dc:identifier "0153-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1307> .
+
+<http://vocab.lib.umd.edu/collection#0153-MMC-NPBA> rdfs:label "Lee C. Frischknecht papers";
+  dc:identifier "0153-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1579> .
+
+<http://vocab.lib.umd.edu/collection#0153-SCPA> rdfs:label "Maryland Music Educators Association (MMEA) Archives";
+  dc:identifier "0153-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/21208> .
+
+<http://vocab.lib.umd.edu/collection#0153-UA> rdfs:label "Records of the Centennial Committee-Land Grant Colleges";
+  dc:identifier "0153-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/11029> .
+
+<http://vocab.lib.umd.edu/collection#0154-MDHC> rdfs:label "Hubert Kelly Waldron papers";
+  dc:identifier "0154-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1308> .
+
+<http://vocab.lib.umd.edu/collection#0154-MMC-NPBA> rdfs:label "Earl H. \"Bud\" Gillis papers";
+  dc:identifier "0154-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1580> .
+
+<http://vocab.lib.umd.edu/collection#0154-SCPA> rdfs:label "John Merrill Knapp Papers";
+  dc:identifier "0154-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/21207> .
+
+<http://vocab.lib.umd.edu/collection#0154-UA> rdfs:label "Campus Rights Committee records";
+  dc:identifier "0154-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/10898> .
+
+<http://vocab.lib.umd.edu/collection#0155-MDHC> rdfs:label "Warfield Family papers";
+  dc:identifier "0155-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1309> .
+
+<http://vocab.lib.umd.edu/collection#0155-MMC-NPBA> rdfs:label "Presley D. Holmes papers";
+  dc:identifier "0155-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1581> .
+
+<http://vocab.lib.umd.edu/collection#0155-SCPA> rdfs:label "Silver Burdett Company Collection";
+  dc:identifier "0155-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/21206> .
+
+<http://vocab.lib.umd.edu/collection#0155-UA> rdfs:label "Concerts collection";
+  dc:identifier "0155-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/10902> .
+
+<http://vocab.lib.umd.edu/collection#0156-MDHC> rdfs:label "Weems-Reynolds Family papers";
+  dc:identifier "0156-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1310> .
+
+<http://vocab.lib.umd.edu/collection#0156-MMC-NPBA> rdfs:label "Raymond D. Hurlbert papers";
+  dc:identifier "0156-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/11189> .
+
+<http://vocab.lib.umd.edu/collection#0156-SCPA> rdfs:label "Hedi Pope and CODA Collection";
+  dc:identifier "0156-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/21853> .
+
+<http://vocab.lib.umd.edu/collection#0156-UA> rdfs:label "Office of Fraternity and Sorority Life records";
+  dc:identifier "0156-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/10899> .
+
+<http://vocab.lib.umd.edu/collection#0157-MDHC> rdfs:label "Carol Wharton papers";
+  dc:identifier "0157-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1311> .
+
+<http://vocab.lib.umd.edu/collection#0157-MMC-NPBA> rdfs:label "Joseph S. Iseman papers";
+  dc:identifier "0157-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1582> .
+
+<http://vocab.lib.umd.edu/collection#0157-SCPA> rdfs:label "C. William Johnson Collection";
+  dc:identifier "0157-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/21854> .
+
+<http://vocab.lib.umd.edu/collection#0157-UA> rdfs:label "University of Maryland Posters and Broadsides collection";
+  dc:identifier "0157-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/11118> .
+
+<http://vocab.lib.umd.edu/collection#0158-MDHC> rdfs:label "William Wilson papers";
+  dc:identifier "0158-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1312> .
+
+<http://vocab.lib.umd.edu/collection#0158-MMC-NPBA> rdfs:label "Laurence A. Jarvik papers";
+  dc:identifier "0158-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1583> .
+
+<http://vocab.lib.umd.edu/collection#0158-SCPA> rdfs:label "Marcia Herndon Papers";
+  dc:identifier "0158-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/21855> .
+
+<http://vocab.lib.umd.edu/collection#0158-UA> rdfs:label "Ralph J. Tyser collection";
+  dc:identifier "0158-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/10365> .
+
+<http://vocab.lib.umd.edu/collection#0159-MMC-NPBA> rdfs:label "Gays and Lesbians in Public Radio (GLIPR) Records";
+  dc:identifier "0159-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42649> .
+
+<http://vocab.lib.umd.edu/collection#0159-SCPA> rdfs:label "Edmund Cykler Collection of International Music Education Resources";
+  dc:identifier "0159-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/22535> .
+
+<http://vocab.lib.umd.edu/collection#0159-UA> rdfs:label "Alpha Phi Omega records";
+  dc:identifier "0159-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/14868> .
+
+<http://vocab.lib.umd.edu/collection#0160-MDHC> rdfs:label "William W. W. Wood papers";
+  dc:identifier "0160-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1314> .
+
+<http://vocab.lib.umd.edu/collection#0160-SCPA> rdfs:label "Organization of American Kodaly Educators Archives";
+  dc:identifier "0160-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/23341> .
+
+<http://vocab.lib.umd.edu/collection#0160-UA> rdfs:label "Daniel Prescott papers";
+  dc:identifier "0160-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/15650> .
+
+<http://vocab.lib.umd.edu/collection#0161-MDHC> rdfs:label "Bertha (Gerneaux) Davis and Albert Fred Woods papers";
+  dc:identifier "0161-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1315> .
+
+<http://vocab.lib.umd.edu/collection#0161-MMC> rdfs:label "Radio Advertising Bureau collection";
+  dc:identifier "0161-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/17190> .
+
+<http://vocab.lib.umd.edu/collection#0161-SCPA> rdfs:label "Minas Christian Papers";
+  dc:identifier "0161-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/23396> .
+
+<http://vocab.lib.umd.edu/collection#0161-UA> rdfs:label "Joan S. Hult papers";
+  dc:identifier "0161-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/16067> .
+
+<http://vocab.lib.umd.edu/collection#0162-MDHC> rdfs:label "John and Margaret Hood Zug papers";
+  dc:identifier "0162-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1316> .
+
+<http://vocab.lib.umd.edu/collection#0162-MMC> rdfs:label "<title>St. Louis Post-Dispatch</title> photographs";
+  dc:identifier "0162-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42461> .
+
+<http://vocab.lib.umd.edu/collection#0162-SCPA> rdfs:label "College Music Society Archives";
+  dc:identifier "0162-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/23397> .
+
+<http://vocab.lib.umd.edu/collection#0162-UA> rdfs:label "Wilhelmina F. Jashemski papers";
+  dc:identifier "0162-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19021> .
+
+<http://vocab.lib.umd.edu/collection#0163-MMC-NPBA> rdfs:label "Patsy P. Layne papers";
+  dc:identifier "0163-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1584> .
+
+<http://vocab.lib.umd.edu/collection#0163-SCPA> rdfs:label "KodÃ¡ly Center of America archives";
+  dc:identifier "0163-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/23398> .
+
+<http://vocab.lib.umd.edu/collection#0163-UA> rdfs:label "Terrapin Trail Club records";
+  dc:identifier "0163-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19083> .
+
+<http://vocab.lib.umd.edu/collection#0164-MMC> rdfs:label "Joseph A. Flaherty papers";
+  dc:identifier "0164-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42479> .
+
+<http://vocab.lib.umd.edu/collection#0164-SCPA> rdfs:label "Satis Coleman Collection";
+  dc:identifier "0164-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/23399> .
+
+<http://vocab.lib.umd.edu/collection#0164-UA> rdfs:label "Theodore H. McNelly papers";
+  dc:identifier "0164-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24649> .
+
+<http://vocab.lib.umd.edu/collection#0165-MDHC> rdfs:label "Maryland Tobacco Improvement Foundation records";
+  dc:identifier "0165-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1319> .
+
+<http://vocab.lib.umd.edu/collection#0165-SCPA> rdfs:label "Boden Sandstrom Papers";
+  dc:identifier "0165-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/23400> .
+
+<http://vocab.lib.umd.edu/collection#0165-UA> rdfs:label "Jack Minker papers";
+  dc:identifier "0165-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/19770> .
+
+<http://vocab.lib.umd.edu/collection#0166-SCPA> rdfs:label "John Wheeler Tufts Collection";
+  dc:identifier "0166-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/23401> .
+
+<http://vocab.lib.umd.edu/collection#0166-UA> rdfs:label "Gymkana records";
+  dc:identifier "0166-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24061> .
+
+<http://vocab.lib.umd.edu/collection#0167-MDHC> rdfs:label "Bowie Family papers";
+  dc:identifier "0167-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1321> .
+
+<http://vocab.lib.umd.edu/collection#0167-MMC-NPBA> rdfs:label "Alan F. Lewis papers";
+  dc:identifier "0167-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1585> .
+
+<http://vocab.lib.umd.edu/collection#0167-SCPA> rdfs:label "John Owen Ward papers";
+  dc:identifier "0167-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/23536> .
+
+<http://vocab.lib.umd.edu/collection#0167-UA> rdfs:label "Footlight Club photographs";
+  dc:identifier "0167-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24062> .
+
+<http://vocab.lib.umd.edu/collection#0168-MDHC> rdfs:label "Gene A. Chesley papers";
+  dc:identifier "0168-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1322> .
+
+<http://vocab.lib.umd.edu/collection#0168-MMC> rdfs:label "WHB Radio scrapbooks";
+  dc:identifier "0168-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42498> .
+
+<http://vocab.lib.umd.edu/collection#0168-SCPA> rdfs:label "Patti P. Gillespie Slides Collection";
+  dc:identifier "0168-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/23545> .
+
+<http://vocab.lib.umd.edu/collection#0168-UA> rdfs:label "Gamer Symphony Orchestra records";
+  dc:identifier "0168-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24063> .
+
+<http://vocab.lib.umd.edu/collection#0169-MDHC> rdfs:label "David Stewart Courtenay papers";
+  dc:identifier "0169-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1323> .
+
+<http://vocab.lib.umd.edu/collection#0169-MMC> rdfs:label "WGAZ/WSBT Station records";
+  dc:identifier "0169-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/21273> .
+
+<http://vocab.lib.umd.edu/collection#0169-SCPA> rdfs:label "UMD Visual Press andamp; San Quentin Drama Workshop Samuel Beckett's ENDGAME Collection";
+  dc:identifier "0169-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/23546> .
+
+<http://vocab.lib.umd.edu/collection#0169-UA> rdfs:label "Jimmy H.C. Lin papers";
+  dc:identifier "0169-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24064> .
+
+<http://vocab.lib.umd.edu/collection#0170-MDHC> rdfs:label "D. McLean Forman papers";
+  dc:identifier "0170-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1324> .
+
+<http://vocab.lib.umd.edu/collection#0170-MMC> rdfs:label "Shirley Eggleston Haner papers";
+  dc:identifier "0170-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42501> .
+
+<http://vocab.lib.umd.edu/collection#0170-SCPA> rdfs:label "Eugene Morlan Papers";
+  dc:identifier "0170-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24230> .
+
+<http://vocab.lib.umd.edu/collection#0170-UA> rdfs:label "M Book collection";
+  dc:identifier "0170-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24065> .
+
+<http://vocab.lib.umd.edu/collection#0171-MDHC> rdfs:label "Hagerstown Bank collection";
+  dc:identifier "0171-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1325> .
+
+<http://vocab.lib.umd.edu/collection#0171-MMC-NPBA> rdfs:label "Lisle L. Longsdorf papers";
+  dc:identifier "0171-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1587> .
+
+<http://vocab.lib.umd.edu/collection#0171-SCPA> rdfs:label "Gladys Pitcher Papers";
+  dc:identifier "0171-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24233> .
+
+<http://vocab.lib.umd.edu/collection#0171-UA> rdfs:label "New Student Welcome and Picnic collection";
+  dc:identifier "0171-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24656> .
+
+<http://vocab.lib.umd.edu/collection#0172-MDHC> rdfs:label "George Hanst papers";
+  dc:identifier "0172-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1326> .
+
+<http://vocab.lib.umd.edu/collection#0172-MMC-NPBA> rdfs:label "Donald R. McNeil papers";
+  dc:identifier "0172-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1589> .
+
+<http://vocab.lib.umd.edu/collection#0172-SCPA> rdfs:label "Paul Traver Papers";
+  dc:identifier "0172-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24229> .
+
+<http://vocab.lib.umd.edu/collection#0172-UA> rdfs:label "Maryland Men's Basketball collection";
+  dc:identifier "0172-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24657> .
+
+<http://vocab.lib.umd.edu/collection#0173-MDHC> rdfs:label "John E. Rastall papers";
+  dc:identifier "0173-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1327> .
+
+<http://vocab.lib.umd.edu/collection#0173-MMC-NPBA> rdfs:label "Midwest Program on Airborne Television Instruction (MPATI) records";
+  dc:identifier "0173-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1591> .
+
+<http://vocab.lib.umd.edu/collection#0173-SCPA> rdfs:label "Lyons Band Instrument Company Collection";
+  dc:identifier "0173-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24549> .
+
+<http://vocab.lib.umd.edu/collection#0173-UA> rdfs:label "Women's Athletics collection";
+  dc:identifier "0173-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24124> .
+
+<http://vocab.lib.umd.edu/collection#0174-MMC> rdfs:label "Alois Havrilla papers";
+  dc:identifier "0174-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42503> .
+
+<http://vocab.lib.umd.edu/collection#0174-MMC-NPBA> rdfs:label "Keith W. Mielke papers";
+  dc:identifier "0174-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1592> .
+
+<http://vocab.lib.umd.edu/collection#0174-SCPA> rdfs:label "H. Robert Cohen Collection on Teatro alla Scala";
+  dc:identifier "0174-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24550> .
+
+<http://vocab.lib.umd.edu/collection#0174-UA> rdfs:label "Flora Waldman Reid collection";
+  dc:identifier "0174-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24116> .
+
+<http://vocab.lib.umd.edu/collection#0175-MDHC> rdfs:label "Francis C. Renner papers";
+  dc:identifier "0175-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1329> .
+
+<http://vocab.lib.umd.edu/collection#0175-SCPA> rdfs:label "Community Songbook Collection";
+  dc:identifier "0175-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/25016> .
+
+<http://vocab.lib.umd.edu/collection#0175-UA> rdfs:label "Harold O. Thomen collection";
+  dc:identifier "0175-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24117> .
+
+<http://vocab.lib.umd.edu/collection#0176-MDHC> rdfs:label "David and Elizabeth Scull papers";
+  dc:identifier "0176-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1330> .
+
+<http://vocab.lib.umd.edu/collection#0176-MMC-NPBA> rdfs:label "LaVerne W. Miller papers";
+  dc:identifier "0176-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1594> .
+
+<http://vocab.lib.umd.edu/collection#0176-SCPA> rdfs:label "Curriculum Guide Collection";
+  dc:identifier "0176-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/25017> .
+
+<http://vocab.lib.umd.edu/collection#0176-UA> rdfs:label "Roy H. Waite collection";
+  dc:identifier "0176-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24119> .
+
+<http://vocab.lib.umd.edu/collection#0177-MMC-NPBA> rdfs:label "Robert A. Mott papers";
+  dc:identifier "0177-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1595> .
+
+<http://vocab.lib.umd.edu/collection#0177-SCPA> rdfs:label "Method Books Collection";
+  dc:identifier "0177-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/25018> .
+
+<http://vocab.lib.umd.edu/collection#0177-UA> rdfs:label "Phyllis Knode Steen collection";
+  dc:identifier "0177-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24118> .
+
+<http://vocab.lib.umd.edu/collection#0178-MDHC> rdfs:label "Jean Spencer papers";
+  dc:identifier "0178-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1332> .
+
+<http://vocab.lib.umd.edu/collection#0178-MMC-NPBA> rdfs:label "National Federation of Community Broadcasters (NFCB) records";
+  dc:identifier "0178-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1596> .
+
+<http://vocab.lib.umd.edu/collection#0178-SCPA> rdfs:label "Operettas for Children Collection";
+  dc:identifier "0178-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/25019> .
+
+<http://vocab.lib.umd.edu/collection#0178-UA> rdfs:label "Jonas Rappeport collection";
+  dc:identifier "0178-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24658> .
+
+<http://vocab.lib.umd.edu/collection#0179-MDHC> rdfs:label "Woman's Suburban Democratic Club records";
+  dc:identifier "0179-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1333> .
+
+<http://vocab.lib.umd.edu/collection#0179-MMC-NPBA> rdfs:label "National Friends of Public Broadcasting (NFPB) records";
+  dc:identifier "0179-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1597> .
+
+<http://vocab.lib.umd.edu/collection#0179-SCPA> rdfs:label "School Music Textbooks Collection";
+  dc:identifier "0179-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/25020> .
+
+<http://vocab.lib.umd.edu/collection#0179-UA> rdfs:label "Bill Weems collection";
+  dc:identifier "0179-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24128> .
+
+<http://vocab.lib.umd.edu/collection#0180-MDHC> rdfs:label "Henry Powell Hopkins papers";
+  dc:identifier "0180-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1334> .
+
+<http://vocab.lib.umd.edu/collection#0180-MMC-NPBA> rdfs:label "Pacifica Foundation records";
+  dc:identifier "0180-MMC-NPBA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1600> .
+
+<http://vocab.lib.umd.edu/collection#0180-SCPA> rdfs:label "Geary Henderson Larrick Papers";
+  dc:identifier "0180-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/25006> .
+
+<http://vocab.lib.umd.edu/collection#0180-UA> rdfs:label "George Weber collection";
+  dc:identifier "0180-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24122> .
+
+<http://vocab.lib.umd.edu/collection#0181-MDHC> rdfs:label "John McConnell papers";
+  dc:identifier "0181-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1335> .
+
+<http://vocab.lib.umd.edu/collection#0181-MMC> rdfs:label "Broadcast Education Association (BEA) records";
+  dc:identifier "0181-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/23730> .
+
+<http://vocab.lib.umd.edu/collection#0181-SCPA> rdfs:label "Queens Symphonic Band Collection";
+  dc:identifier "0181-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/25007> .
+
+<http://vocab.lib.umd.edu/collection#0181-UA> rdfs:label "Barry Gossett collection";
+  dc:identifier "0181-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24066> .
+
+<http://vocab.lib.umd.edu/collection#0182-MDHC> rdfs:label "Joseph Raynes papers";
+  dc:identifier "0182-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1336> .
+
+<http://vocab.lib.umd.edu/collection#0182-SCPA> rdfs:label "Salvatore Minichini Music Collection";
+  dc:identifier "0182-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/25021> .
+
+<http://vocab.lib.umd.edu/collection#0182-UA> rdfs:label "Jacqueline Heise collection";
+  dc:identifier "0182-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24067> .
+
+<http://vocab.lib.umd.edu/collection#0183-MDHC> rdfs:label "Theodore R. McCann papers";
+  dc:identifier "0183-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1337> .
+
+<http://vocab.lib.umd.edu/collection#0183-SCPA> rdfs:label "Maryland Summer Institute for the Creative and Performing Arts (MSICPA) Collection";
+  dc:identifier "0183-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/25009> .
+
+<http://vocab.lib.umd.edu/collection#0183-UA> rdfs:label "Homecoming collection";
+  dc:identifier "0183-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24068> .
+
+<http://vocab.lib.umd.edu/collection#0184-MDHC> rdfs:label "Jandl-Stevenson collection";
+  dc:identifier "0184-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1338> .
+
+<http://vocab.lib.umd.edu/collection#0184-SCPA> rdfs:label "Pillsbury Foundation School records";
+  dc:identifier "0184-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/25010> .
+
+<http://vocab.lib.umd.edu/collection#0184-UA> rdfs:label "May Day collection";
+  dc:identifier "0184-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24650> .
+
+<http://vocab.lib.umd.edu/collection#0185-MDHC> rdfs:label "Robert Fergusson and Alexander Hamilton papers";
+  dc:identifier "0185-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1339> .
+
+<http://vocab.lib.umd.edu/collection#0185-MMC> rdfs:label "Special Collections in Mass Media and Culture Serials collection";
+  dc:identifier "0185-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/18683> .
+
+<http://vocab.lib.umd.edu/collection#0185-SCPA> rdfs:label "Alice Parker Collection";
+  dc:identifier "0185-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/25011> .
+
+<http://vocab.lib.umd.edu/collection#0185-UA> rdfs:label "Mildred P. Smith collection";
+  dc:identifier "0185-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24129> .
+
+<http://vocab.lib.umd.edu/collection#0186-MMC> rdfs:label "Elizabeth L. Young papers";
+  dc:identifier "0186-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/8281> .
+
+<http://vocab.lib.umd.edu/collection#0186-SCPA> rdfs:label "James L. Fisher Collection";
+  dc:identifier "0186-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/25012> .
+
+<http://vocab.lib.umd.edu/collection#0186-UA> rdfs:label "Gay Student Alliance records";
+  dc:identifier "0186-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24069> .
+
+<http://vocab.lib.umd.edu/collection#0187-MDHC> rdfs:label "Reuben Gilder papers";
+  dc:identifier "0187-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1341> .
+
+<http://vocab.lib.umd.edu/collection#0187-SCPA> rdfs:label "Karl King Score Collection";
+  dc:identifier "0187-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/25008> .
+
+<http://vocab.lib.umd.edu/collection#0187-UA> rdfs:label "Young Socialist Alliance records";
+  dc:identifier "0187-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24125> .
+
+<http://vocab.lib.umd.edu/collection#0188-MDHC> rdfs:label "John T. Whalen papers";
+  dc:identifier "0188-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1342> .
+
+<http://vocab.lib.umd.edu/collection#0188-SCPA> rdfs:label "Mayhew Lake \"Symphony in Gold\" scores collection";
+  dc:identifier "0188-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/25013> .
+
+<http://vocab.lib.umd.edu/collection#0189-MMC> rdfs:label "Library of American Broadcasting Scripts collection";
+  dc:identifier "0189-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/18512> .
+
+<http://vocab.lib.umd.edu/collection#0189-SCPA> rdfs:label "Star Music Company scores";
+  dc:identifier "0189-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/25014> .
+
+<http://vocab.lib.umd.edu/collection#0189-UA> rdfs:label "Charles W. Misner papers";
+  dc:identifier "0189-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24679> .
+
+<http://vocab.lib.umd.edu/collection#0190-MDHC> rdfs:label "Joan Dillon papers";
+  dc:identifier "0190-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1344> .
+
+<http://vocab.lib.umd.edu/collection#0190-MMC> rdfs:label "Fielden Farrington scripts";
+  dc:identifier "0190-MMC";
+  owl:sameAs <https://hdl.handle.net/1903.1/43848> .
+
+<http://vocab.lib.umd.edu/collection#0190-SCPA> rdfs:label "Minesinger Collection of Theatre Programs";
+  dc:identifier "0190-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/25015> .
+
+<http://vocab.lib.umd.edu/collection#0190-UA> rdfs:label "Richard Matteson collection";
+  dc:identifier "0190-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24651> .
+
+<http://vocab.lib.umd.edu/collection#0191-MMC> rdfs:label "Maurice Webster papers";
+  dc:identifier "0191-MMC";
+  owl:sameAs <https://hdl.handle.net/1903.1/43863> .
+
+<http://vocab.lib.umd.edu/collection#0191-SCPA> rdfs:label "International Association of Music Libraries (IAML) Archive";
+  dc:identifier "0191-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/25604> .
+
+<http://vocab.lib.umd.edu/collection#0191-UA> rdfs:label "Julian Simon papers";
+  dc:identifier "0191-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24121> .
+
+<http://vocab.lib.umd.edu/collection#0192-MDHC> rdfs:label "Association for Intercollegiate Athletics for Women (AIAW) records";
+  dc:identifier "0192-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1346> .
+
+<http://vocab.lib.umd.edu/collection#0192-MMC> rdfs:label "Alfred R. Schneider ABC speeches";
+  dc:identifier "0192-MMC";
+  owl:sameAs <https://hdl.handle.net/1903.1/43865> .
+
+<http://vocab.lib.umd.edu/collection#0192-SCPA> rdfs:label "Donald McGinnis papers";
+  dc:identifier "0192-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/25668> .
+
+<http://vocab.lib.umd.edu/collection#0192-UA> rdfs:label "Lewis Lawson papers";
+  dc:identifier "0192-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1525> .
+
+<http://vocab.lib.umd.edu/collection#0193-MDHC> rdfs:label "Gordon W. Prange papers";
+  dc:identifier "0193-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1347> .
+
+<http://vocab.lib.umd.edu/collection#0193-MMC> rdfs:label "Association for Recorded Sound Collections (ARSC) records";
+  dc:identifier "0193-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/19186> .
+
+<http://vocab.lib.umd.edu/collection#0193-SCPA> rdfs:label "American Bandmasters Association Research Center Score Collection";
+  dc:identifier "0193-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/25669> .
+
+<http://vocab.lib.umd.edu/collection#0193-UA> rdfs:label "William S. Peterson papers";
+  dc:identifier "0193-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1545> .
+
+<http://vocab.lib.umd.edu/collection#0194-MDHC> rdfs:label "American News Women's Club records";
+  dc:identifier "0194-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1348> .
+
+<http://vocab.lib.umd.edu/collection#0194-UA> rdfs:label "John Fuegi papers";
+  dc:identifier "0194-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1769> .
+
+<http://vocab.lib.umd.edu/collection#0195-SCPA> rdfs:label "D.C. Punk and Indie Fanzine collection";
+  dc:identifier "0195-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/26175> .
+
+<http://vocab.lib.umd.edu/collection#0195-UA> rdfs:label "Jane Donawerth papers";
+  dc:identifier "0195-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/7644> .
+
+<http://vocab.lib.umd.edu/collection#0196-MDHC> rdfs:label "Baltimore Environmental Center records";
+  dc:identifier "0196-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1350> .
+
+<http://vocab.lib.umd.edu/collection#0196-SCPA> rdfs:label "James Bolle papers";
+  dc:identifier "0196-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/26176> .
+
+<http://vocab.lib.umd.edu/collection#0196-UA> rdfs:label "William Milne Holton papers";
+  dc:identifier "0196-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/7850> .
+
+<http://vocab.lib.umd.edu/collection#0197-MDHC> rdfs:label "Samuel Moore Barclay papers";
+  dc:identifier "0197-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1351> .
+
+<http://vocab.lib.umd.edu/collection#0197-SCPA> rdfs:label "Harriet Mogge Collection";
+  dc:identifier "0197-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/26640> .
+
+<http://vocab.lib.umd.edu/collection#0197-UA> rdfs:label "Mukul Kundu papers";
+  dc:identifier "0197-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/15633> .
+
+<http://vocab.lib.umd.edu/collection#0198-MDHC> rdfs:label "Mary Boergers papers";
+  dc:identifier "0198-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1352> .
+
+<http://vocab.lib.umd.edu/collection#0198-SCPA> rdfs:label "Elizabeth Weaver Collection";
+  dc:identifier "0198-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/26641> .
+
+<http://vocab.lib.umd.edu/collection#0198-UA> rdfs:label "Martha J. Ross papers";
+  dc:identifier "0198-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/15311> .
+
+<http://vocab.lib.umd.edu/collection#0199-SCPA> rdfs:label "Eunice L. Boardman Collection";
+  dc:identifier "0199-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42747> .
+
+<http://vocab.lib.umd.edu/collection#0199-UA> rdfs:label "Ted R. Gurr papers";
+  dc:identifier "0199-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/9067> .
+
+<http://vocab.lib.umd.edu/collection#0200-MDHC> rdfs:label "Orin M. Bullock, Jr. papers";
+  dc:identifier "0200-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1354> .
+
+<http://vocab.lib.umd.edu/collection#0200-SCPA> rdfs:label "Leonard B. Smith Collection";
+  dc:identifier "0200-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42748> .
+
+<http://vocab.lib.umd.edu/collection#0200-UA> rdfs:label "R. Lee Hornbake awards";
+  dc:identifier "0200-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/9069> .
+
+<http://vocab.lib.umd.edu/collection#0201-SCPA> rdfs:label "Official Records of the American Composers Alliance (ACA)";
+  dc:identifier "0201-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/30672> .
+
+<http://vocab.lib.umd.edu/collection#0201-UA> rdfs:label "Donald Maley papers";
+  dc:identifier "0201-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24165> .
+
+<http://vocab.lib.umd.edu/collection#0202-SCPA> rdfs:label "William Foster Collection";
+  dc:identifier "0202-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/30907> .
+
+<http://vocab.lib.umd.edu/collection#0202-UA> rdfs:label "Graciela Nemes papers";
+  dc:identifier "0202-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24166> .
+
+<http://vocab.lib.umd.edu/collection#0203-SCPA> rdfs:label "Lawrence K. Moss papers";
+  dc:identifier "0203-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/31155> .
+
+<http://vocab.lib.umd.edu/collection#0203-UA> rdfs:label "WMUC records";
+  dc:identifier "0203-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/23599> .
+
+<http://vocab.lib.umd.edu/collection#0204-SCPA> rdfs:label "Joseph Schuster Cello Scores Collection";
+  dc:identifier "0204-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/31210> .
+
+<http://vocab.lib.umd.edu/collection#0204-UA> rdfs:label "Warren Evans papers";
+  dc:identifier "0204-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24675> .
+
+<http://vocab.lib.umd.edu/collection#0205-SCPA> rdfs:label "Michael Mark Rare Books Collection";
+  dc:identifier "0205-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/31209> .
+
+<http://vocab.lib.umd.edu/collection#0205-UA> rdfs:label "Giles B. Cooke photographs";
+  dc:identifier "0205-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42618> .
+
+<http://vocab.lib.umd.edu/collection#0206-SCPA> rdfs:label "Silver Spring Cooperative Nursery School: Ruth Crawford-Seeger Remembered Project Collection";
+  dc:identifier "0206-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/32167> .
+
+<http://vocab.lib.umd.edu/collection#0206-UA> rdfs:label "Harms Family DVDs";
+  dc:identifier "0206-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42619> .
+
+<http://vocab.lib.umd.edu/collection#0207-MDHC> rdfs:label "Henry Chandlee Forman papers";
+  dc:identifier "0207-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1361> .
+
+<http://vocab.lib.umd.edu/collection#0207-SCPA> rdfs:label "C.C. Birchard Company Collection";
+  dc:identifier "0207-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/32247> .
+
+<http://vocab.lib.umd.edu/collection#0208-SCPA> rdfs:label "George Bryan Papers";
+  dc:identifier "0208-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42749> .
+
+<http://vocab.lib.umd.edu/collection#0208-UA> rdfs:label "Pride Alliance records";
+  dc:identifier "0208-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42620> .
+
+<http://vocab.lib.umd.edu/collection#0209-SCPA> rdfs:label "Leon Major papers";
+  dc:identifier "0209-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/32428> .
+
+<http://vocab.lib.umd.edu/collection#0209-UA> rdfs:label "\"I'd Rather Be Studying\" Campus Motto collection";
+  dc:identifier "0209-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42621> .
+
+<http://vocab.lib.umd.edu/collection#0210-SCPA> rdfs:label "Charles O. Moody Collection";
+  dc:identifier "0210-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/32738> .
+
+<http://vocab.lib.umd.edu/collection#0210-UA> rdfs:label "Fear the Turtle Project collection";
+  dc:identifier "0210-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42622> .
+
+<http://vocab.lib.umd.edu/collection#0211-MDHC> rdfs:label "Clark S. Hobbs papers";
+  dc:identifier "0211-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1365> .
+
+<http://vocab.lib.umd.edu/collection#0211-SCPA> rdfs:label "Records of the University of Maryland Department of Dance";
+  dc:identifier "0211-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/32943> .
+
+<http://vocab.lib.umd.edu/collection#0211-UA> rdfs:label "Diamondback photographs";
+  dc:identifier "0211-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/25001> .
+
+<http://vocab.lib.umd.edu/collection#0212-MDHC> rdfs:label "Anne G. Ingram papers";
+  dc:identifier "0212-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1366> .
+
+<http://vocab.lib.umd.edu/collection#0212-SCPA> rdfs:label "Ruth Kafka on Theodore M. Tobani Collection";
+  dc:identifier "0212-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/32947> .
+
+<http://vocab.lib.umd.edu/collection#0212-UA> rdfs:label "PandemoniUM recordings";
+  dc:identifier "0212-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/25005> .
+
+<http://vocab.lib.umd.edu/collection#0213-GWP> rdfs:label "Japan-America Student Conference (JASC) records";
+  dc:identifier "0213-GWP";
+  owl:sameAs <http://hdl.handle.net/1903.1/1367> .
+
+<http://vocab.lib.umd.edu/collection#0213-SCPA> rdfs:label "Andre Kostelanetz Recordings Collection";
+  dc:identifier "0213-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/32958> .
+
+<http://vocab.lib.umd.edu/collection#0213-UA> rdfs:label "James Kehoe collection";
+  dc:identifier "0213-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42623> .
+
+<http://vocab.lib.umd.edu/collection#0214-MDHC> rdfs:label "Cheryl C. Kagan papers";
+  dc:identifier "0214-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1368> .
+
+<http://vocab.lib.umd.edu/collection#0214-SCPA> rdfs:label "The FranâˆšÃŸois Loup scores collection";
+  dc:identifier "0214-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/32984> .
+
+<http://vocab.lib.umd.edu/collection#0214-UA> rdfs:label "Irvin Wolf photographs";
+  dc:identifier "0214-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24995> .
+
+<http://vocab.lib.umd.edu/collection#0215-SCPA> rdfs:label "Raymond Luedeke papers";
+  dc:identifier "0215-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/33425> .
+
+<http://vocab.lib.umd.edu/collection#0215-UA> rdfs:label "Joseph Wilkinson photographs";
+  dc:identifier "0215-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24994> .
+
+<http://vocab.lib.umd.edu/collection#0216-MDHC> rdfs:label "Richard Estep Lankford papers";
+  dc:identifier "0216-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1370> .
+
+<http://vocab.lib.umd.edu/collection#0216-SCPA> rdfs:label "Michael Seyfrit papers";
+  dc:identifier "0216-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/33484> .
+
+<http://vocab.lib.umd.edu/collection#0216-UA> rdfs:label "Arthur Van Reuth photographs and penant";
+  dc:identifier "0216-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24993> .
+
+<http://vocab.lib.umd.edu/collection#0217-MDHC> rdfs:label "Lee Family papers";
+  dc:identifier "0217-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1371> .
+
+<http://vocab.lib.umd.edu/collection#0217-SCPA> rdfs:label "Robert Ellis Dunn collection";
+  dc:identifier "0217-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/33475> .
+
+<http://vocab.lib.umd.edu/collection#0217-UA> rdfs:label "Jack Zane collection";
+  dc:identifier "0217-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24996> .
+
+<http://vocab.lib.umd.edu/collection#0218-MDHC> rdfs:label "C. Thomas McMillen papers";
+  dc:identifier "0218-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1372> .
+
+<http://vocab.lib.umd.edu/collection#0218-SCPA> rdfs:label "Biography files collections, Special Collections in Performing Arts";
+  dc:identifier "0218-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/33480> .
+
+<http://vocab.lib.umd.edu/collection#0218-UA> rdfs:label "Lesbian, Gay, and Bisexual Alliance records";
+  dc:identifier "0218-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42624> .
+
+<http://vocab.lib.umd.edu/collection#0219-MDHC> rdfs:label "Mandel Family papers";
+  dc:identifier "0219-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1373> .
+
+<http://vocab.lib.umd.edu/collection#0219-SCPA> rdfs:label "The Hugo Keesing Collection of Popular Sheet Music";
+  dc:identifier "0219-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/33492> .
+
+<http://vocab.lib.umd.edu/collection#0219-UA> rdfs:label "History of the University of Maryland - Campus Unrest records";
+  dc:identifier "0219-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42419> .
+
+<http://vocab.lib.umd.edu/collection#0220-MDHC> rdfs:label "Maryland Association for Family and Community Education (MDAFCE) records";
+  dc:identifier "0220-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1374> .
+
+<http://vocab.lib.umd.edu/collection#0220-SCPA> rdfs:label "Records of the University of Maryland Percussion Program";
+  dc:identifier "0220-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/36414> .
+
+<http://vocab.lib.umd.edu/collection#0220-UA> rdfs:label "Men's Glee Club photographs and recording";
+  dc:identifier "0220-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42626> .
+
+<http://vocab.lib.umd.edu/collection#0221-MDHC> rdfs:label "Maryland Federation of Business and Professional Women's Clubs, Inc. records";
+  dc:identifier "0221-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1375> .
+
+<http://vocab.lib.umd.edu/collection#0221-SCPA> rdfs:label "The Sharon Cheslow Punk Flyers collection, 1979-1991";
+  dc:identifier "0221-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42750> .
+
+<http://vocab.lib.umd.edu/collection#0221-UA> rdfs:label "Lesbian, Gay, Bisexual, and Transgender Equity Center records";
+  dc:identifier "0221-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42627> .
+
+<http://vocab.lib.umd.edu/collection#0222-MDHC> rdfs:label "Lucille Maurer papers";
+  dc:identifier "0222-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1376> .
+
+<http://vocab.lib.umd.edu/collection#0222-SCPA> rdfs:label "\"Follow the Fringe Project\" Collection, INST 729F, documenting the Edinburgh Festival Fringe";
+  dc:identifier "0222-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42751> .
+
+<http://vocab.lib.umd.edu/collection#0222-UA> rdfs:label "Maryland Agricultural College records";
+  dc:identifier "0222-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42628> .
+
+<http://vocab.lib.umd.edu/collection#0223-MDHC> rdfs:label "Constance A. Morella papers";
+  dc:identifier "0223-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1377> .
+
+<http://vocab.lib.umd.edu/collection#0223-SCPA> rdfs:label "Jason Farrell collection";
+  dc:identifier "0223-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42752> .
+
+<http://vocab.lib.umd.edu/collection#0223-UA> rdfs:label "Alumni Reunions collection";
+  dc:identifier "0223-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42629> .
+
+<http://vocab.lib.umd.edu/collection#0224-MDHC> rdfs:label "W. Joseph Moyer papers";
+  dc:identifier "0224-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1378> .
+
+<http://vocab.lib.umd.edu/collection#0224-UA> rdfs:label "Resident Life scrapbook";
+  dc:identifier "0224-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42630> .
+
+<http://vocab.lib.umd.edu/collection#0225-MDHC> rdfs:label "National Extension Homemakers Council Voices of American Homemakers records";
+  dc:identifier "0225-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1379> .
+
+<http://vocab.lib.umd.edu/collection#0225-UA> rdfs:label "<title>Terrapin</title> photographs and negatives";
+  dc:identifier "0225-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24997> .
+
+<http://vocab.lib.umd.edu/collection#0226-MDHC> rdfs:label "National Organization for Women, Maryland Chapter records";
+  dc:identifier "0226-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1380> .
+
+<http://vocab.lib.umd.edu/collection#0226-UA> rdfs:label "University of Maryland Chapel audio recordings";
+  dc:identifier "0226-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42631> .
+
+<http://vocab.lib.umd.edu/collection#0227-MDHC> rdfs:label "National Women's Studies Association (NWSA) records";
+  dc:identifier "0227-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1381> .
+
+<http://vocab.lib.umd.edu/collection#0227-UA> rdfs:label "Sigma Chi records";
+  dc:identifier "0227-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42632> .
+
+<http://vocab.lib.umd.edu/collection#0228-MDHC> rdfs:label "Howard M. Norton papers";
+  dc:identifier "0228-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1382> .
+
+<http://vocab.lib.umd.edu/collection#0228-UA> rdfs:label "Student Archivists at Maryland (SAM) records";
+  dc:identifier "0228-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24999> .
+
+<http://vocab.lib.umd.edu/collection#0229-MDHC> rdfs:label "Overseas Education Fund (OEF) records";
+  dc:identifier "0229-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1383> .
+
+<http://vocab.lib.umd.edu/collection#0229-UA> rdfs:label "Student Government Association (SGA) records";
+  dc:identifier "0229-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/25003> .
+
+<http://vocab.lib.umd.edu/collection#0230-MDHC> rdfs:label "Philip Perlman papers";
+  dc:identifier "0230-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1384> .
+
+<http://vocab.lib.umd.edu/collection#0230-UA> rdfs:label "Primannum Honor Society records";
+  dc:identifier "0230-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42633> .
+
+<http://vocab.lib.umd.edu/collection#0231-MDHC> rdfs:label "Prince George's County Library Federation records";
+  dc:identifier "0231-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1385> .
+
+<http://vocab.lib.umd.edu/collection#0231-UA> rdfs:label "Presentations and Ceremonies collection";
+  dc:identifier "0231-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42634> .
+
+<http://vocab.lib.umd.edu/collection#0232-MDHC> rdfs:label "Frederick L. Rath, Jr. papers";
+  dc:identifier "0232-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1386> .
+
+<http://vocab.lib.umd.edu/collection#0232-UA> rdfs:label "Student Activities collection";
+  dc:identifier "0232-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/25000> .
+
+<http://vocab.lib.umd.edu/collection#0233-MDHC> rdfs:label "Carlton Ralph Sickles papers";
+  dc:identifier "0233-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1387> .
+
+<http://vocab.lib.umd.edu/collection#0233-UA> rdfs:label "Phi Kappa Phi records";
+  dc:identifier "0233-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42635> .
+
+<http://vocab.lib.umd.edu/collection#0234-MDHC> rdfs:label "Fred Simmons papers";
+  dc:identifier "0234-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1388> .
+
+<http://vocab.lib.umd.edu/collection#0234-UA> rdfs:label "Oral History collection";
+  dc:identifier "0234-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/25004> .
+
+<http://vocab.lib.umd.edu/collection#0235-MDHC> rdfs:label "Thomas H. Osbourn Family papers";
+  dc:identifier "0235-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1389> .
+
+<http://vocab.lib.umd.edu/collection#0235-UA> rdfs:label "Omicron Delta Kappa records";
+  dc:identifier "0235-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42636> .
+
+<http://vocab.lib.umd.edu/collection#0236-MDHC> rdfs:label "Newton I. Steers papers";
+  dc:identifier "0236-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1390> .
+
+<http://vocab.lib.umd.edu/collection#0236-UA> rdfs:label "M Club records";
+  dc:identifier "0236-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42637> .
+
+<http://vocab.lib.umd.edu/collection#0237-UA-UA> rdfs:label "Stamp Union Program Council (SUPC) scrapbook";
+  dc:identifier "0237-UA-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42638> .
+
+<http://vocab.lib.umd.edu/collection#0238-MDHC> rdfs:label "Suburban Maryland Fair Housing, Inc. records";
+  dc:identifier "0238-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1392> .
+
+<http://vocab.lib.umd.edu/collection#0238-UA> rdfs:label "Sigma Xi records";
+  dc:identifier "0238-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42639> .
+
+<http://vocab.lib.umd.edu/collection#0239-UA> rdfs:label "Records of the Student Union - Director's Office";
+  dc:identifier "0239-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24998> .
+
+<http://vocab.lib.umd.edu/collection#0240-UA> rdfs:label "Senior Theses collection";
+  dc:identifier "0240-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42640> .
+
+<http://vocab.lib.umd.edu/collection#0241-MDHC> rdfs:label "United States Women's Lacrosse Association records";
+  dc:identifier "0241-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1395> .
+
+<http://vocab.lib.umd.edu/collection#0241-UA> rdfs:label "Phi Beta Kappa records";
+  dc:identifier "0241-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42641> .
+
+<http://vocab.lib.umd.edu/collection#0242-MDHC> rdfs:label "Booker T. Washington Papers Editorial Project collection";
+  dc:identifier "0242-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1396> .
+
+<http://vocab.lib.umd.edu/collection#0242-UA> rdfs:label "University Theater records";
+  dc:identifier "0242-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24992> .
+
+<http://vocab.lib.umd.edu/collection#0243-UA> rdfs:label "UNIV 100: The Student in the University - Media Literacy Learning Community collection";
+  dc:identifier "0243-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/24991> .
+
+<http://vocab.lib.umd.edu/collection#0244-UA> rdfs:label "Jerome Forrest papers";
+  dc:identifier "0244-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/32340> .
+
+<http://vocab.lib.umd.edu/collection#0245-MDHC> rdfs:label "Ruth S. Wolf papers";
+  dc:identifier "0245-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1399> .
+
+<http://vocab.lib.umd.edu/collection#0245-UA> rdfs:label "Koinonia Agapes records";
+  dc:identifier "0245-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42642> .
+
+<http://vocab.lib.umd.edu/collection#0246-MDHC> rdfs:label "Women's Action Coalition of Prince George's County records";
+  dc:identifier "0246-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1400> .
+
+<http://vocab.lib.umd.edu/collection#0246-UA> rdfs:label "Jacob Elry Metzger papers";
+  dc:identifier "0246-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1753> .
+
+<http://vocab.lib.umd.edu/collection#0247-MDHC> rdfs:label "Anne St. Clair Wright papers";
+  dc:identifier "0247-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1401> .
+
+<http://vocab.lib.umd.edu/collection#0247-UA> rdfs:label "Gahan Family papers";
+  dc:identifier "0247-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1737> .
+
+<http://vocab.lib.umd.edu/collection#0248-MDHC> rdfs:label "Edmondson-Jacobs Family papers";
+  dc:identifier "0248-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1402> .
+
+<http://vocab.lib.umd.edu/collection#0248-UA> rdfs:label "Ronald Bamford papers";
+  dc:identifier "0248-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1739> .
+
+<http://vocab.lib.umd.edu/collection#0249-MDHC> rdfs:label "George Koonce collection";
+  dc:identifier "0249-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1403> .
+
+<http://vocab.lib.umd.edu/collection#0249-UA> rdfs:label "David Edward Brown papers";
+  dc:identifier "0249-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1741> .
+
+<http://vocab.lib.umd.edu/collection#0250-MDHC> rdfs:label "Dorothy Sucher collection";
+  dc:identifier "0250-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1404> .
+
+<http://vocab.lib.umd.edu/collection#0250-UA> rdfs:label "Theodore L. Bissell papers";
+  dc:identifier "0250-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1750> .
+
+<http://vocab.lib.umd.edu/collection#0251-MDHC> rdfs:label "James Thompson papers";
+  dc:identifier "0251-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1405> .
+
+<http://vocab.lib.umd.edu/collection#0251-UA> rdfs:label "William L. Amoss papers";
+  dc:identifier "0251-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1751> .
+
+<http://vocab.lib.umd.edu/collection#0252-MDHC> rdfs:label "Demorest's New-York Illustrated News Woodcut collection";
+  dc:identifier "0252-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1406> .
+
+<http://vocab.lib.umd.edu/collection#0252-UA> rdfs:label "William Bickley papers";
+  dc:identifier "0252-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1752> .
+
+<http://vocab.lib.umd.edu/collection#0253-MDHC> rdfs:label "Daniel S. Lynch papers";
+  dc:identifier "0253-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1407> .
+
+<http://vocab.lib.umd.edu/collection#0253-UA> rdfs:label "Julian Chisholm II photographs and negatives";
+  dc:identifier "0253-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1723> .
+
+<http://vocab.lib.umd.edu/collection#0254-MDHC> rdfs:label "Coalition to Preserve Black Marsh records";
+  dc:identifier "0254-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1408> .
+
+<http://vocab.lib.umd.edu/collection#0254-UA> rdfs:label "Kenneth Grace papers";
+  dc:identifier "0254-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1726> .
+
+<http://vocab.lib.umd.edu/collection#0255-MDHC> rdfs:label "Greenbelt Oral History Project collection";
+  dc:identifier "0255-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1409> .
+
+<http://vocab.lib.umd.edu/collection#0255-UA> rdfs:label "Robert Lamar Green papers";
+  dc:identifier "0255-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1727> .
+
+<http://vocab.lib.umd.edu/collection#0256-MDHC> rdfs:label "Lawrence Joseph Hogan papers";
+  dc:identifier "0256-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1410> .
+
+<http://vocab.lib.umd.edu/collection#0256-UA> rdfs:label "Morley Jull papers";
+  dc:identifier "0256-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1730> .
+
+<http://vocab.lib.umd.edu/collection#0257-MDHC> rdfs:label "Francis Francois papers";
+  dc:identifier "0257-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1411> .
+
+<http://vocab.lib.umd.edu/collection#0257-UA> rdfs:label "R. Sumter Griffith papers";
+  dc:identifier "0257-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1734> .
+
+<http://vocab.lib.umd.edu/collection#0258-MDHC> rdfs:label "Prince George's County Council of Parent-Teacher Associations (PGCCPTA) records";
+  dc:identifier "0258-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1412> .
+
+<http://vocab.lib.umd.edu/collection#0258-UA> rdfs:label "Ann R. Hull papers";
+  dc:identifier "0258-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1712> .
+
+<http://vocab.lib.umd.edu/collection#0259-UA> rdfs:label "Elbert Byrd papers";
+  dc:identifier "0259-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1223> .
+
+<http://vocab.lib.umd.edu/collection#0260-MDHC> rdfs:label "Cresap/Bruce Family papers";
+  dc:identifier "0260-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1414> .
+
+<http://vocab.lib.umd.edu/collection#0260-UA> rdfs:label "Harry Clifton Byrd papers";
+  dc:identifier "0260-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1224> .
+
+<http://vocab.lib.umd.edu/collection#0261-MDHC> rdfs:label "Saul J. Harris papers";
+  dc:identifier "0261-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1427> .
+
+<http://vocab.lib.umd.edu/collection#0261-UA> rdfs:label "Helmut Landsberg papers";
+  dc:identifier "0261-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1248> .
+
+<http://vocab.lib.umd.edu/collection#0262-MDHC> rdfs:label "Judge Norris S. Barratt papers";
+  dc:identifier "0262-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1428> .
+
+<http://vocab.lib.umd.edu/collection#0262-UA> rdfs:label "Elliott Montroll papers";
+  dc:identifier "0262-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1265> .
+
+<http://vocab.lib.umd.edu/collection#0263-MDHC> rdfs:label "Elizabeth K. Hartline papers";
+  dc:identifier "0263-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1429> .
+
+<http://vocab.lib.umd.edu/collection#0263-UA> rdfs:label "Harry Patterson papers";
+  dc:identifier "0263-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1272> .
+
+<http://vocab.lib.umd.edu/collection#0264-MDHC> rdfs:label "Anneke Davis papers";
+  dc:identifier "0264-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1430> .
+
+<http://vocab.lib.umd.edu/collection#0264-UA> rdfs:label "Francis C. Stark papers";
+  dc:identifier "0264-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1274> .
+
+<http://vocab.lib.umd.edu/collection#0265-MDHC> rdfs:label "Mary L. Nock papers";
+  dc:identifier "0265-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1431> .
+
+<http://vocab.lib.umd.edu/collection#0265-UA> rdfs:label "Elmer Plischke papers";
+  dc:identifier "0265-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1275> .
+
+<http://vocab.lib.umd.edu/collection#0266-MDHC> rdfs:label "Marion Theresa (M. T.) Biddle papers";
+  dc:identifier "0266-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1432> .
+
+<http://vocab.lib.umd.edu/collection#0266-UA> rdfs:label "William Sands papers";
+  dc:identifier "0266-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1283> .
+
+<http://vocab.lib.umd.edu/collection#0267-MDHC> rdfs:label "Richard Hubbard Howland papers";
+  dc:identifier "0267-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1433> .
+
+<http://vocab.lib.umd.edu/collection#0267-UA> rdfs:label "Mark Shoemaker papers";
+  dc:identifier "0267-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1289> .
+
+<http://vocab.lib.umd.edu/collection#0268-MDHC> rdfs:label "Greenbelt Homes, Inc. collection";
+  dc:identifier "0268-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1434> .
+
+<http://vocab.lib.umd.edu/collection#0268-UA> rdfs:label "Mary S. Shorb papers";
+  dc:identifier "0268-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1290> .
+
+<http://vocab.lib.umd.edu/collection#0269-MDHC> rdfs:label "Navy Legacy Resource Management Program collection";
+  dc:identifier "0269-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1435> .
+
+<http://vocab.lib.umd.edu/collection#0269-UA> rdfs:label "Isabella Hayes papers";
+  dc:identifier "0269-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1363> .
+
+<http://vocab.lib.umd.edu/collection#0270-MDHC> rdfs:label "Polly Walker papers";
+  dc:identifier "0270-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1436> .
+
+<http://vocab.lib.umd.edu/collection#0270-UA> rdfs:label "J. B. S. Norton papers";
+  dc:identifier "0270-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1269> .
+
+<http://vocab.lib.umd.edu/collection#0271-MDHC> rdfs:label "William J. Murtagh papers";
+  dc:identifier "0271-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1437> .
+
+<http://vocab.lib.umd.edu/collection#0272-MDHC> rdfs:label "William G. Wilson papers";
+  dc:identifier "0272-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1438> .
+
+<http://vocab.lib.umd.edu/collection#0273-MDHC> rdfs:label "William S. Schmidt papers";
+  dc:identifier "0273-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1439> .
+
+<http://vocab.lib.umd.edu/collection#0274-MDHC> rdfs:label "Women's Studies pamphlet collection";
+  dc:identifier "0274-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1440> .
+
+<http://vocab.lib.umd.edu/collection#0275-MDHC> rdfs:label "Ray Hiebert papers";
+  dc:identifier "0275-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1441> .
+
+<http://vocab.lib.umd.edu/collection#0275-UA> rdfs:label "Louis R. Harlan papers";
+  dc:identifier "0275-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1362> .
+
+<http://vocab.lib.umd.edu/collection#0276-MDHC> rdfs:label "Silver Spring Nursery School archives";
+  dc:identifier "0276-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1442> .
+
+<http://vocab.lib.umd.edu/collection#0276-UA> rdfs:label "Betty B. Baehr papers";
+  dc:identifier "0276-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1349> .
+
+<http://vocab.lib.umd.edu/collection#0277-MDHC> rdfs:label "Charles E. Bowers Family collection";
+  dc:identifier "0277-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1443> .
+
+<http://vocab.lib.umd.edu/collection#0277-UA> rdfs:label "Franklin Burdette papers";
+  dc:identifier "0277-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1355> .
+
+<http://vocab.lib.umd.edu/collection#0278-MDHC> rdfs:label "Hepburn Family papers";
+  dc:identifier "0278-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1444> .
+
+<http://vocab.lib.umd.edu/collection#0278-UA> rdfs:label "Verne E. Chatelain papers";
+  dc:identifier "0278-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1357> .
+
+<http://vocab.lib.umd.edu/collection#0279-MDHC> rdfs:label "Historic American Buildings Survey (HABS) collection";
+  dc:identifier "0279-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1445> .
+
+<http://vocab.lib.umd.edu/collection#0279-UA> rdfs:label "Dudley Dillard papers";
+  dc:identifier "0279-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1358> .
+
+<http://vocab.lib.umd.edu/collection#0280-MDHC> rdfs:label "Pleasant Hunter Family papers";
+  dc:identifier "0280-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1446> .
+
+<http://vocab.lib.umd.edu/collection#0280-UA> rdfs:label "John E. Faber papers";
+  dc:identifier "0280-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1360> .
+
+<http://vocab.lib.umd.edu/collection#0281-MDHC> rdfs:label "Vivian Newman collection";
+  dc:identifier "0281-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1447> .
+
+<http://vocab.lib.umd.edu/collection#0282-MDHC> rdfs:label "Aaron S. Oberly papers";
+  dc:identifier "0282-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1448> .
+
+<http://vocab.lib.umd.edu/collection#0282-UA> rdfs:label "Adele H. Stamp papers";
+  dc:identifier "0282-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1317> .
+
+<http://vocab.lib.umd.edu/collection#0283-MDHC> rdfs:label "Alice Rabin papers";
+  dc:identifier "0283-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1449> .
+
+<http://vocab.lib.umd.edu/collection#0283-UA> rdfs:label "Charles E. White papers";
+  dc:identifier "0283-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1318> .
+
+<http://vocab.lib.umd.edu/collection#0284-MDHC> rdfs:label "Sears Roebuck blueprints collection";
+  dc:identifier "0284-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1450> .
+
+<http://vocab.lib.umd.edu/collection#0284-UA> rdfs:label "Ben Shneiderman papers";
+  dc:identifier "0284-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1331> .
+
+<http://vocab.lib.umd.edu/collection#0285-MDHC> rdfs:label "Robert M. August papers";
+  dc:identifier "0285-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1451> .
+
+<http://vocab.lib.umd.edu/collection#0285-UA> rdfs:label "Clyne S. Shaffner papers";
+  dc:identifier "0285-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1340> .
+
+<http://vocab.lib.umd.edu/collection#0286-MDHC> rdfs:label "Rhea Cohen papers";
+  dc:identifier "0286-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1452> .
+
+<http://vocab.lib.umd.edu/collection#0286-UA> rdfs:label "Helen Bradley Lang papers";
+  dc:identifier "0286-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1413> .
+
+<http://vocab.lib.umd.edu/collection#0287-MDHC> rdfs:label "Philip E. Hartman papers";
+  dc:identifier "0287-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1453> .
+
+<http://vocab.lib.umd.edu/collection#0287-UA> rdfs:label "Edward M. Rider papers";
+  dc:identifier "0287-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/4276> .
+
+<http://vocab.lib.umd.edu/collection#0288-MDHC> rdfs:label "Newton Family papers";
+  dc:identifier "0288-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1454> .
+
+<http://vocab.lib.umd.edu/collection#0288-UA> rdfs:label "E. P. Young papers";
+  dc:identifier "0288-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1345> .
+
+<http://vocab.lib.umd.edu/collection#0289-MDHC> rdfs:label "Mary W. Stewart papers";
+  dc:identifier "0289-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1455> .
+
+<http://vocab.lib.umd.edu/collection#0289-UA> rdfs:label "Sterling Byrd collection";
+  dc:identifier "0289-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1356> .
+
+<http://vocab.lib.umd.edu/collection#0290-MDHC> rdfs:label "Raymond E. Miller papers";
+  dc:identifier "0290-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1456> .
+
+<http://vocab.lib.umd.edu/collection#0290-UA> rdfs:label "Laurence Heilprin papers";
+  dc:identifier "0290-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1364> .
+
+<http://vocab.lib.umd.edu/collection#0291-MDHC> rdfs:label "Ernest A. Connally papers";
+  dc:identifier "0291-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1457> .
+
+<http://vocab.lib.umd.edu/collection#0291-UA> rdfs:label "Frank J. Kerr papers";
+  dc:identifier "0291-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1369> .
+
+<http://vocab.lib.umd.edu/collection#0292-MDHC> rdfs:label "Hiroshi Daifuku papers";
+  dc:identifier "0292-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1458> .
+
+<http://vocab.lib.umd.edu/collection#0292-UA> rdfs:label "Orman E. Street papers";
+  dc:identifier "0292-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1391> .
+
+<http://vocab.lib.umd.edu/collection#0293-MDHC> rdfs:label "John Carroll Dunn papers";
+  dc:identifier "0293-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/8768> .
+
+<http://vocab.lib.umd.edu/collection#0293-UA> rdfs:label "Joseph Weber papers";
+  dc:identifier "0293-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1397> .
+
+<http://vocab.lib.umd.edu/collection#0294-MDHC> rdfs:label "Richard Moe papers";
+  dc:identifier "0294-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/7568> .
+
+<http://vocab.lib.umd.edu/collection#0294-UA> rdfs:label "Stephen G. Brush papers";
+  dc:identifier "0294-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1473> .
+
+<http://vocab.lib.umd.edu/collection#0295-MDHC> rdfs:label "Charles E. Peterson papers";
+  dc:identifier "0295-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1459> .
+
+<http://vocab.lib.umd.edu/collection#0295-UA> rdfs:label "Mary Lee Bundy papers";
+  dc:identifier "0295-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/3966> .
+
+<http://vocab.lib.umd.edu/collection#0296-UA> rdfs:label "Mancur Olson papers";
+  dc:identifier "0296-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/15566> .
+
+<http://vocab.lib.umd.edu/collection#0297-MDHC> rdfs:label "Professional Restoration records";
+  dc:identifier "0297-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1460> .
+
+<http://vocab.lib.umd.edu/collection#0297-UA> rdfs:label "Fraternities and Sororities collection";
+  dc:identifier "0297-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42536> .
+
+<http://vocab.lib.umd.edu/collection#0298-MDHC> rdfs:label "American Association of University Women, Metropolitan Area Mass Media Committee records";
+  dc:identifier "0298-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1461> .
+
+<http://vocab.lib.umd.edu/collection#0298-SCPA-GROFF> rdfs:label "Skip Groff papers";
+  dc:identifier "0298-SCPA-GROFF";
+  owl:sameAs <http://hdl.handle.net/1903.1/42189> .
+
+<http://vocab.lib.umd.edu/collection#0298-UA> rdfs:label "James Reveal papers";
+  dc:identifier "0298-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1328> .
+
+<http://vocab.lib.umd.edu/collection#0299-MDHC> rdfs:label "Subject Photographs -- Print File";
+  dc:identifier "0299-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/8770> .
+
+<http://vocab.lib.umd.edu/collection#0299-SCPA> rdfs:label "Andrew Thomas papers";
+  dc:identifier "0299-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/42188> .
+
+<http://vocab.lib.umd.edu/collection#0299-UA> rdfs:label "Romeo Mansueti papers";
+  dc:identifier "0299-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1732> .
+
+<http://vocab.lib.umd.edu/collection#0300-MDHC> rdfs:label "Charles Fleetwood Hanna papers";
+  dc:identifier "0300-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1462> .
+
+<http://vocab.lib.umd.edu/collection#0301-MDHC> rdfs:label "Thomas Kensett Family papers";
+  dc:identifier "0301-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1463> .
+
+<http://vocab.lib.umd.edu/collection#0303-MDHC> rdfs:label "Messrs. Freeman and Almy archives";
+  dc:identifier "0303-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1465> .
+
+<http://vocab.lib.umd.edu/collection#0304-MDHC> rdfs:label "Louise Phillips scrapbooks";
+  dc:identifier "0304-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1466> .
+
+<http://vocab.lib.umd.edu/collection#0305-MDHC> rdfs:label "American Association of University Women (AAUW), Kensington Branch archives";
+  dc:identifier "0305-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1467> .
+
+<http://vocab.lib.umd.edu/collection#0306-MDHC> rdfs:label "Dorothy McKnight papers";
+  dc:identifier "0306-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1468> .
+
+<http://vocab.lib.umd.edu/collection#0307-MDHC> rdfs:label "American Association of University Women (AAUW), Rockville Branch records";
+  dc:identifier "0307-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1469> .
+
+<http://vocab.lib.umd.edu/collection#0308-MDHC> rdfs:label "John William Stewart Family papers";
+  dc:identifier "0308-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1470> .
+
+<http://vocab.lib.umd.edu/collection#0309-MDHC> rdfs:label "Sellman Family papers";
+  dc:identifier "0309-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1770> .
+
+<http://vocab.lib.umd.edu/collection#0310-MDHC> rdfs:label "John S. Toll papers";
+  dc:identifier "0310-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1471> .
+
+<http://vocab.lib.umd.edu/collection#0313-MDHC> rdfs:label "European Heritage Documents collection";
+  dc:identifier "0313-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/3022> .
+
+<http://vocab.lib.umd.edu/collection#0314-MDHC> rdfs:label "Preservation Action records";
+  dc:identifier "0314-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1474> .
+
+<http://vocab.lib.umd.edu/collection#0315-MDHC> rdfs:label "Harwood Family Buzzard Island papers";
+  dc:identifier "0315-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1475> .
+
+<http://vocab.lib.umd.edu/collection#0316-MDHC> rdfs:label "Adrienne Mandel papers";
+  dc:identifier "0316-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1476> .
+
+<http://vocab.lib.umd.edu/collection#0317-MDHC> rdfs:label "Carol S. Petzold papers";
+  dc:identifier "0317-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1477> .
+
+<http://vocab.lib.umd.edu/collection#0318-MDHC> rdfs:label "Peter Franchot papers";
+  dc:identifier "0318-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1478> .
+
+<http://vocab.lib.umd.edu/collection#0318-SCPA-RUBENSTEIN> rdfs:label "Lee G. Rubenstein collection of theatre programs";
+  dc:identifier "0318-SCPA-RUBENSTEIN";
+  owl:sameAs <http://hdl.handle.net/1903.1/43406> .
+
+<http://vocab.lib.umd.edu/collection#0319-MDHC> rdfs:label "Helen L. Koss papers";
+  dc:identifier "0319-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1479> .
+
+<http://vocab.lib.umd.edu/collection#0319-SCPA> rdfs:label "The Hugo Keesing Collection on Television and Popular Theme Songs";
+  dc:identifier "0319-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/43407> .
+
+<http://vocab.lib.umd.edu/collection#0320-MDHC> rdfs:label "Charles S. Burns papers";
+  dc:identifier "0320-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1480> .
+
+<http://vocab.lib.umd.edu/collection#0320-SCPA-MONTONI> rdfs:label "Hope Haley Montoni collection of chamber music with voice";
+  dc:identifier "0320-SCPA-MONTONI";
+  owl:sameAs <http://hdl.handle.net/1903.1/43412> .
+
+<http://vocab.lib.umd.edu/collection#0321-MDHC> rdfs:label "Baltimore Smallpox Epidemic collection";
+  dc:identifier "0321-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1481> .
+
+<http://vocab.lib.umd.edu/collection#0321-SCPA> rdfs:label "James Sclater collection on Reginald Kell";
+  dc:identifier "0321-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/43569> .
+
+<http://vocab.lib.umd.edu/collection#0322-MDHC> rdfs:label "Brantz Mayer papers";
+  dc:identifier "0322-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1482> .
+
+<http://vocab.lib.umd.edu/collection#0322-SCPA-ABA> rdfs:label "Volkwein Bros. Band collection";
+  dc:identifier "0322-SCPA-ABA";
+  owl:sameAs <http://hdl.handle.net/1903.1/43570> .
+
+<http://vocab.lib.umd.edu/collection#0323-MDHC> rdfs:label "William Henry Duvall, Jr., Textbook and Engineering Laboratory Notebook";
+  dc:identifier "0323-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/3009> .
+
+<http://vocab.lib.umd.edu/collection#0323-SCPA> rdfs:label "Grant Beglarian papers";
+  dc:identifier "0323-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/43571> .
+
+<http://vocab.lib.umd.edu/collection#0324-SCPA> rdfs:label "Acton E. Ostling, Jr. papers";
+  dc:identifier "0324-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/43599> .
+
+<http://vocab.lib.umd.edu/collection#0325-SCPA> rdfs:label "Ernest O. Caneva papers";
+  dc:identifier "0325-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/43619> .
+
+<http://vocab.lib.umd.edu/collection#0326-MDHC> rdfs:label "Frederick Stone papers";
+  dc:identifier "0326-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/3293> .
+
+<http://vocab.lib.umd.edu/collection#0326-SCPA> rdfs:label "Robert E. Foster papers";
+  dc:identifier "0326-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/43620> .
+
+<http://vocab.lib.umd.edu/collection#0327-MDHC> rdfs:label "Ruth Lawless Busbey papers";
+  dc:identifier "0327-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/4579> .
+
+<http://vocab.lib.umd.edu/collection#0327-SCPA-SAYENGA> rdfs:label "Kurt Sayenga collection";
+  dc:identifier "0327-SCPA-SAYENGA";
+  owl:sameAs <http://hdl.handle.net/1903.1/43630> .
+
+<http://vocab.lib.umd.edu/collection#0328-MDHC> rdfs:label "Jennie M. Forehand papers";
+  dc:identifier "0328-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/3292> .
+
+<http://vocab.lib.umd.edu/collection#0328-SCPA> rdfs:label "Thomas E. Caneva papers";
+  dc:identifier "0328-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/43678> .
+
+<http://vocab.lib.umd.edu/collection#0329-MDHC> rdfs:label "College Park Girls' Club archives";
+  dc:identifier "0329-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/3290> .
+
+<http://vocab.lib.umd.edu/collection#0329-SCPA> rdfs:label "John O'Reilly papers";
+  dc:identifier "0329-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/43681> .
+
+<http://vocab.lib.umd.edu/collection#0330-MDHC> rdfs:label "Arthur J. Kiser Papers";
+  dc:identifier "0330-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/3291> .
+
+<http://vocab.lib.umd.edu/collection#0330-SCPA> rdfs:label "Robert J. Garofalo papers";
+  dc:identifier "0330-SCPA";
+  owl:sameAs <http://hdl.handle.net/1903.1/43682> .
+
+<http://vocab.lib.umd.edu/collection#0331-MDHC> rdfs:label "Cronin, L. Eugene papers";
+  dc:identifier "0331-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/3407> .
+
+<http://vocab.lib.umd.edu/collection#0331-SCPA> rdfs:label "The Hugo Keesing Collection on Music and World War I";
+  dc:identifier "0331-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/43846> .
+
+<http://vocab.lib.umd.edu/collection#0332-MDHC> rdfs:label "Leland Scott collection";
+  dc:identifier "0332-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/7419> .
+
+<http://vocab.lib.umd.edu/collection#0332-SCPA> rdfs:label "The Hugo Keesing Collection on Music and the Gulf Wars";
+  dc:identifier "0332-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/43847> .
+
+<http://vocab.lib.umd.edu/collection#0333-MDHC> rdfs:label "Stoddert Family papers";
+  dc:identifier "0333-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/4580> .
+
+<http://vocab.lib.umd.edu/collection#0333-SCPA> rdfs:label "Chester E. Whiting collection";
+  dc:identifier "0333-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/43849> .
+
+<http://vocab.lib.umd.edu/collection#0334-MDHC> rdfs:label "Urban Information Interpreters, Inc. archives";
+  dc:identifier "0334-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/3965> .
+
+<http://vocab.lib.umd.edu/collection#0334-SCPA-DAVIS> rdfs:label "John Davis collection on punk";
+  dc:identifier "0334-SCPA-DAVIS";
+  owl:sameAs <https://hdl.handle.net/1903.1/43850> .
+
+<http://vocab.lib.umd.edu/collection#0335-SCPA> rdfs:label "The Hugo Keesing Collection on Annette Funicello and Hayley Mills";
+  dc:identifier "0335-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/43854> .
+
+<http://vocab.lib.umd.edu/collection#0336-MDHC> rdfs:label "Albert R. Wynn papers";
+  dc:identifier "0336-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/4274> .
+
+<http://vocab.lib.umd.edu/collection#0336-SCPA> rdfs:label "The Hugo Keesing Collection on Jacoba Feenstra's Sheet Music";
+  dc:identifier "0336-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/43855> .
+
+<http://vocab.lib.umd.edu/collection#0337-SCPA-ICA> rdfs:label "Frank Colantuono papers";
+  dc:identifier "0337-SCPA-ICA";
+  owl:sameAs <https://hdl.handle.net/1903.1/43860> .
+
+<http://vocab.lib.umd.edu/collection#0338-MDHC> rdfs:label "American Association of University Women (AAUW), Bowie Branch archives";
+  dc:identifier "0338-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/4275> .
+
+<http://vocab.lib.umd.edu/collection#0338-SCPA-ICA> rdfs:label "Donald Martino music greeting cards collection";
+  dc:identifier "0338-SCPA-ICA";
+  owl:sameAs <https://hdl.handle.net/1903.1/43862> .
+
+<http://vocab.lib.umd.edu/collection#0339-MDHC> rdfs:label "Franklin B. Brannan papers";
+  dc:identifier "0339-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/9347> .
+
+<http://vocab.lib.umd.edu/collection#0339-SCPA> rdfs:label "Laban/Bartenieff Institute of Movement Studies archives";
+  dc:identifier "0339-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/43879> .
+
+<http://vocab.lib.umd.edu/collection#0340-MDHC> rdfs:label "Feminist Studies records";
+  dc:identifier "0340-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/4942> .
+
+<http://vocab.lib.umd.edu/collection#0340-SCPA> rdfs:label "Major Orchestra Librarians' Association official records";
+  dc:identifier "0340-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/43880> .
+
+<http://vocab.lib.umd.edu/collection#0341-MDHC> rdfs:label "Off Our Backs records";
+  dc:identifier "0341-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/11903> .
+
+<http://vocab.lib.umd.edu/collection#0341-SCPA> rdfs:label "Alcine J. Wiltz Papers";
+  dc:identifier "0341-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/43881> .
+
+<http://vocab.lib.umd.edu/collection#0342-MDHC> rdfs:label "American Political Items Collectors records";
+  dc:identifier "0342-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/9061> .
+
+<http://vocab.lib.umd.edu/collection#0342-SCPA> rdfs:label "The Hugo Keesing Collection on Popular Music Memorabilia";
+  dc:identifier "0342-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/43882> .
+
+<http://vocab.lib.umd.edu/collection#0343-MDHC> rdfs:label "Andrew Aines papers";
+  dc:identifier "0343-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/9062> .
+
+<http://vocab.lib.umd.edu/collection#0343-SCPA> rdfs:label "David Patterson's Tone Patterns: The Didactic Materials and Principles of Piano Technics, 1926";
+  dc:identifier "0343-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/43917> .
+
+<http://vocab.lib.umd.edu/collection#0344-SCPA> rdfs:label "Anonymous Private Collection of American Sheet Music 1";
+  dc:identifier "0344-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/43961> .
+
+<http://vocab.lib.umd.edu/collection#0345-SCPA> rdfs:label "Mrs. Shippen Sheet Music Collection";
+  dc:identifier "0345-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/43969> .
+
+<http://vocab.lib.umd.edu/collection#0346-MDHC> rdfs:label "Thomas S. Duckett Family papers";
+  dc:identifier "0346-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/9065> .
+
+<http://vocab.lib.umd.edu/collection#0346-SCPA-BUSHMILLER> rdfs:label "Paul Bushmiller collection on punk, 1979-1992";
+  dc:identifier "0346-SCPA-BUSHMILLER";
+  owl:sameAs <https://hdl.handle.net/1903.1/44018> .
+
+<http://vocab.lib.umd.edu/collection#0347-MDHC> rdfs:label "Caroline K. Ehlers papers";
+  dc:identifier "0347-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/9066> .
+
+<http://vocab.lib.umd.edu/collection#0347-SCPA-SCHREIBMAN> rdfs:label "Michael Schreibman papers";
+  dc:identifier "0347-SCPA-SCHREIBMAN";
+  owl:sameAs <https://hdl.handle.net/1903.1/44020> .
+
+<http://vocab.lib.umd.edu/collection#0348-SCPA> rdfs:label "Alfred Lewis collection of Al Jolson recordings";
+  dc:identifier "0348-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/44079> .
+
+<http://vocab.lib.umd.edu/collection#0349-SCPA> rdfs:label "William L. Montgomery collection of music for flute";
+  dc:identifier "0349-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/44121> .
+
+<http://vocab.lib.umd.edu/collection#0350-SCPA> rdfs:label "Margery Morgan Lowens collection on Edward MacDowell";
+  dc:identifier "0350-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/44122> .
+
+<http://vocab.lib.umd.edu/collection#0351-SCPA> rdfs:label "Special Collections in Performing Arts biography files collection";
+  dc:identifier "0351-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/45226> .
+
+<http://vocab.lib.umd.edu/collection#0352-MDHC> rdfs:label "International Federation for Information and Documentation (FID) records";
+  dc:identifier "0352-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/9058> .
+
+<http://vocab.lib.umd.edu/collection#0352-SCPA> rdfs:label "Vera Stâˆšâˆ‚ger-Schwarz papers";
+  dc:identifier "0352-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/45228> .
+
+<http://vocab.lib.umd.edu/collection#0353-MDHC> rdfs:label "Charles B. Sewell papers";
+  dc:identifier "0353-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/9059> .
+
+<http://vocab.lib.umd.edu/collection#0354-MDHC> rdfs:label "Biographical Photographs -- Print File";
+  dc:identifier "0354-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/11030> .
+
+<http://vocab.lib.umd.edu/collection#0354-SCPA> rdfs:label "Jacklin Bolton Stopp collection of 19th-century American music";
+  dc:identifier "0354-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/45262> .
+
+<http://vocab.lib.umd.edu/collection#0355-MDHC> rdfs:label "Washington Area Women's Center archives";
+  dc:identifier "0355-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42643> .
+
+<http://vocab.lib.umd.edu/collection#0355-SCPA> rdfs:label "Jacklin Bolton Stopp papers";
+  dc:identifier "0355-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/45287> .
+
+<http://vocab.lib.umd.edu/collection#0356-MDHC> rdfs:label "New Ventures, Inc. records";
+  dc:identifier "0356-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/12798> .
+
+<http://vocab.lib.umd.edu/collection#0356-SCPA> rdfs:label "Performing arts autographs and manuscripts collection";
+  dc:identifier "0356-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/45298> .
+
+<http://vocab.lib.umd.edu/collection#0357-MDHC> rdfs:label "Byron Family papers";
+  dc:identifier "0357-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/15843> .
+
+<http://vocab.lib.umd.edu/collection#0359-SCPA-RAPHLING> rdfs:label "Sam Raphling Collection";
+  dc:identifier "0359-SCPA-RAPHLING";
+  owl:sameAs <https://hdl.handle.net/1903.1/45305> .
+
+<http://vocab.lib.umd.edu/collection#0360-SCPA> rdfs:label "Irwin Heilner papers";
+  dc:identifier "0360-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/45310> .
+
+<http://vocab.lib.umd.edu/collection#0361-MDHC> rdfs:label "Bruce Gardner papers";
+  dc:identifier "0361-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/15649> .
+
+<http://vocab.lib.umd.edu/collection#0362-SCPA> rdfs:label "Frank Simon collection";
+  dc:identifier "0362-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/45908> .
+
+<http://vocab.lib.umd.edu/collection#0363-MDHC> rdfs:label "World's Fair Ephemeral and Graphic Materials collection";
+  dc:identifier "0363-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/1632> .
+
+<http://vocab.lib.umd.edu/collection#0363-SCPA> rdfs:label "Griffith Rose Materials";
+  dc:identifier "0363-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/45909> .
+
+<http://vocab.lib.umd.edu/collection#0364-MDHC> rdfs:label "Alonzo W. Phillips papers";
+  dc:identifier "0364-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/18496> .
+
+<http://vocab.lib.umd.edu/collection#0364-SCPA-DCPUNK> rdfs:label "D.C. Punk collection";
+  dc:identifier "0364-SCPA-DCPUNK";
+  owl:sameAs <https://hdl.handle.net/1903.1/45972> .
+
+<http://vocab.lib.umd.edu/collection#0365-MDHC> rdfs:label "Eleanor Tydings Ditzen papers";
+  dc:identifier "0365-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/18936> .
+
+<http://vocab.lib.umd.edu/collection#0365-SCPA> rdfs:label "The Keesing Collection on Music and the Vietnam War";
+  dc:identifier "0365-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/45977> .
+
+<http://vocab.lib.umd.edu/collection#0366-MDHC> rdfs:label "Paint Branch Garden Club records";
+  dc:identifier "0366-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/20584> .
+
+<http://vocab.lib.umd.edu/collection#0366-SCPA-MSMC> rdfs:label "Maryland Sheet Music collection";
+  dc:identifier "0366-SCPA-MSMC";
+  owl:sameAs <https://hdl.handle.net/1903.1/45983> .
+
+<http://vocab.lib.umd.edu/collection#0367-MDHC> rdfs:label "John E. Marshall &amp; Son records";
+  dc:identifier "0367-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42644> .
+
+<http://vocab.lib.umd.edu/collection#0367-SCPA> rdfs:label "Robert Davis & Henry J. Schalizki Papers";
+  dc:identifier "0367-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46056> .
+
+<http://vocab.lib.umd.edu/collection#0368-MDHC> rdfs:label "E. Elaine Crow papers";
+  dc:identifier "0368-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/20782> .
+
+<http://vocab.lib.umd.edu/collection#0368-SCPA-ICA> rdfs:label "Eric Simon manuscripts collection";
+  dc:identifier "0368-SCPA-ICA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46088> .
+
+<http://vocab.lib.umd.edu/collection#0369-MDHC> rdfs:label "Nellie Longsworth papers";
+  dc:identifier "0369-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42645> .
+
+<http://vocab.lib.umd.edu/collection#0369-SCPA-ICA> rdfs:label "Max Gebhardt collection of clarinet manuscripts";
+  dc:identifier "0369-SCPA-ICA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46089> .
+
+<http://vocab.lib.umd.edu/collection#0370-MDHC> rdfs:label "Civil War-Era Pictorial envelopes and song sheets";
+  dc:identifier "0370-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/24645> .
+
+<http://vocab.lib.umd.edu/collection#0370-SCPA-PUNKART> rdfs:label "Punk Art collection";
+  dc:identifier "0370-SCPA-PUNKART";
+  owl:sameAs <https://hdl.handle.net/1903.1/46091> .
+
+<http://vocab.lib.umd.edu/collection#0371-MDHC> rdfs:label "The Rita M. Cacas Filipino American Community Archives collection";
+  dc:identifier "0371-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42646> .
+
+<http://vocab.lib.umd.edu/collection#0371-SCPA-AHEARN> rdfs:label "Edward Allen Ahearn print collection on jazz and blues";
+  dc:identifier "0371-SCPA-AHEARN";
+  owl:sameAs <https://hdl.handle.net/1903.1/46093> .
+
+<http://vocab.lib.umd.edu/collection#0372-MDHC> rdfs:label "Point Lookout Civil War collection";
+  dc:identifier "0372-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42647> .
+
+<http://vocab.lib.umd.edu/collection#0372-SCPA> rdfs:label "Serge de Gastyne compositions collection";
+  dc:identifier "0372-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46094> .
+
+<http://vocab.lib.umd.edu/collection#0373-SCPA> rdfs:label "Martha Davis papers";
+  dc:identifier "0373-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46095> .
+
+<http://vocab.lib.umd.edu/collection#0373-UA> rdfs:label "Johannes Martinus Burgers papers";
+  dc:identifier "0373-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1704> .
+
+<http://vocab.lib.umd.edu/collection#0374-MDHC> rdfs:label "National Conference of State Historic Preservation Officers records";
+  dc:identifier "0374-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/13396> .
+
+<http://vocab.lib.umd.edu/collection#0374-SCPA> rdfs:label "Chris Baronner digital collection on D.C. punk";
+  dc:identifier "0374-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46096> .
+
+<http://vocab.lib.umd.edu/collection#0375-MDHC> rdfs:label "Archaeology in Annapolis records";
+  dc:identifier "0375-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/12546> .
+
+<http://vocab.lib.umd.edu/collection#0375-SCPA> rdfs:label "Harriett Johnson papers";
+  dc:identifier "0375-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46097> .
+
+<http://vocab.lib.umd.edu/collection#0376-MDHC> rdfs:label "Margot Gayle papers";
+  dc:identifier "0376-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/14845> .
+
+<http://vocab.lib.umd.edu/collection#0376-SCPA> rdfs:label "Michel Huglo & Barbara Haggh-Huglo collection";
+  dc:identifier "0376-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46099> .
+
+<http://vocab.lib.umd.edu/collection#0377-MDHC> rdfs:label "Merilyn B. Reeves papers";
+  dc:identifier "0377-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/36188> .
+
+<http://vocab.lib.umd.edu/collection#0377-SCPA> rdfs:label "Edward N. Waters Music Library Association records";
+  dc:identifier "0377-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46101> .
+
+<http://vocab.lib.umd.edu/collection#0378-MDHC> rdfs:label "Baltimore News American collection";
+  dc:identifier "0378-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42224> .
+
+<http://vocab.lib.umd.edu/collection#0378-SCPA> rdfs:label "Kenneth F. Hoke-Witherspoon collection";
+  dc:identifier "0378-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46102> .
+
+<http://vocab.lib.umd.edu/collection#0379-MDHC> rdfs:label "Mackall Family papers";
+  dc:identifier "0379-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42221> .
+
+<http://vocab.lib.umd.edu/collection#0380-MDHC> rdfs:label "Harold A. and Barbara B. Knapp papers";
+  dc:identifier "0380-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42396> .
+
+<http://vocab.lib.umd.edu/collection#0380-SCPA> rdfs:label "Adolph Weiss and Paula Hughes papers";
+  dc:identifier "0380-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46105> .
+
+<http://vocab.lib.umd.edu/collection#0381-MDHC> rdfs:label "Maryland Temperance collection";
+  dc:identifier "0381-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42578> .
+
+<http://vocab.lib.umd.edu/collection#0381-SCPA> rdfs:label "Robbie White collection on the Slickee Boys";
+  dc:identifier "0381-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46116> .
+
+<http://vocab.lib.umd.edu/collection#0382-SCPA> rdfs:label "Irma H. Collins papers";
+  dc:identifier "0382-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46119> .
+
+<http://vocab.lib.umd.edu/collection#0383-SCPA> rdfs:label "Duvall record collection";
+  dc:identifier "0383-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46124> .
+
+<http://vocab.lib.umd.edu/collection#0384-SCPA> rdfs:label "Frank Wickes papers (ABA)";
+  dc:identifier "0384-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46130> .
+
+<http://vocab.lib.umd.edu/collection#0385-SCPA> rdfs:label "John Mahlmann papers";
+  dc:identifier "0385-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46574> .
+
+<http://vocab.lib.umd.edu/collection#0386-SCPA> rdfs:label "Carl L. Todd collection on A.H. Benade and the NX Clarinet";
+  dc:identifier "0386-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46619> .
+
+<http://vocab.lib.umd.edu/collection#0387-SCPA> rdfs:label "Gregory Kosteck scores";
+  dc:identifier "0387-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46620> .
+
+<http://vocab.lib.umd.edu/collection#0388-SCPA> rdfs:label "Aaron Avshalomov scores collection";
+  dc:identifier "0388-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46621> .
+
+<http://vocab.lib.umd.edu/collection#0389-SCPA> rdfs:label "Jacob Avshalomov scores collection";
+  dc:identifier "0389-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46622> .
+
+<http://vocab.lib.umd.edu/collection#0390-SCPA> rdfs:label "Irmgard Bartenieff papers";
+  dc:identifier "0390-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46623> .
+
+<http://vocab.lib.umd.edu/collection#0391-SCPA> rdfs:label "National School Orchestra Association (NSOA) records";
+  dc:identifier "0391-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46639> .
+
+<http://vocab.lib.umd.edu/collection#0392-SCPA> rdfs:label "American String Teachers Association (ASTA) records";
+  dc:identifier "0392-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46642> .
+
+<http://vocab.lib.umd.edu/collection#0393-SCPA> rdfs:label "Dena J. Epstein papers";
+  dc:identifier "0393-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46643> .
+
+<http://vocab.lib.umd.edu/collection#0394-SCPA> rdfs:label "George Sturm correspondence";
+  dc:identifier "0394-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46644> .
+
+<http://vocab.lib.umd.edu/collection#0395-SCPA> rdfs:label "SCPA Podcast collection";
+  dc:identifier "0395-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46645> .
+
+<http://vocab.lib.umd.edu/collection#0399-MDHC> rdfs:label "Leonard Smallwood papers";
+  dc:identifier "0399-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42219> .
+
+<http://vocab.lib.umd.edu/collection#0400-MDHC> rdfs:label "Abraham Jones papers";
+  dc:identifier "0400-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/42220> .
+
+<http://vocab.lib.umd.edu/collection#0415-SCPA> rdfs:label "Ian MacKaye digital collection of punk fanzines";
+  dc:identifier "0415-SCPA";
+  owl:sameAs <https://hdl.handle.net/1903.1/47873> .
+
+<http://vocab.lib.umd.edu/collection#0428-SCPA-HAMERMAN> rdfs:label "Don Hamerman collection of performing arts photographs";
+  dc:identifier "0428-SCPA-HAMERMAN";
+  owl:sameAs <https://hdl.handle.net/1903.1/48961> .
+
+<http://vocab.lib.umd.edu/collection#0478-UA> rdfs:label "Vice President for Academic Affairs and Provost records";
+  dc:identifier "0478-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1646> .
+
+<http://vocab.lib.umd.edu/collection#0480-UA> rdfs:label "University Publications collection";
+  dc:identifier "0480-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/43403> .
+
+<http://vocab.lib.umd.edu/collection#0483-MMC> rdfs:label "Broadcast Music, Inc. (BMI) audio tapes and scrapbooks";
+  dc:identifier "0483-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/43600> .
+
+<http://vocab.lib.umd.edu/collection#0484-MDHC> rdfs:label "Andrew and Joseph Pearson papers";
+  dc:identifier "0484-MDHC";
+  owl:sameAs <http://hdl.handle.net/1903.1/43734> .
+
+<http://vocab.lib.umd.edu/collection#0485-MMC> rdfs:label "National Association of Educational Broadcasters (NAEB) audio tapes";
+  dc:identifier "0485-MMC";
+  owl:sameAs <https://hdl.handle.net/1903.1/43845> .
+
+<http://vocab.lib.umd.edu/collection#0487-MDHC> rdfs:label "Victor Gold papers";
+  dc:identifier "0487-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/43859> .
+
+<http://vocab.lib.umd.edu/collection#0490-MDHC> rdfs:label "Grover C. Hinds III and Diane Skogland Hinds collection";
+  dc:identifier "0490-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/43878> .
+
+<http://vocab.lib.umd.edu/collection#0491-MDHC> rdfs:label "James C. and Mary G. Holland collection";
+  dc:identifier "0491-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/43883> .
+
+<http://vocab.lib.umd.edu/collection#0492-MMC> rdfs:label "Group W (the Westinghouse Broadcasting Co.) audio tapes";
+  dc:identifier "0492-MMC";
+  owl:sameAs <https://hdl.handle.net/1903.1/43884> .
+
+<http://vocab.lib.umd.edu/collection#0493-MDHC> rdfs:label "Cornelius Comegys papers";
+  dc:identifier "0493-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/43968> .
+
+<http://vocab.lib.umd.edu/collection#0494-MDHC> rdfs:label "Anderson Family papers";
+  dc:identifier "0494-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/43991> .
+
+<http://vocab.lib.umd.edu/collection#0497-UA> rdfs:label "Lesbian, Gay, Bisexual, Transgender, Queer (LGBTQ) oral histories";
+  dc:identifier "0497-UA";
+  owl:sameAs <https://hdl.handle.net/1903.1/44022> .
+
+<http://vocab.lib.umd.edu/collection#0498-MDHC> rdfs:label "Florence Green Shay and Thomas Reed Shay papers";
+  dc:identifier "0498-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/44030> .
+
+<http://vocab.lib.umd.edu/collection#0499-MDHC> rdfs:label "Patapsco Female Institute collection";
+  dc:identifier "0499-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/44031> .
+
+<http://vocab.lib.umd.edu/collection#0500-MDHC> rdfs:label "Maryland Real Estate Appraisal collection";
+  dc:identifier "0500-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/44032> .
+
+<http://vocab.lib.umd.edu/collection#0502-MDHC> rdfs:label "Pratt Street Riot collection";
+  dc:identifier "0502-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/44103> .
+
+<http://vocab.lib.umd.edu/collection#0503-MDHC> rdfs:label "A. Lynn Bolles papers";
+  dc:identifier "0503-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/44123> .
+
+<http://vocab.lib.umd.edu/collection#0504-MDHC> rdfs:label "Old Parish House at 200 collection";
+  dc:identifier "0504-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/45229> .
+
+<http://vocab.lib.umd.edu/collection#0505-MDHC> rdfs:label "Reginald Sellman photographs";
+  dc:identifier "0505-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/45231> .
+
+<http://vocab.lib.umd.edu/collection#0506-MDHC> rdfs:label "Weems Family papers";
+  dc:identifier "0506-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/45232> .
+
+<http://vocab.lib.umd.edu/collection#0507-MDHC> rdfs:label "Sophia Bolgiano papers";
+  dc:identifier "0507-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/45240> .
+
+<http://vocab.lib.umd.edu/collection#0508-MDHC> rdfs:label "Lamping Family papers";
+  dc:identifier "0508-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/45242> .
+
+<http://vocab.lib.umd.edu/collection#0509-MDHC> rdfs:label "Capital Centre collection";
+  dc:identifier "0509-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/45243> .
+
+<http://vocab.lib.umd.edu/collection#0510-MMC> rdfs:label "Scott Howe Bowen papers";
+  dc:identifier "0510-MMC";
+  owl:sameAs <https://hdl.handle.net/1903.1/45249> .
+
+<http://vocab.lib.umd.edu/collection#0511-MDHC> rdfs:label "John Zug surveys";
+  dc:identifier "0511-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/45251> .
+
+<http://vocab.lib.umd.edu/collection#0513-MDHC> rdfs:label "Robinson Family papers";
+  dc:identifier "0513-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/45255> .
+
+<http://vocab.lib.umd.edu/collection#0514-MDHC> rdfs:label "Joseph Spence papers";
+  dc:identifier "0514-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/45288> .
+
+<http://vocab.lib.umd.edu/collection#0515-LBR> rdfs:label "Metropolitan Washington Council AFL-CIO records";
+  dc:identifier "0515-LBR";
+  owl:sameAs <https://hdl.handle.net/1903.1/45293> .
+
+<http://vocab.lib.umd.edu/collection#0516-MDHC> rdfs:label "Martin Tschudy papers";
+  dc:identifier "0516-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/45294> .
+
+<http://vocab.lib.umd.edu/collection#0517-MDHC> rdfs:label "Maryland Historical Markers photographs";
+  dc:identifier "0517-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/45300> .
+
+<http://vocab.lib.umd.edu/collection#0518-MDHC> rdfs:label "Oswald Tilghman papers";
+  dc:identifier "0518-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/45302> .
+
+<http://vocab.lib.umd.edu/collection#0519-MDHC> rdfs:label "John W. Frece papers";
+  dc:identifier "0519-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/45303> .
+
+<http://vocab.lib.umd.edu/collection#0523-MDHC> rdfs:label "Congressional Union for Woman Suffrage newsletter collection";
+  dc:identifier "0523-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/45311> .
+
+<http://vocab.lib.umd.edu/collection#0525-MDHC> rdfs:label "American Association of University Women, Towson Branch (AAUW) records";
+  dc:identifier "0525-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/45315> .
+
+<http://vocab.lib.umd.edu/collection#0526-MDHC> rdfs:label "WAVES United States Naval Training Center Photograph Album";
+  dc:identifier "0526-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/45317> .
+
+<http://vocab.lib.umd.edu/collection#0527-MDHC> rdfs:label "Gladys Stigler scrapbook";
+  dc:identifier "0527-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/45318> .
+
+<http://vocab.lib.umd.edu/collection#0528-MDHC> rdfs:label "Hannah Purcell Bruton scrapbook";
+  dc:identifier "0528-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/45912> .
+
+<http://vocab.lib.umd.edu/collection#0531-MDHC> rdfs:label "Anna Witmer Myers papers";
+  dc:identifier "0531-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/45917> .
+
+<http://vocab.lib.umd.edu/collection#0532-MDHC> rdfs:label "University Park Woman's Club records";
+  dc:identifier "0532-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/45949> .
+
+<http://vocab.lib.umd.edu/collection#0533-MMC> rdfs:label "Donald Jensen QSL collection";
+  dc:identifier "0533-MMC";
+  owl:sameAs <https://hdl.handle.net/1903.1/45950> .
+
+<http://vocab.lib.umd.edu/collection#0534-UA> rdfs:label "President's Commission on Lesbian, Gay, Bisexual, and Transgender Issues records";
+  dc:identifier "0534-UA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46018> .
+
+<http://vocab.lib.umd.edu/collection#0535-LBR> rdfs:label "Thurman B. Wenzl papers";
+  dc:identifier "0535-LBR";
+  owl:sameAs <https://hdl.handle.net/1903.1/46051> .
+
+<http://vocab.lib.umd.edu/collection#0536-LBR> rdfs:label "Martha Tabor photographs";
+  dc:identifier "0536-LBR";
+  owl:sameAs <https://hdl.handle.net/1903.1/46057> .
+
+<http://vocab.lib.umd.edu/collection#0538-MMC> rdfs:label "Oscar Katz papers";
+  dc:identifier "0538-MMC";
+  owl:sameAs <https://hdl.handle.net/1903.1/46061> .
+
+<http://vocab.lib.umd.edu/collection#0539-LIT> rdfs:label "Early Printed and Manuscript Leaf collection";
+  dc:identifier "0539-LIT";
+  owl:sameAs <https://hdl.handle.net/1903.1/46062> .
+
+<http://vocab.lib.umd.edu/collection#0540-UA> rdfs:label "Elaine J. Coates oral history";
+  dc:identifier "0540-UA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46085> .
+
+<http://vocab.lib.umd.edu/collection#0542-LBR> rdfs:label "Lester N. Trachtman Papers";
+  dc:identifier "0542-LBR";
+  owl:sameAs <https://hdl.handle.net/1903.1/46098> .
+
+<http://vocab.lib.umd.edu/collection#0543-UA> rdfs:label "Maryland LEAD Program records";
+  dc:identifier "0543-UA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46100> .
+
+<http://vocab.lib.umd.edu/collection#0544-LIT> rdfs:label "The Rose and Joseph Pagnani Collection of Girls' Series Books";
+  dc:identifier "0544-LIT";
+  owl:sameAs <https://hdl.handle.net/1903.1/46104> .
+
+<http://vocab.lib.umd.edu/collection#0545-MDHC> rdfs:label "Toaping Castle Chapter, National Society Daughters of the American Revolution records";
+  dc:identifier "0545-MDHC";
+  owl:sameAs <https://hdl.handle.net/1903.1/46113> .
+
+<http://vocab.lib.umd.edu/collection#0546-GWP> rdfs:label "Roy W. Simonson papers";
+  dc:identifier "0546-GWP";
+  owl:sameAs <https://hdl.handle.net/1903.1/46114> .
+
+<http://vocab.lib.umd.edu/collection#0547-LBR> rdfs:label "African American Labor Center (AALC) records";
+  dc:identifier "0547-LBR";
+  owl:sameAs <https://hdl.handle.net/1903.1/46115> .
+
+<http://vocab.lib.umd.edu/collection#0548-MMC> rdfs:label "Connie Lawn papers";
+  dc:identifier "0548-MMC";
+  owl:sameAs <https://hdl.handle.net/1903.1/46117> .
+
+<http://vocab.lib.umd.edu/collection#0549-LIT> rdfs:label "Frank, Howard and Jane Collection of Science Fiction Pulp Magazines";
+  dc:identifier "0549-LIT";
+  owl:sameAs <https://hdl.handle.net/1903.1/46602> .
+
+<http://vocab.lib.umd.edu/collection#0550-UA> rdfs:label "Black Student Union records";
+  dc:identifier "0550-UA";
+  owl:sameAs <https://hdl.handle.net/1903.1/46640> .
+
+<http://vocab.lib.umd.edu/collection#0551-LBR> rdfs:label "Pride at Work records";
+  dc:identifier "0551-LBR";
+  owl:sameAs <https://hdl.handle.net/1903.1/46646> .
+
+<http://vocab.lib.umd.edu/collection#0562-GWP> rdfs:label "Julius Bassin papers";
+  dc:identifier "0562-GWP";
+  owl:sameAs <https://hdl.handle.net/1903.1/46736> .
+
+<http://vocab.lib.umd.edu/collection#160-MMC> rdfs:label "Dennis Hart <title>Monitor</title> collection";
+  dc:identifier "160-MMC";
+  owl:sameAs <http://hdl.handle.net/1903.1/43404> .
+
+<http://vocab.lib.umd.edu/collection#182-MMC-LAB> rdfs:label "Fran Norris Papers";
+  dc:identifier "182-MMC-LAB";
+  owl:sameAs <http://hdl.handle.net/1903.1/3294> .
+
+<http://vocab.lib.umd.edu/collection#2017-088-MASON> rdfs:label "Manuscript correspondence of Abigail Mason, 1888 and undated";
+  dc:identifier "2017-088-MASON";
+  owl:sameAs <http://hdl.handle.net/1903.1/42753> .
+
+<http://vocab.lib.umd.edu/collection#2019-SCPA-0083> rdfs:label "Records of the Smallbeer Theatre Company";
+  dc:identifier "2019-SCPA-0083";
+  owl:sameAs <https://hdl.handle.net/1903.1/45316> .
+
+<http://vocab.lib.umd.edu/collection#2020-SCPA-0008> rdfs:label "Records of the Chair of the Board of the Directors, African Continuum Theatre Company";
+  dc:identifier "2020-SCPA-0008";
+  owl:sameAs <https://hdl.handle.net/1903.1/45250> .
+
+<http://vocab.lib.umd.edu/collection#272-UA> rdfs:label "University of Maryland College Republican Club records";
+  dc:identifier "272-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1423> .
+
+<http://vocab.lib.umd.edu/collection#274-UA> rdfs:label "Reginald Truitt papers";
+  dc:identifier "274-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1302> .
+
+<http://vocab.lib.umd.edu/collection#281-UA> rdfs:label "J. Franklin Witter papers";
+  dc:identifier "281-UA";
+  owl:sameAs <http://hdl.handle.net/1903.1/1313> .
+
+<http://vocab.lib.umd.edu/collection#9999-RARE-LIT> rdfs:label "Rare Stacks collection";
+  dc:identifier "9999-RARE-LIT" .

--- a/plastron-models/tests/data/vocabularies/dcmitype.ttl
+++ b/plastron-models/tests/data/vocabularies/dcmitype.ttl
@@ -1,0 +1,123 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix dcam: <http://purl.org/dc/dcam/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://purl.org/dc/dcmitype/>
+    dcterms:modified "2012-06-14"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    dcterms:publisher <http://purl.org/dc/aboutdcmi#DCMI> ;
+    dcterms:title "DCMI Type Vocabulary"@en .
+
+<http://purl.org/dc/dcmitype/Collection>
+    dcam:memberOf dcterms:DCMIType ;
+    dcterms:description "A collection is described as a group; its parts may also be separately described."@en ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "An aggregation of resources."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/dcmitype/> ;
+    rdfs:label "Collection"@en .
+
+<http://purl.org/dc/dcmitype/Dataset>
+    dcam:memberOf dcterms:DCMIType ;
+    dcterms:description "Examples include lists, tables, and databases.  A dataset may be useful for direct machine processing."@en ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "Data encoded in a defined structure."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/dcmitype/> ;
+    rdfs:label "Dataset"@en .
+
+<http://purl.org/dc/dcmitype/Event>
+    dcam:memberOf dcterms:DCMIType ;
+    dcterms:description "Metadata for an event provides descriptive information that is the basis for discovery of the purpose, location, duration, and responsible agents associated with an event. Examples include an exhibition, webcast, conference, workshop, open day, performance, battle, trial, wedding, tea party, conflagration."@en ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A non-persistent, time-based occurrence."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/dcmitype/> ;
+    rdfs:label "Event"@en .
+
+<http://purl.org/dc/dcmitype/Image>
+    dcam:memberOf dcterms:DCMIType ;
+    dcterms:description "Examples include images and photographs of physical objects, paintings, prints, drawings, other images and graphics, animations and moving pictures, film, diagrams, maps, musical notation.  Note that Image may include both electronic and physical representations."@en ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A visual representation other than text."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/dcmitype/> ;
+    rdfs:label "Image"@en .
+
+<http://purl.org/dc/dcmitype/InteractiveResource>
+    dcam:memberOf dcterms:DCMIType ;
+    dcterms:description "Examples include forms on Web pages, applets, multimedia learning objects, chat services, or virtual reality environments."@en ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A resource requiring interaction from the user to be understood, executed, or experienced."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/dcmitype/> ;
+    rdfs:label "Interactive Resource"@en .
+
+<http://purl.org/dc/dcmitype/MovingImage>
+    dcam:memberOf dcterms:DCMIType ;
+    dcterms:description "Examples include animations, movies, television programs, videos, zoetropes, or visual output from a simulation.  Instances of the type Moving Image must also be describable as instances of the broader type Image."@en ;
+    dcterms:issued "2003-11-18"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A series of visual representations imparting an impression of motion when shown in succession."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/dcmitype/> ;
+    rdfs:label "Moving Image"@en ;
+    rdfs:subClassOf <http://purl.org/dc/dcmitype/Image> .
+
+<http://purl.org/dc/dcmitype/PhysicalObject>
+    dcam:memberOf dcterms:DCMIType ;
+    dcterms:description "Note that digital representations of, or surrogates for, these objects should use Image, Text or one of the other types."@en ;
+    dcterms:issued "2002-07-13"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "An inanimate, three-dimensional object or substance."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/dcmitype/> ;
+    rdfs:label "Physical Object"@en .
+
+<http://purl.org/dc/dcmitype/Service>
+    dcam:memberOf dcterms:DCMIType ;
+    dcterms:description "Examples include a photocopying service, a banking service, an authentication service, interlibrary loans, a Z39.50 or Web server."@en ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A system that provides one or more functions."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/dcmitype/> ;
+    rdfs:label "Service"@en .
+
+<http://purl.org/dc/dcmitype/Software>
+    dcam:memberOf dcterms:DCMIType ;
+    dcterms:description "Examples include a C source file, MS-Windows .exe executable, or Perl script."@en ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A computer program in source or compiled form."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/dcmitype/> ;
+    rdfs:label "Software"@en .
+
+<http://purl.org/dc/dcmitype/Sound>
+    dcam:memberOf dcterms:DCMIType ;
+    dcterms:description "Examples include a music playback file format, an audio compact disc, and recorded speech or sounds."@en ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A resource primarily intended to be heard."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/dcmitype/> ;
+    rdfs:label "Sound"@en .
+
+<http://purl.org/dc/dcmitype/StillImage>
+    dcam:memberOf dcterms:DCMIType ;
+    dcterms:description "Examples include paintings, drawings, graphic designs, plans and maps. Recommended best practice is to assign the type Text to images of textual materials. Instances of the type Still Image must also be describable as instances of the broader type Image."@en ;
+    dcterms:issued "2003-11-18"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A static visual representation."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/dcmitype/> ;
+    rdfs:label "Still Image"@en ;
+    rdfs:subClassOf <http://purl.org/dc/dcmitype/Image> .
+
+<http://purl.org/dc/dcmitype/Text>
+    dcam:memberOf dcterms:DCMIType ;
+    dcterms:description "Examples include books, letters, dissertations, poems, newspapers, articles, archives of mailing lists. Note that facsimiles or images of texts are still of the genre Text."@en ;
+    dcterms:issued "2000-07-11"^^<http://www.w3.org/2001/XMLSchema#date> ;
+    a rdfs:Class ;
+    rdfs:comment "A resource consisting primarily of words for reading."@en ;
+    rdfs:isDefinedBy <http://purl.org/dc/dcmitype/> ;
+    rdfs:label "Text"@en .
+
+

--- a/plastron-models/tests/data/vocabularies/form.ttl
+++ b/plastron-models/tests/data/vocabularies/form.ttl
@@ -1,0 +1,222 @@
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://vocab.lib.umd.edu/form#architectural_drawings> rdfs:label "Architectural drawings (visual works)";
+  dc:identifier "architectural_drawings";
+  owl:sameAs <http://vocab.getty.edu/page/aat/300034787> .
+
+<http://vocab.lib.umd.edu/form#art> rdfs:label "Art";
+  dc:identifier "art";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2017027218> .
+
+<http://vocab.lib.umd.edu/form#books> rdfs:label "Books";
+  dc:identifier "books";
+  owl:sameAs <http://vocab.getty.edu/page/aat/300028051> .
+
+<http://vocab.lib.umd.edu/form#broadsides_notices> rdfs:label "Broadsides (notices)";
+  dc:identifier "broadsides_notices";
+  owl:sameAs <http://vocab.getty.edu/page/aat/300026739> .
+
+<http://vocab.lib.umd.edu/form#business_correspondence> rdfs:label "Business correspondence";
+  dc:identifier "business_correspondence";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2014026054> .
+
+<http://vocab.lib.umd.edu/form#catalogs> rdfs:label "Catalogs";
+  dc:identifier "catalogs";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2014026057> .
+
+<http://vocab.lib.umd.edu/form#certificates> rdfs:label "Certificates";
+  dc:identifier "certificates";
+  owl:sameAs <http://vocab.getty.edu/page/aat/300026841> .
+
+<http://vocab.lib.umd.edu/form#chapbooks> rdfs:label "Chapbooks";
+  dc:identifier "chapbooks";
+  owl:sameAs <http://vocab.getty.edu/page/aat/300152367> .
+
+<http://vocab.lib.umd.edu/form#conference_papers> rdfs:label "Conference papers and proceedings";
+  dc:identifier "conference_papers";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2014026068> .
+
+<http://vocab.lib.umd.edu/form#diaries> rdfs:label "Diaries";
+  dc:identifier "diaries";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2014026085> .
+
+<http://vocab.lib.umd.edu/form#drama> rdfs:label "Drama";
+  dc:identifier "drama";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2014026297> .
+
+<http://vocab.lib.umd.edu/form#drawings> rdfs:label "Drawings";
+  dc:identifier "drawings";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2017027231> .
+
+<http://vocab.lib.umd.edu/form#ephemera> rdfs:label "Ephemera";
+  dc:identifier "ephemera";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2014026093> .
+
+<http://vocab.lib.umd.edu/form#essays> rdfs:label "Essays";
+  dc:identifier "essays";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2014026094> .
+
+<http://vocab.lib.umd.edu/form#exhibition_catalogs> rdfs:label "Exhibition catalogs";
+  dc:identifier "exhibition_catalogs";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2014026098> .
+
+<http://vocab.lib.umd.edu/form#fanzines> rdfs:label "Fanzines";
+  dc:identifier "fanzines";
+  owl:sameAs <http://vocab.getty.edu/page/aat/300252980> .
+
+<http://vocab.lib.umd.edu/form#fliers_ephemera> rdfs:label "Fliers (ephemera)";
+  dc:identifier "fliers_ephemera";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2017026133> .
+
+<http://vocab.lib.umd.edu/form#greeting_cards> rdfs:label "Greeting cards";
+  dc:identifier "greeting_cards";
+  owl:sameAs <http://vocab.getty.edu/page/aat/300026778> .
+
+<http://vocab.lib.umd.edu/form#illustrated_works> rdfs:label "Illustrated works";
+  dc:identifier "illustrated_works";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2014026111> .
+
+<http://vocab.lib.umd.edu/form#invitations> rdfs:label "Invitations";
+  dc:identifier "invitations";
+  owl:sameAs <http://vocab.getty.edu/page/aat/300027083> .
+
+<http://vocab.lib.umd.edu/form#manuscripts> rdfs:label "Manuscripts (documents)";
+  dc:identifier "manuscripts";
+  owl:sameAs <http://vocab.getty.edu/page/aat/300028569> .
+
+<http://vocab.lib.umd.edu/form#manuscripts_publication> rdfs:label "Manuscripts for publication";
+  dc:identifier "manuscripts_publication";
+  owl:sameAs <http://vocab.getty.edu/page/aat/300028579> .
+
+<http://vocab.lib.umd.edu/form#maps> rdfs:label "Maps";
+  dc:identifier "maps";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2011026387> .
+
+<http://vocab.lib.umd.edu/form#negatives> rdfs:label "Negatives (photographs)";
+  dc:identifier "negatives";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2019026026> .
+
+<http://vocab.lib.umd.edu/form#newsletters> rdfs:label "Newsletters";
+  dc:identifier "newsletters";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2014026131> .
+
+<http://vocab.lib.umd.edu/form#newspaper_clippings> rdfs:label "Newspaper clippings";
+  dc:identifier "newspaper_clippings";
+  owl:sameAs <http://vocab.getty.edu/page/aat/300429554> .
+
+<http://vocab.lib.umd.edu/form#newspapers> rdfs:label "Newspapers";
+  dc:identifier "newspapers";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2014026132> .
+
+<http://vocab.lib.umd.edu/form#nonfiction_films> rdfs:label "Nonfiction films";
+  dc:identifier "nonfiction_films";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2011026423> .
+
+<http://vocab.lib.umd.edu/form#paintings> rdfs:label "Paintings (visual works)";
+  dc:identifier "paintings";
+  owl:sameAs <http://vocab.getty.edu/page/aat/300033618> .
+
+<http://vocab.lib.umd.edu/form#pamphlets> rdfs:label "Pamphlets";
+  dc:identifier "pamphlets";
+  owl:sameAs <http://vocab.getty.edu/page/aat/300220572> .
+
+<http://vocab.lib.umd.edu/form#periodicals> rdfs:label "Periodicals";
+  dc:identifier "periodicals";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2014026139> .
+
+<http://vocab.lib.umd.edu/form#personal_correspondence> rdfs:label "Personal correspondence";
+  dc:identifier "personal_correspondence";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2014026141> .
+
+<http://vocab.lib.umd.edu/form#photograph_albums> rdfs:label "Photograph albums";
+  dc:identifier "photograph_albums";
+  owl:sameAs <http://vocab.getty.edu/page/aat/300026695> .
+
+<http://vocab.lib.umd.edu/form#photographs> rdfs:label "Photographs";
+  dc:identifier "photographs";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2017027249> .
+
+<http://vocab.lib.umd.edu/form#poetry> rdfs:label "Poetry";
+  dc:identifier "poetry";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2014026481> .
+
+<http://vocab.lib.umd.edu/form#pool_reports> rdfs:label "Pool reports";
+  dc:identifier "pool_reports" .
+
+<http://vocab.lib.umd.edu/form#postcards> rdfs:label "Postcards";
+  dc:identifier "postcards";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2014026151> .
+
+<http://vocab.lib.umd.edu/form#posters> rdfs:label "Posters";
+  dc:identifier "posters";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2014026152> .
+
+<http://vocab.lib.umd.edu/form#press_releases> rdfs:label "Press releases";
+  dc:identifier "press_releases";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2014026153> .
+
+<http://vocab.lib.umd.edu/form#prints> rdfs:label "Prints (visual works)";
+  dc:identifier "prints";
+  owl:sameAs <http://vocab.getty.edu/page/aat/300041273> .
+
+<http://vocab.lib.umd.edu/form#programs> rdfs:label "Programs (publications)";
+  dc:identifier "programs";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2014026156> .
+
+<http://vocab.lib.umd.edu/form#property_records> rdfs:label "Property records";
+  dc:identifier "property_records";
+  owl:sameAs <http://vocab.getty.edu/page/aat/300027243> .
+
+<http://vocab.lib.umd.edu/form#records> rdfs:label "Records (documents)";
+  dc:identifier "records";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2014026163> .
+
+<http://vocab.lib.umd.edu/form#reports> rdfs:label "Reports";
+  dc:identifier "reports";
+  owl:sameAs <http://vocab.getty.edu/page/aat/300027267> .
+
+<http://vocab.lib.umd.edu/form#research_notes> rdfs:label "Research notes";
+  dc:identifier "research_notes";
+  owl:sameAs <http://vocab.getty.edu/page/aat/300265639> .
+
+<http://vocab.lib.umd.edu/form#rosters> rdfs:label "Rosters";
+  dc:identifier "rosters";
+  owl:sameAs <http://vocab.getty.edu/page/aat/300027178> .
+
+<http://vocab.lib.umd.edu/form#scores> rdfs:label "Scores";
+  dc:identifier "scores";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2014027077> .
+
+<http://vocab.lib.umd.edu/form#scrapbooks> rdfs:label "Scrapbooks";
+  dc:identifier "scrapbooks";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2014026173> .
+
+<http://vocab.lib.umd.edu/form#sculpture> rdfs:label "Sculpture (visual works)";
+  dc:identifier "sculpture";
+  owl:sameAs <http://vocab.getty.edu/page/aat/300047090> .
+
+<http://vocab.lib.umd.edu/form#sheet_music> rdfs:label "Sheet music";
+  dc:identifier "sheet_music";
+  owl:sameAs <http://vocab.getty.edu/page/aat/300026430> .
+
+<http://vocab.lib.umd.edu/form#slides_photographs> rdfs:label "Slides (photographs)";
+  dc:identifier "slides_photographs";
+  owl:sameAs <http://vocab.getty.edu/page/aat/300128371> .
+
+<http://vocab.lib.umd.edu/form#speeches> rdfs:label "Speeches";
+  dc:identifier "speeches";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2011026363> .
+
+<http://vocab.lib.umd.edu/form#spoken_word> rdfs:label "Spoken word poetry";
+  dc:identifier "spoken_word";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2014026552> .
+
+<http://vocab.lib.umd.edu/form#transcripts> rdfs:label "Transcripts";
+  dc:identifier "transcripts";
+  owl:sameAs <http://vocab.getty.edu/page/aat/300027388> .
+
+<http://vocab.lib.umd.edu/form#yearbooks> rdfs:label "School yearbooks";
+  dc:identifier "yearbooks";
+  owl:sameAs <http://id.loc.gov/authorities/genreForms/gf2014026172> .

--- a/plastron-models/tests/data/vocabularies/rightsStatement.ttl
+++ b/plastron-models/tests/data/vocabularies/rightsStatement.ttl
@@ -1,0 +1,35 @@
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://vocab.lib.umd.edu/rightsStatement#CNE> rdfs:label "Copyright Not Evaluated";
+  dc:identifier "CNE";
+  owl:sameAs <http://rightsstatements.org/vocab/CNE/1.0/> .
+
+<http://vocab.lib.umd.edu/rightsStatement#InC> rdfs:label "In Copyright";
+  dc:identifier "InC";
+  owl:sameAs <http://rightsstatements.org/vocab/InC/1.0/> .
+
+<http://vocab.lib.umd.edu/rightsStatement#InC-EDU> rdfs:label "In Copyright - Educational Use Permitted";
+  dc:identifier "InC-EDU";
+  owl:sameAs <http://rightsstatements.org/vocab/InC-EDU/1.0/> .
+
+<http://vocab.lib.umd.edu/rightsStatement#InC-NC> rdfs:label "In Copyright - Non-Commercial Use Permitted";
+  dc:identifier "InC-NC";
+  owl:sameAs <http://rightsstatements.org/vocab/InC-NC/1.0/> .
+
+<http://vocab.lib.umd.edu/rightsStatement#InC-RUU> rdfs:label "In Copyright - Rights-Holder(s) Unlocatable or Unidentifiable";
+  dc:identifier "InC-RUU";
+  owl:sameAs <http://rightsstatements.org/vocab/InC-RUU/1.0/> .
+
+<http://vocab.lib.umd.edu/rightsStatement#NKC> rdfs:label "No Known Copyright";
+  dc:identifier "NKC";
+  owl:sameAs <http://rightsstatements.org/vocab/NKC/1.0/> .
+
+<http://vocab.lib.umd.edu/rightsStatement#NoC-US> rdfs:label "No Copyright - United States";
+  dc:identifier "NoC-US";
+  owl:sameAs <http://rightsstatements.org/vocab/NoC-US/1.0/> .
+
+<http://vocab.lib.umd.edu/rightsStatement#UND> rdfs:label "Copyright Undetermined";
+  dc:identifier "UND";
+  owl:sameAs <http://rightsstatements.org/vocab/UND/1.0/> .

--- a/plastron-models/tests/data/vocabularies/set.ttl
+++ b/plastron-models/tests/data/vocabularies/set.ttl
@@ -1,0 +1,7 @@
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://vocab.lib.umd.edu/set#test> rdfs:label "Test Presentation Set";
+  dc:identifier "test";
+  owl:sameAs <http://vocab.lib.umd.edu/set#test> .

--- a/plastron-models/tests/data/vocabularies/termsOfUse.ttl
+++ b/plastron-models/tests/data/vocabularies/termsOfUse.ttl
@@ -1,0 +1,7 @@
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://vocab.lib.umd.edu/termsOfUse#test> rdfs:label "Test Terms of Use";
+  dc:identifier "test";
+  owl:sameAs <http://vocab.lib.umd.edu/termsOfUse#test> .

--- a/plastron-models/tests/test_terms_of_use.py
+++ b/plastron-models/tests/test_terms_of_use.py
@@ -1,0 +1,64 @@
+from plastron.models.umd import Item
+from plastron.models.letter import Letter
+from plastron.models.newspaper import Issue
+from plastron.models.poster import Poster
+from plastron.namespaces import dcterms
+from rdflib import Graph, URIRef
+
+import pytest
+
+base_uri = 'http://example.com/xyz'
+
+
+@pytest.mark.parametrize("model_class", [Item, Letter, Poster, Issue])
+def test_model_with_terms_of_use(model_class):
+    model = create_model_with_terms_of_use(
+        model_class, base_uri, 'foo'
+    )
+
+    assert model.terms_of_use.value == URIRef('http://vocab.lib.umd.edu/termsOfUse#foo')
+
+
+@pytest.mark.parametrize("model_class", [Item, Letter, Poster, Issue])
+def test_model_validation_with_valid_terms_of_user(model_class):
+    model = create_model_with_terms_of_use(
+        model_class, base_uri, 'test'
+    )
+    assert model.terms_of_use.is_valid
+
+
+@pytest.mark.parametrize("model_class", [Item, Letter, Poster, Issue])
+def test_model_validation_with_invalid_terms_of_use(model_class):
+    model = create_model_with_terms_of_use(
+        model_class, base_uri, 'not_valid'
+    )
+    assert not model.terms_of_use.is_valid
+
+
+@pytest.mark.parametrize("model_class", [Item, Letter, Poster, Issue])
+def test_terms_of_use_can_be_set_on_model(model_class):
+    model = model_class(uri=base_uri)
+    model.terms_of_use = URIRef('http://vocab.lib.umd.edu/termsOfUse#test')
+
+    expected = (URIRef(base_uri), dcterms.license, URIRef('http://vocab.lib.umd.edu/termsOfUse#test'))
+    assert expected in model.graph
+    assert model.terms_of_use.is_valid
+
+# Helper Functions
+
+
+def create_terms_of_use_turtle_format(term_of_use):
+    preamble = '@prefix dcterms: <http://purl.org/dc/terms/> .'
+    preamble = preamble + '@prefix umdtermsOfUse: <http://vocab.lib.umd.edu/termsOfUse#> .'
+    terms_of_use = preamble
+    terms_of_use += f'<> dcterms:license umdtermsOfUse:{term_of_use} .'
+    return terms_of_use
+
+
+def create_model_with_terms_of_use(model_class, item_uri, terms_of_use):
+    terms_of_use = create_terms_of_use_turtle_format(terms_of_use)
+
+    model_graph = Graph().parse(data=terms_of_use, format='turtle', publicID=item_uri)
+    model = model_class(graph=model_graph, uri=item_uri)
+
+    return model


### PR DESCRIPTION
### Vocabulary Retrieval for Tests

The `get_vocabulary method` in the `plastron-models/src/plastron/validation/vocabularies/__init__.py` module initializer controls how vocabularies used for validation are retrieved.

Vocabularies used to validate models are retrieved either from the local filesystem, or from a vocabulary server on the network.

The code uses two variables:

* `VOCABULARIES_DIR` - The full filepath to the directory containing the local vocabulary files
* `VOCABULARIES` - A dictionary mapping a URI to the name of the file containing the vocabulary.

Vocabularies matching URIs in the `VOCABULARIES` dictionary are first looked up locally, with the local file being used, if found. If not, a network lookup using the URI as the vocabulary location is used.

Vocabulary URIs not in the `VOCABULARIES` dictionary are always looked up via the network.

In general, unit tests should be run without making calls to the network, as making a network call makes the tests slower and less reliable.

The retrieval of the vocabularies via the `__init__.py` module initializer is problematic for the tests, because the module initialization occurs before a test is even run. This makes normal methods of overriding the network calls ineffective. For example, trying to intercept the network calls using the “httpretty” library doesn’t work, because by the time the “@httpretty.activate” decorator is accessed, the module has already been initialized. The same is true when attempting to “monkey patch” the module.

One method that was found to work was to add a `conftest.py` file into the root directory of the project, with a pytest_configure method. It is necessary to have the `conftest.py` in the root directory, so that it will always be used when running pytests in any of the Plastron modules (as those tests may use one of the content models with a vocabulary). This method runs as soon as pytest starts, and before any modules are loaded, providing an opportunity to set the “VOCABULARIES_DIR” and “VOCABULARIES” variables to values that are suitable for testing.

Any vocabularies needed for the tests should be added as follows:

1) Add a file containing the vocabulary (in "turtle" format) to the “plastron-models/tests/data/vocabularies/" directory.
2) In the `conftest.py` file in the root directory, add the vocabulary URI and filename to the `VOCABULARIES` dictionary.

Note that if a vocabulary is not added, a network call will still be attempted, due to the fallback behavior of the get_vocabularies method.

### Terms of Use

Modified each model by adding the following:

```
    terms_of_use = ObjectProperty(
        dcterms.license,
        validate=is_from_vocabulary('http://vocab.lib.umd.edu/termsOfUse#')
    )
```
* Item - plastron-models/src/plastron/models/umd.py
* Issue - plastron-models/src/plastron/models/newspaper.py
* Letter - plastron-models/src/plastron/models/letter.py
* Poster - plastron-models/src/plastron/models/poster.py

Also added the following to the “HEADER_MAP” for each model:

```
        'terms_of_use': 'Terms of Use',
```

Tests have been added in “plastron-models/tests/test_terms_of_use.py“ to verify that:

* The “terms_of_use” field on a model will be populated from parsing a Graph containing a “dcterms.license“ predicate and value
* Setting the “terms_of_use” field on a model will populate the resulting graph with the “dcterms.license“ predicate and value.
* An invalid term of use can be detected by the “terms_of_use” validator

Added a sample "termsOfUse" vocabulary to the local test vocabularies (and the "conftest.py" file).

https://umd-dit.atlassian.net/browse/LIBFCREPO-1339