### PR TITLE
LIBFCREPO-1431. Changed namespace to "https://schema.org/"

### DIFF
--- a/plastron-models/tests/test_copyright_notice.py
+++ b/plastron-models/tests/test_copyright_notice.py
@@ -24,7 +24,7 @@ def test_copyright_notice_can_be_set_on_model(model_class):
     model = model_class(uri=base_uri)
     model.copyright_notice = Literal(copyright_notice)
 
-    expected = (URIRef(base_uri), URIRef('http://schema.org/copyrightNotice'), Literal(copyright_notice))
+    expected = (URIRef(base_uri), URIRef('https://schema.org/copyrightNotice'), Literal(copyright_notice))
     assert expected in model.graph
 
 

--- a/plastron-utils/src/plastron/namespaces/__init__.py
+++ b/plastron-utils/src/plastron/namespaces/__init__.py
@@ -93,7 +93,7 @@ rel = Namespace('http://id.loc.gov/vocabulary/relators/')
 sc = Namespace('http://www.shared-canvas.org/ns/')
 """[Shared Canvas Data Model](https://iiif.io/api/model/shared-canvas/1.0/)"""
 
-schema = Namespace('http://schema.org/')
+schema = Namespace('https://schema.org/')
 """[Schema.org](https://schema.org/)"""
 
 skos = Namespace('http://www.w3.org/2004/02/skos/core#')


### PR DESCRIPTION
Changed the "http://schema.org/" namespace to "https://schema.org/" as "https" is the prefix used in the canonical URLs on the schema.org website.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1431