### PR TITLE
LIBFCREPO-1495. Updates to support solrizer content model mapping.

### DIFF
--- a/plastron-cli/src/plastron/cli/commands/importcommand.py
+++ b/plastron-cli/src/plastron/cli/commands/importcommand.py
@@ -6,7 +6,7 @@ from typing import TextIO
 from plastron.cli.commands import BaseCommand
 from plastron.jobs.importjob import ImportConfig, ImportJob
 from plastron.jobs import Jobs
-from plastron.models import get_model_class, ModelClassNotFoundError
+from plastron.models import get_model_from_name, ModelClassNotFoundError
 from plastron.utils import datetimestamp, uri_or_curie
 
 logger = logging.getLogger(__name__)
@@ -22,7 +22,7 @@ def percentile(n):
 
 def write_model_template(model_name: str, template_file: TextIO):
     try:
-        model_class = get_model_class(model_name)
+        model_class = get_model_from_name(model_name)
     except ModelClassNotFoundError as e:
         raise RuntimeError(f'Cannot find model class named {model_name}') from e
     if not hasattr(model_class, 'HEADER_MAP'):

--- a/plastron-cli/src/plastron/cli/commands/set.py
+++ b/plastron-cli/src/plastron/cli/commands/set.py
@@ -6,7 +6,7 @@ from typing import Iterable, Tuple, Dict, Type
 from rdflib import Literal
 
 from plastron.cli.commands import BaseCommand
-from plastron.models import get_model_class
+from plastron.models import get_model_from_name
 from plastron.utils import uri_or_curie
 from plastron.rdfmapping.descriptors import DataProperty, ObjectProperty
 from plastron.rdfmapping.resources import RDFResourceBase
@@ -64,7 +64,7 @@ def get_new_values(model_class: Type[RDFResourceBase], fields_to_set: Iterable[T
 
 
 def set_fields(ctx, model_name: str, fields_to_set: Iterable[Tuple[str, str]], uris: Iterable[str]):
-    model_class = get_model_class(model_name)
+    model_class = get_model_from_name(model_name)
     values = get_new_values(model_class, fields_to_set)
     for uri in uris:
         resource: RepositoryResource = ctx.obj.repo[uri].read()

--- a/plastron-cli/src/plastron/cli/commands/update.py
+++ b/plastron-cli/src/plastron/cli/commands/update.py
@@ -3,7 +3,7 @@ from argparse import FileType, Namespace
 
 from plastron.cli.commands import BaseCommand
 from plastron.jobs.updatejob import UpdateJob
-from plastron.models import get_model_class
+from plastron.models import get_model_from_name
 from plastron.utils import ItemLog, parse_predicate_list
 
 logger = logging.getLogger(__name__)
@@ -73,7 +73,7 @@ class Command(BaseCommand):
             raise RuntimeError("Model must be provided when performing validation")
 
         # Retrieve the model to use for validation
-        model_class = get_model_class(args.model) if args.model else None
+        model_class = get_model_from_name(args.model) if args.model else None
 
         sparql_update = args.update_file.read().encode('utf-8')
 

--- a/plastron-cli/tests/commands/test_set.py
+++ b/plastron-cli/tests/commands/test_set.py
@@ -5,7 +5,7 @@ import pytest
 from rdflib import URIRef, Literal
 
 from plastron.cli.commands.set import get_new_values, set_fields
-from plastron.models import Item
+from plastron.models.umd import Item
 from plastron.rdfmapping.resources import RDFResource
 from plastron.repo import RepositoryResource, Repository
 

--- a/plastron-cli/tests/test_embedded_objects.py
+++ b/plastron-cli/tests/test_embedded_objects.py
@@ -1,7 +1,7 @@
 import pytest
 
 from plastron.jobs.importjob.spreadsheet import MetadataSpreadsheet
-from plastron.models import Item
+from plastron.models.umd import Item
 from plastron.repo import Repository
 
 

--- a/plastron-models/pyproject.toml
+++ b/plastron-models/pyproject.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 requires-python = ">= 3.8"
 dependencies = [
     "edtf_validate",
+    "importlib_metadata",
     "iso639",
     "lxml",
     "requests",

--- a/plastron-models/pyproject.toml
+++ b/plastron-models/pyproject.toml
@@ -35,6 +35,12 @@ test = [
     "pytest-cov",
 ]
 
+[project.entry-points.'plastron.content_models']
+Item = "plastron.models.umd:Item"
+Issue = "plastron.models.newspaper:Issue"
+Letter = "plastron.models.letter:Letter"
+Poster = "plastron.models.poster:Poster"
+
 [build-system]
 requires = ["setuptools>=66.1.0"]
 build-backend = "setuptools.build_meta"

--- a/plastron-models/src/plastron/models/__init__.py
+++ b/plastron-models/src/plastron/models/__init__.py
@@ -1,4 +1,4 @@
-from importlib.metadata import entry_points
+from importlib_metadata import entry_points
 from typing import Type
 
 from rdflib import URIRef

--- a/plastron-models/src/plastron/models/umd.py
+++ b/plastron-models/src/plastron/models/umd.py
@@ -23,7 +23,7 @@ class AdminSet(RDFResource):
 
 @rdf_type(umd.Item)
 class Item(PCDMObject, HandleBearingResource):
-    member_of = ObjectProperty(pcdm.memberOf, cls=AdminSet)
+    member_of = ObjectProperty(pcdm.memberOf)
     object_type = ObjectProperty(
         dcterms.type,
         required=True,

--- a/plastron-models/src/plastron/serializers/__init__.py
+++ b/plastron-models/src/plastron/serializers/__init__.py
@@ -3,7 +3,9 @@ import logging
 
 from rdflib import URIRef
 
-from plastron.models import Issue, Letter, Poster
+from plastron.models.letter import Letter
+from plastron.models.newspaper import Issue
+from plastron.models.poster import Poster
 from plastron.namespaces import bibo, rdf
 from plastron.serializers.csv import CSVSerializer
 from plastron.serializers.turtle import TurtleSerializer

--- a/plastron-models/tests/serializers/conftest.py
+++ b/plastron-models/tests/serializers/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 from rdflib import Literal
 
-from plastron.models import Item
+from plastron.models.umd import Item
 
 
 @pytest.fixture

--- a/plastron-repo/src/plastron/jobs/exportjob.py
+++ b/plastron-repo/src/plastron/jobs/exportjob.py
@@ -21,7 +21,7 @@ from plastron.client import ClientError
 from plastron.context import PlastronContext
 from plastron.files import get_ssh_client
 from plastron.jobs import Job
-from plastron.models import Item
+from plastron.models.umd import Item
 from plastron.models.pcdm import PCDMFile
 from plastron.repo import DataReadError, BinaryResource
 from plastron.repo.pcdm import PCDMObjectResource, AggregationResource, PCDMFileBearingResource

--- a/plastron-repo/src/plastron/jobs/importjob/__init__.py
+++ b/plastron-repo/src/plastron/jobs/importjob/__init__.py
@@ -18,7 +18,7 @@ from plastron.files import BinarySource, ZipFileSource, RemoteFileSource, HTTPFi
 from plastron.handles import HandleInfo
 from plastron.jobs import JobError, JobConfig, Job
 from plastron.jobs.importjob.spreadsheet import LineReference, MetadataSpreadsheet, InvalidRow, Row, MetadataError
-from plastron.models import get_model_class, ModelClassNotFoundError
+from plastron.models import get_model_from_name, ModelClassNotFoundError
 from plastron.models.annotations import FullTextAnnotation, TextualBody
 from plastron.namespaces import umdaccess, sc
 from plastron.rdf.pcdm import File, PreservationMasterFile
@@ -320,7 +320,7 @@ class ImportJob(Job):
     @property
     def model_class(self):
         if self._model_class is None:
-            self._model_class = get_model_class(self.config.model)
+            self._model_class = get_model_from_name(self.config.model)
         return self._model_class
 
     def store_metadata_file(self, input_file: IO):

--- a/plastron-repo/tests/jobs/test_import_job_utils.py
+++ b/plastron-repo/tests/jobs/test_import_job_utils.py
@@ -5,7 +5,7 @@ from plastron.files import LocalFileSource, RemoteFileSource, ZipFileSource
 from plastron.jobs.importjob import ImportJob
 from plastron.jobs.importjob.spreadsheet import ColumnSpec, build_fields, build_file_groups, parse_value_string, \
     MetadataError
-from plastron.models import Item
+from plastron.models.umd import Item
 from plastron.namespaces import umdtype
 from plastron.rdfmapping.descriptors import DataProperty
 

--- a/plastron-repo/tests/jobs/test_metadata_spreadsheet.py
+++ b/plastron-repo/tests/jobs/test_metadata_spreadsheet.py
@@ -5,7 +5,7 @@ from plastron.jobs.importjob.spreadsheet import InvalidRow
 from rdflib import Literal
 
 from plastron.jobs.importjob import MetadataSpreadsheet
-from plastron.models import Item
+from plastron.models.umd import Item
 from plastron.namespaces import umdtype
 from plastron.repo import Repository
 

--- a/plastron-stomp/src/plastron/stomp/commands/update.py
+++ b/plastron-stomp/src/plastron/stomp/commands/update.py
@@ -5,7 +5,7 @@ from typing import Generator, Any, Dict
 from plastron.context import PlastronContext
 from plastron.jobs.updatejob import UpdateJob
 from plastron.messaging.messages import PlastronCommandMessage
-from plastron.models import get_model_class
+from plastron.models import get_model_from_name
 from plastron.utils import strtobool, parse_predicate_list
 
 logger = logging.getLogger(__name__)
@@ -24,7 +24,7 @@ def parse_message(message: PlastronCommandMessage) -> Dict[str, Any]:
         raise RuntimeError("Model must be provided when performing validation")
 
     # Retrieve the model to use for validation
-    model_class = get_model_class(model) if model else None
+    model_class = get_model_from_name(model) if model else None
 
     traverse = parse_predicate_list(recursive) if recursive is not None else []
     return {

--- a/plastron-stomp/tests/commands/test_update_stomp.py
+++ b/plastron-stomp/tests/commands/test_update_stomp.py
@@ -5,7 +5,8 @@ from pytest import raises
 
 from plastron.client import Client, Endpoint
 from plastron.messaging.messages import PlastronCommandMessage
-from plastron.models import Letter, Item
+from plastron.models.letter import Letter
+from plastron.models.umd import Item
 from plastron.repo import Repository
 from plastron.stomp.commands.update import parse_message
 


### PR DESCRIPTION
* Changed model autoloading to use entry points:
  - group "plastron.content_models" in pyproject.toml project.entry-points
  - format: name = package:class
  - renamed `get_model_class()` to `get_model_from_name()`
  - added `get_model_from_uri()`
  - added `guess_model()`

* Remove the object class from the `member_of` property, since that was causing a circular inclusion loop in solrizer when following the linked objects
  - General principle: embed/include from the top down, not bottom up or mixed

https://umd-dit.atlassian.net/browse/LIBFCREPO-1495