### PR TITLE
LIBFCREPO-1449. Prevent non-Literal values from being added to a DataProperty.

### DIFF
--- a/plastron-models/src/plastron/models/poster.py
+++ b/plastron-models/src/plastron/models/poster.py
@@ -27,7 +27,7 @@ class Poster(PCDMObject):
     location = DataProperty(dc.coverage)
     longitude = DataProperty(geo.long)
     latitude = DataProperty(geo.lat)
-    subject = ObjectProperty(dc.subject)
+    subject = DataProperty(dc.subject, repeatable=True)
     rights = ObjectProperty(dcterms.rights, required=True)
     terms_of_use = ObjectProperty(
         dcterms.license,

--- a/plastron-models/tests/test_poster_model.py
+++ b/plastron-models/tests/test_poster_model.py
@@ -1,4 +1,5 @@
-from rdflib import Literal
+import pytest as pytest
+from rdflib import Literal, URIRef
 
 from plastron.models.poster import Poster
 
@@ -24,3 +25,29 @@ def test_poster_valid_with_only_required_fields():
     poster.rights = 'http://rightsstatements.org/vocab/NoC-US/1.0/'
 
     assert poster.is_valid
+
+
+@pytest.mark.parametrize(
+    ('subject_value', 'expected_validity'),
+    [
+        ([], True),
+        ([Literal('single')], True),
+        ([Literal('one'), Literal('two')], True),
+    ]
+)
+def test_poster_subject_field_literals(subject_value, expected_validity):
+    poster = Poster(subject=subject_value)
+    assert bool(poster.subject.is_valid) == expected_validity
+
+
+@pytest.mark.parametrize(
+    'value',
+    [
+        ['foo'],
+        [12345],
+        [URIRef('http://example.com/foo')],
+    ]
+)
+def test_poster_subject_field_non_literal_fails(value):
+    with pytest.raises(TypeError):
+        Poster(subject=value)

--- a/plastron-rdf/src/plastron/rdfmapping/properties.py
+++ b/plastron-rdf/src/plastron/rdfmapping/properties.py
@@ -132,9 +132,14 @@ class RDFDataProperty(RDFProperty):
         self.datatype: URIRef = datatype
         """The datatype of this property"""
 
+    def add(self, value):
+        if not isinstance(value, Literal):
+            raise TypeError(f'Cannot add a non-Literal value {value} to data property {self.attr_name}')
+        super().add(value)
+
     @property
     def values(self) -> Iterator[Literal]:
-        return filter(lambda v: v.datatype == self.datatype, super().values)
+        return filter(lambda v: isinstance(v, Literal) and v.datatype == self.datatype, super().values)
 
     @property
     def languages(self) -> Iterator[str]:


### PR DESCRIPTION
- switched the `Poster.subject` attribute to a DataProperty
- added tests

https://umd-dit.atlassian.net/browse/LIBFCREPO-1449