### PR TITLE
LIBFCREPO-1512: Moving addition of SSH_PRIVATE_KEY

### DIFF
--- a/plastron-stomp/src/plastron/stomp/commands/importcommand.py
+++ b/plastron-stomp/src/plastron/stomp/commands/importcommand.py
@@ -1,7 +1,7 @@
 import io
 import logging
 from argparse import ArgumentTypeError
-from typing import Generator, Any, Dict, Optional
+from typing import Any, Dict, Generator, Optional
 
 from rdflib import URIRef
 
@@ -70,9 +70,10 @@ def importcommand(
         job = jobs.get_job(ImportJob, job_id=job_id)
         # update the config with any changes in this request
         job.update_config(job_config_args)
-        job.ssh_private_key = config.get('SSH_PRIVATE_KEY', None)
     else:
         job = jobs.create_job(ImportJob, config=ImportConfig(**job_config_args))
+
+    job.ssh_private_key = config.get('SSH_PRIVATE_KEY', None)
 
     return job.run(
         context=context,


### PR DESCRIPTION
Before, when import jobs would be created, the lack of the private key being set would result in "System Error during Validation" in Archelon for the job status.

Now they should succeed on the first try, without needing to resubmit

https://umd-dit.atlassian.net/browse/LIBFCREPO-1512