### PR TITLE
LIBFCREPO-1451. Catch ConnectionError in plastron.client.Client.request()

### DIFF
--- a/plastron-client/src/plastron/client/__init__.py
+++ b/plastron-client/src/plastron/client/__init__.py
@@ -436,7 +436,12 @@ class Client:
         keyword arguments are passed to the underlying `session.request()`
         method."""
         logger.debug(f'{method} {url}')
-        response = self.session.request(method, url, **kwargs)
+        try:
+            response = self.session.request(method, url, **kwargs)
+        except ConnectionError as e:
+            message = ' '.join(str(arg) for arg in e.args)
+            logger.error(message)
+            raise RuntimeError(f'Connection error: {message}') from e
         logger.debug(f'{response.status_code} {response.reason}')
         return response
 


### PR DESCRIPTION
Re-raise as a RuntimeError

https://umd-dit.atlassian.net/browse/LIBFCREPO-1451