### PR TITLE
LIBFCREPO-1438. Modified Import "make-templates" to handle mapped hea…

### DIFF
--- a/plastron-cli/src/plastron/cli/commands/importcommand.py
+++ b/plastron-cli/src/plastron/cli/commands/importcommand.py
@@ -31,7 +31,26 @@ def write_model_template(model_name: str, template_file: TextIO):
 
     logger.info(f'Writing template for the {model_class.__name__} model to {template_file.name}')
     writer = csv.writer(template_file)
-    writer.writerow(list(model_class.HEADER_MAP.values()) + ['FILES', 'ITEM_FILES'])
+    writer.writerow(parse_model_header_map(model_class) + ['FILES', 'ITEM_FILES'])
+
+
+def parse_model_header_map(model_class):
+    """
+    Returns a list of fields to use as column headers for the CSV template file
+    derived from the HEADER_MAP of the given model class.
+    """
+    header_fields = []
+
+    for header in model_class.HEADER_MAP.values():
+        if isinstance(header, dict):
+            # Every value in a header map dictionary is assumed to be a field
+            # name that should be used by the CSV file.
+            for value in header.values():
+                header_fields.append(value)
+        else:
+            header_fields.append(header)
+
+    return header_fields
 
 
 def configure_cli(subparsers):


### PR DESCRIPTION
…ders

Modified the "--make-template" functionality of the "import" command to handle model HEADER_MAPs with dictionary values containing "label" and "same_as" keys, which are converted to individual CSV header fields.

This was done by introducing a "parse_model_header_map" to the "plastron-cli/src/plastron/cli/commands/importcommand.py" file, and checking to see if the header value is a simple string, or a dictionary, and taking appropriate action. The "write_model_template" was then updated to use the new method.

Added a unit test using the "Item" model to verify functionality.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1438