### PR TITLE
LIBFCREPO-1447. Always get vocabulary at validation function execution time.

### DIFF
--- a/plastron-models/pyproject.toml
+++ b/plastron-models/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "freezegun",
+    "httpretty",
     "pytest",
     "pytest-cov",
 ]

--- a/plastron-models/src/plastron/validation/rules.py
+++ b/plastron-models/src/plastron/validation/rules.py
@@ -30,10 +30,8 @@ def is_iso_8601_date(value: str) -> bool:
 
 
 def is_from_vocabulary(vocab_uri):
-    subjects = get_subjects(vocab_uri)
-
     def _value_from_vocab(value):
-        return value in subjects
+        return value in get_subjects(vocab_uri)
 
     _value_from_vocab.__doc__ = f'from vocabulary {vocab_uri}'
     return _value_from_vocab

--- a/plastron-models/src/plastron/validation/vocabularies/__init__.py
+++ b/plastron-models/src/plastron/validation/vocabularies/__init__.py
@@ -1,5 +1,4 @@
 import logging
-from functools import lru_cache
 from os.path import abspath, dirname
 from pathlib import Path
 from typing import Set
@@ -45,7 +44,6 @@ def get_vocabulary(vocab_uri: str) -> Graph:
     return graph
 
 
-@lru_cache()
 def get_subjects(vocab_uri: str) -> Set[Node]:
     subjects = set(get_vocabulary(vocab_uri).subjects())
     return subjects

--- a/plastron-models/tests/test_is_from_vocabulary.py
+++ b/plastron-models/tests/test_is_from_vocabulary.py
@@ -1,0 +1,64 @@
+from unittest.mock import MagicMock
+
+import httpretty
+import pytest
+from rdflib import Graph, URIRef, Literal
+
+import plastron.validation.vocabularies
+from plastron.namespaces import rdfs
+from plastron.validation.rules import is_from_vocabulary
+
+
+@pytest.fixture
+def empty_graph() -> Graph:
+    return Graph()
+
+
+@pytest.fixture
+def one_subject_graph() -> Graph:
+    graph = Graph()
+    graph.add((URIRef('http://example.com/vocab#term'), rdfs.label, Literal('Test Term')))
+    return graph
+
+
+def graph_response(graph: Graph, media_type: str = 'text/turtle') -> httpretty.Response:
+    return httpretty.Response(
+        graph.serialize(format=media_type),
+        adding_headers={'Content-Type': media_type},
+    )
+
+
+def test_is_from_vocabulary_doc_string():
+    is_valid = is_from_vocabulary('http://example.com/vocab#')
+    assert is_valid.__doc__ == 'from vocabulary http://example.com/vocab#'
+
+
+def test_is_from_vocabulary_with_updates_via_mock(monkeypatch, empty_graph, one_subject_graph):
+    mock_get_vocabulary = MagicMock()
+    mock_get_vocabulary.side_effect = [empty_graph, one_subject_graph]
+    monkeypatch.setattr(plastron.validation.vocabularies, 'get_vocabulary', mock_get_vocabulary)
+    is_valid = is_from_vocabulary('http://example.com/vocab#')
+    term = URIRef('http://example.com/vocab#term')
+    # this first call should fail, the second should succeed
+    # because get_vocabulary is called twice
+    assert not is_valid(term)
+    assert is_valid(term)
+    assert mock_get_vocabulary.call_count == 2
+
+
+@httpretty.activate
+def test_is_from_vocabulary_with_updates_via_http(empty_graph, one_subject_graph):
+    httpretty.register_uri(
+        method=httpretty.GET,
+        uri='http://example.com/vocab#',
+        responses=[
+            graph_response(empty_graph),
+            graph_response(one_subject_graph),
+        ],
+    )
+    is_valid = is_from_vocabulary('http://example.com/vocab#')
+    term = URIRef('http://example.com/vocab#term')
+    # this first call should fail, the second should succeed
+    # because two HTTP requests are made with different responses
+    assert not is_valid(term)
+    assert is_valid(term)


### PR DESCRIPTION
- removed "@lru_cache" from `get_subjects()`
- moved call to `get_subjects()` into the body of the validation function
- added httpretty to test dependencies from plastron-models

https://umd-dit.atlassian.net/browse/LIBFCREPO-1447