### PR TITLE
LIBFCREPO-1425. Remove per-row publishing/hiding from Plastron import

### DIFF
--- a/docs/decisions/0004-resource-publication-and-visibility-via-import.md
+++ b/docs/decisions/0004-resource-publication-and-visibility-via-import.md
@@ -1,0 +1,57 @@
+# 0004 - Resource Publication and Visibility via Import
+
+Date: June 11, 2024
+
+## Context
+
+Plastron has historically provided the ability to control the publication and
+visibility status of resources on an individual basis via the "PUBLISH" and
+"HIDDEN" columns of the metadata CSV file.
+
+As Plastron has evolved, and Archelon has gained the ability to handle imports,
+controlling the publication and visibility status of resources via the
+metadata CSV file has become increasingly difficult. For example, bugs have been
+seen in which the per-row specification of "PUBLISH" and "HIDDEN", would work
+when importing via the Plastron CLI “import” command, but would *not* work when
+importing the same CSV file through Archelon.
+
+The notion of what "published" means has also changed over time. Initially, it
+simply meant that an "rdf:type" of `http://vocab.lib.umd.edu/access#Published`
+was added to the resource. This eventually changed, however, so that publishing
+an item also included the minting of a handle for the resource.
+
+Because of these changes, it came to be understood that the existing usage
+of "PUBLISH" and "HIDDEN" fields in the CSV file:
+
+* Conflated the “state” of the field (whether a resource was published or
+  hidden) with the “action” of publishing/hiding resources
+
+* Was confusing, because while “True” in the appropriate column would
+  publish/hide the resource, setting the column to “False” would *not*
+  unpublish/unhide the resource.
+
+## Decision
+
+Based on the above the decision was made to remove from Plastron the ability to
+publish or hide individual resources when importing a CSV file. In other words,
+the “PUBLISH” and “HIDDEN” fields in the CSV file would only reflect the current
+state of the resource, and changing them would have no effect on the resource.
+
+The ability to immediately publish all the resources in an import by specifying
+the “--publish” flag on the  Plastron “import” command has been retained, as it
+is remains useful to importers, and its semantics are straightforward.
+
+Plastron has `publish` and `unpublish` commands that enable a resource (or list
+of resources) to be published/unpublished, and those commands also provide
+options for setting the visibility (to either hidden or visible).
+
+## Consequences
+
+Not being able to control the publication status and visibility of individual
+resources when importing may inconvenience users, as publishing/hiding resources
+may require additional steps. The most common use case of immediately publishing
+resources on import, however, has been retained.
+
+The overall functionality of Plastron is unchanged, as the ability to control
+the publication status and visibility of resources is provided by other
+commands.

--- a/plastron-cli/docs/import.md
+++ b/plastron-cli/docs/import.md
@@ -2,14 +2,14 @@
 
 ## CLI Usage
 
-```
-$ plastron import -h
+```zsh
+$ plastron import --help
 usage: plastron import [-h] [-m MODEL] [-l LIMIT] [-% PERCENTAGE]
                        [--validate-only] [--make-template FILENAME]
                        [--access URI|CURIE] [--member-of URI]
                        [--binaries-location LOCATION] [--container PATH]
                        [--job-id JOB_ID] [--resume]
-                       [--extract-text-from MIME_TYPES]
+                       [--extract-text-from MIME_TYPES] [--publish]
                        [import_file]
 
 Import data to the repository
@@ -24,41 +24,36 @@ optional arguments:
   -l LIMIT, --limit LIMIT
                         limit the number of rows to read from the import file
   -% PERCENTAGE, --percent PERCENTAGE
-                        select an evenly spaced subset of items to import; the
-                        size of this set will be as close as possible to the
-                        specified percentage of the total items
+                        select an evenly spaced subset of items to import; the size of this set will be as close as possible to the specified percentage
+                        of the total items
   --validate-only       only validate, do not do the actual import
   --make-template FILENAME
                         create a CSV template for the given model
   --access URI|CURIE    URI or CURIE of the access class to apply to new items
   --member-of URI       URI of the object that new items are PCDM members of
   --binaries-location LOCATION
-                        where to find binaries; either a path to a directory,
-                        a "zip:<path to zipfile>" URI, an SFTP URI in the form
-                        "sftp://<user>@<host>/<path to dir>", or a URI in the
-                        form "zip+sftp://<user>@<host>/<path to zipfile>"
-  --container PATH      parent container for new items; defaults to the
-                        RELPATH in the repo configuration file
-  --job-id JOB_ID       unique identifier for this job; defaults to
-                        "import-{timestamp}"
-  --resume              resume a job that has been started; requires --job-id
-                        {id} to be present
+                        where to find binaries; either a path to a directory, a "zip:<path to zipfile>" URI, an SFTP URI in the form
+                        "sftp://<user>@<host>/<path to dir>", or a URI in the form "zip+sftp://<user>@<host>/<path to zipfile>"
+  --container PATH      parent container for new items; defaults to the RELPATH in the repo configuration file
+  --job-id JOB_ID       unique identifier for this job; defaults to "import-{timestamp}"
+  --resume              resume a job that has been started; requires --job-id {id} to be present
   --extract-text-from MIME_TYPES, -x MIME_TYPES
-                        extract text from binaries of the given MIME types,
-                        and add as annotations
+                        extract text from binaries of the given MIME types, and add as annotations
+  --publish             automatically publish all items in this import
 ```
 
 ## Daemon Usage
 
 STOMP message headers:
 
-```
+```text
 PlastronCommand: import
 PlastronJobId: JOB_ID
 PlastronArg-model: MODEL
 PlastronArg-limit: LIMIT
 PlastronArg-percent: PERCENTAGE
 PlastronArg-validate-only: {true|false}
+PlastronArg-publish: {true|false}
 PlastronArg-resume: {true|false}
 PlastronArg-access: ACCESS
 PlastronArg-member-of: MEMBER_OF
@@ -152,7 +147,7 @@ plastron -c repo.yml import \
 
 Plastron will create the following structure in the `JOBS_DIR`:
 
-```
+```text
 {JOBS_DIR}
     +- import-foo-1           # job ID
         +- completed.log.csv  # completed item log
@@ -162,7 +157,7 @@ Plastron will create the following structure in the `JOBS_DIR`:
 
 Resume that job later:
 
-```bash
+```zsh
 plastron -c repo.yml import \
     --job-id import-foo-1 \
     --resume
@@ -181,7 +176,7 @@ select new subsets of items that have not yet been imported.
 
 For example, start a job that has 50 items total, but only load 10% at first:
 
-```bash
+```zsh
 plastron -c repo.yml import \
     --model Item \
     --binaries-location /path/to/binaries \
@@ -196,7 +191,7 @@ uncompleted items as possible.
 
 If you resume the job with the `--percent 10` option again:
 
-```bash
+```zsh
 plastron -c repo.yml import \
     --job-id percentile-job \
     --resume \

--- a/plastron-repo/src/plastron/jobs/importjob/__init__.py
+++ b/plastron-repo/src/plastron/jobs/importjob/__init__.py
@@ -462,8 +462,6 @@ class ImportRow:
         self.item = row.get_object(context.repo, read_from_repo=not validate_only)
         if publish is not None:
             self._publish = publish
-        else:
-            self._publish = row.publish
 
     def __str__(self):
         return str(self.row.line_reference)
@@ -558,12 +556,6 @@ class ImportRow:
         logger.debug(f'Member of: {self.job.member_of}')
         if self.job.member_of is not None:
             self.item.member_of = self.job.member_of
-        # set publication status
-        if self.row.publish:
-            self.item.rdf_type.add(umdaccess.Published)
-        # set visibility
-        if self.row.hidden:
-            self.item.rdf_type.add(umdaccess.Hidden)
 
         if self.job.extract_text_types is not None:
             annotate_from_files(self.item, self.job.extract_text_types)

--- a/plastron-repo/tests/jobs/test_import_job.py
+++ b/plastron-repo/tests/jobs/test_import_job.py
@@ -78,21 +78,12 @@ def test_import_job_create_resource(import_file, jobs):
     mock_repo.__getitem__.return_value = mock_container
     mock_context = MagicMock(spec=PlastronContext, repo=mock_repo)
 
-    expected_publication_statuses = [
-        'Unpublished',
-        'Published',
-        'UnpublishedHidden',
-        'PublishedHidden',
-        'Unpublished',
-        'Unpublished',
-        'Unpublished',
-        'UnpublishedHidden',
-        'Published',
-    ]
     import_job = jobs.create_job(ImportJob, config=ImportConfig(job_id='123', model='Item'))
     for i, stats in enumerate(import_job.run(context=mock_context, import_file=import_file.open())):
         assert mock_container.obj is not None
-        assert get_publication_status(mock_container.obj) == expected_publication_statuses[i]
+        # PUBLISH and HIDDEN columns should be ignored, all items
+        # should be unpublished
+        assert get_publication_status(mock_container.obj) == 'Unpublished'
 
 
 def test_import_job_create_resource_publish_all(import_file, jobs):
@@ -102,21 +93,11 @@ def test_import_job_create_resource_publish_all(import_file, jobs):
     mock_repo.__getitem__.return_value = mock_container
     mock_context = MagicMock(spec=PlastronContext, repo=mock_repo)
 
-    expected_publication_statuses = [
-        'Published',
-        'Published',
-        'PublishedHidden',
-        'PublishedHidden',
-        'Published',
-        'Published',
-        'Published',
-        'PublishedHidden',
-        'Published',
-    ]
     import_job = jobs.create_job(ImportJob, config=ImportConfig(job_id='123', model='Item'))
     for i, stats in enumerate(import_job.run(context=mock_context, publish=True, import_file=import_file.open())):
         assert mock_container.obj is not None
-        assert get_publication_status(mock_container.obj) == expected_publication_statuses[i]
+        # HIDDEN column should be ignored, all items should be published
+        assert get_publication_status(mock_container.obj) == 'Published'
 
 
 def test_config_read_none_string_as_none(jobs):


### PR DESCRIPTION
Removed code from the
“plastron-repo/src/plastron/jobs/importjob/__init__.py” file where the “publish” and “hidden” fields from individual CSV rows was used to publish/hide items. This included removing code from the “create_resource” method, which set the “umdaccess.Published” and “umdaccess.Hidden” RDF type for newly created items (which was problematic because it was setting the types without doing other “publish” activities such as minting a new handle).

Updated the unit tests, and the “plastron-cli/docs/import.md” file (which had become out-of-date with the current options provided by the “import” command).

Based on the changes in this issue, the “import” command only publishes via the “--publish” flag, which published all the items in the import. There is no way to “hide” (or make visible) an item via the “import” ommand – use the “publish” and “unpublish” commands instead (via the “--hide” and “--visible” flags).

Added an ADR document, as the decision to remove the per-row use of the “PUBLISH” and “HIDDEN” fields by the “import” command seemed to rise to that level (from a philosophical/”what were we thinking” perspective).

https://umd-dit.atlassian.net/browse/LIBFCREPO-1425