### PR TITLE
LIBFCREPO-1582. Include the CLI command name in the User-Agent string

### DIFF
--- a/plastron-cli/src/plastron/cli/__init__.py
+++ b/plastron-cli/src/plastron/cli/__init__.py
@@ -156,6 +156,9 @@ def main():
         if not hasattr(command_module, 'Command'):
             raise RuntimeError(f'Unable to execute command {args.cmd_name}')
 
+        plastron_context.client.ua_string = f'plastron/{plastron_context.version} ({args.cmd_name})'
+        logger.debug(f'Client User-Agent set to "{plastron_context.client.ua_string}"')
+
         command = command_module.Command(context=plastron_context)
 
         print_header(args)

--- a/plastron-cli/src/plastron/cli/commands/importcommand.py
+++ b/plastron-cli/src/plastron/cli/commands/importcommand.py
@@ -194,8 +194,8 @@ class Command(BaseCommand):
             if args.job_id is None:
                 # TODO: generate a more unique id? add in user and hostname?
                 args.job_id = f"import-{datetimestamp()}"
+                logger.info(f'Creating new job {args.job_id}')
 
-            logger.info(f'Creating new job {args.job_id}')
             job = jobs.create_job(
                 job_class=ImportJob,
                 config=ImportConfig(

--- a/plastron-repo/src/plastron/context/__init__.py
+++ b/plastron-repo/src/plastron/context/__init__.py
@@ -65,7 +65,7 @@ class PlastronContext:
                 self._client = Client(
                     endpoint=self.endpoint,
                     auth=get_authenticator(repo_config),
-                    ua_string=f'plastron/{version}',
+                    ua_string=f'plastron/{self.version}',
                     on_behalf_of=self.args.delegated_user,
                     structure=RepositoryStructure[repo_config.get('STRUCTURE', 'flat').upper()]
                 )


### PR DESCRIPTION
- example: "plastron/4.4.0 (import)"
- fix position of logging message in the import command class

https://umd-dit.atlassian.net/browse/LIBFCREPO-1582