### PR TITLE
LIBFCREPO-1470. Ensure language tagged columns are exported.

### DIFF
--- a/plastron-models/tests/serializers/conftest.py
+++ b/plastron-models/tests/serializers/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+from rdflib import Literal
+
+from plastron.models import Item
+
+
+@pytest.fixture
+def header_map():
+    return {
+        'title': 'Title',
+        'subject': {
+            'label': 'Subject',
+            'same_as': 'Subject URI',
+        },
+    }
+
+
+@pytest.fixture
+def multilingual_item():
+    return Item(title=[Literal('The Trial'), Literal('Der Prozeß', lang='de')])

--- a/plastron-models/tests/serializers/test_csv.py
+++ b/plastron-models/tests/serializers/test_csv.py
@@ -38,3 +38,11 @@ def test_write(resource, expected_values):
     row = serializer.write(resource=resource)
     for key, expected_value in expected_values.items():
         assert row[key] == expected_value
+
+
+def test_serialize_multiple_languages(multilingual_item, header_map):
+    serializer = CSVSerializer()
+    row = serializer.write(multilingual_item)
+    expected_values = {'Title': 'The Trial', 'Title [de]': 'Der Prozeß'}
+    for key, value in expected_values.items():
+        assert row[key] == value


### PR DESCRIPTION
- rename CSVSerializer attribute "rows_by_content_model" to "sheets"
- created a Sheet class that encapsulates all the per-sheet metadata that the row_info dictionaries did
- created a ColumnDict class that encapsulates the return value from flatten()
- moved the write_csv_file() function into the Sheet class as a method
- after calling flatten(), add the language tagged columns to the "extra_columns" dictionary
- updated tests

https://umd-dit.atlassian.net/browse/LIBFCREPO-1470