### PR TITLE
LIBFCREPO_1583. Added ContentModeledResource class.

### DIFF
--- a/plastron-models/pyproject.toml
+++ b/plastron-models/pyproject.toml
@@ -37,9 +37,11 @@ test = [
 ]
 
 [project.entry-points.'plastron.content_models']
-Item = "plastron.models.umd:Item"
+File = "plastron.models.page:File"
 Issue = "plastron.models.newspaper:Issue"
+Item = "plastron.models.umd:Item"
 Letter = "plastron.models.letter:Letter"
+Page = "plastron.models.page:Page"
 Poster = "plastron.models.poster:Poster"
 
 [build-system]

--- a/plastron-models/src/plastron/models/__init__.py
+++ b/plastron-models/src/plastron/models/__init__.py
@@ -1,6 +1,6 @@
-from importlib_metadata import entry_points
-from typing import Type
+from typing import Type, Dict
 
+from importlib_metadata import entry_points
 from rdflib import URIRef
 
 from plastron.rdfmapping.resources import RDFResourceBase, RDFResource
@@ -19,14 +19,20 @@ class ModelClassNotFoundError(ModelClassError):
         self.model_name = model_name
 
 
-def get_model_from_name(model_name: str) -> Type[RDFResourceBase]:
+class ContentModeledResource(RDFResourceBase):
+    model_name: str
+    is_top_level: bool = False
+    HEADER_MAP: Dict = None
+
+
+def get_model_from_name(model_name: str) -> Type[ContentModeledResource]:
     try:
         return CONTENT_MODEL_CLASSES[model_name].load()
     except KeyError as e:
         raise ModelClassNotFoundError(model_name) from e
 
 
-def get_model_from_uri(rdf_type: URIRef) -> Type[RDFResourceBase]:
+def get_model_from_uri(rdf_type: URIRef) -> Type[ContentModeledResource]:
     for plugin in CONTENT_MODEL_CLASSES:
         cls = plugin.load()
         if rdf_type in cls.default_values.get('rdf_type', set()):
@@ -34,7 +40,7 @@ def get_model_from_uri(rdf_type: URIRef) -> Type[RDFResourceBase]:
     raise ModelClassNotFoundError(str(rdf_type))
 
 
-def guess_model(resource: RDFResource) -> Type[RDFResourceBase]:
+def guess_model(resource: RDFResource) -> Type[ContentModeledResource]:
     for plugin in CONTENT_MODEL_CLASSES:
         cls = plugin.load()
         if cls.default_values.get('rdf_type', set()) <= set(resource.rdf_type.values):

--- a/plastron-models/src/plastron/models/letter.py
+++ b/plastron-models/src/plastron/models/letter.py
@@ -1,10 +1,12 @@
 from rdflib import URIRef
 
 from plastron.handles import HandleBearingResource
+from plastron.models import ContentModeledResource
 from plastron.models.authorities import UMD_TERMS_OF_USE_STATEMENTS, UMD_PRESENTATION_SETS
 from plastron.models.fedora import FedoraResource
 from plastron.models.pcdm import PCDMObject
-from plastron.namespaces import bibo, dc, dcmitype, dcterms, edm, geo, rel, skos, ore, owl, umd, schema
+from plastron.models.page import Page
+from plastron.namespaces import bibo, dc, dcmitype, dcterms, edm, geo, rel, skos, ore, owl, umd, schema, pcdm
 from plastron.rdfmapping.decorators import rdf_type
 from plastron.rdfmapping.descriptors import ObjectProperty, DataProperty
 from plastron.rdfmapping.resources import RDFResource
@@ -38,7 +40,12 @@ class Collection(AuthorityRecord):
 
 
 @rdf_type(bibo.Letter, umd.Letter)
-class Letter(PCDMObject, HandleBearingResource, FedoraResource):
+class Letter(ContentModeledResource, PCDMObject, HandleBearingResource, FedoraResource):
+    model_name = 'Letter'
+    is_top_level = True
+
+    member_of = ObjectProperty(pcdm.memberOf)
+    has_member = ObjectProperty(pcdm.hasMember, repeatable=True, cls=Page)
     title = DataProperty(dcterms.title, required=True)
     author = ObjectProperty(rel.aut, repeatable=True, embed=True, cls=Agent)
     recipient = ObjectProperty(bibo.recipient, repeatable=True, embed=True, cls=Agent)

--- a/plastron-models/src/plastron/models/newspaper.py
+++ b/plastron-models/src/plastron/models/newspaper.py
@@ -1,27 +1,31 @@
 from lxml.etree import parse, XMLSyntaxError
 
 from plastron.handles import HandleBearingResource
+from plastron.models import ContentModeledResource
 from plastron.models.annotations import TextblockOnPage
 from plastron.models.authorities import UMD_TERMS_OF_USE_STATEMENTS, UMD_PRESENTATION_SETS
 from plastron.models.fedora import FedoraResource
 from plastron.models.pcdm import PCDMObject, PCDMFile
-from plastron.namespaces import bibo, carriers, dc, dcterms, fabio, ndnp, ore, pcdm, pcdmuse, schema, umdtype, umd
+from plastron.namespaces import bibo, carriers, dc, dcterms, fabio, ndnp, ore, pcdm, pcdmuse, schema, umd
 from plastron.rdf.ocr import ALTOResource
 from plastron.rdfmapping.decorators import rdf_type
 from plastron.rdfmapping.descriptors import DataProperty, ObjectProperty
-from plastron.validation.rules import is_handle, is_iso_8601_date
+from plastron.validation.rules import is_iso_8601_date
 from plastron.validation.vocabularies import ControlledVocabularyProperty
 
 
 @rdf_type(bibo.Issue, umd.Newspaper)
-class Issue(PCDMObject, HandleBearingResource, FedoraResource):
+class Issue(ContentModeledResource, PCDMObject, HandleBearingResource, FedoraResource):
     """Newspaper issue"""
+    model_name = 'Issue'
+    is_top_level = True
+
+    member_of = ObjectProperty(pcdm.memberOf)
     title = DataProperty(dcterms.title, required=True)
     date = DataProperty(dc.date, required=True, validate=is_iso_8601_date)
     volume = DataProperty(bibo.volume, required=True)
     issue = DataProperty(bibo.issue, required=True)
     edition = DataProperty(bibo.edition, required=True)
-    handle = DataProperty(dcterms.identifier, datatype=umdtype.handle, validate=is_handle)
     presentation_set = ControlledVocabularyProperty(ore.isAggregatedBy, repeatable=True, vocab=UMD_PRESENTATION_SETS)
     copyright_notice = DataProperty(schema.copyrightNotice)
     terms_of_use = ControlledVocabularyProperty(dcterms.license, vocab=UMD_TERMS_OF_USE_STATEMENTS)

--- a/plastron-models/src/plastron/models/page.py
+++ b/plastron-models/src/plastron/models/page.py
@@ -1,0 +1,26 @@
+from plastron.models import ContentModeledResource
+from plastron.models.pcdm import PCDMObject, PCDMFile
+from plastron.namespaces import fabio, pcdm, dcterms
+from plastron.rdfmapping.decorators import rdf_type
+from plastron.rdfmapping.descriptors import ObjectProperty, DataProperty
+
+
+class File(ContentModeledResource, PCDMFile):
+    model_name = 'File'
+    is_top_level = False
+
+    file_of = ObjectProperty(pcdm.fileOf)
+
+
+@rdf_type(fabio.Page)
+class Page(ContentModeledResource, PCDMObject):
+    model_name = 'Page'
+    is_top_level = False
+
+    member_of = ObjectProperty(pcdm.memberOf)
+    has_file = ObjectProperty(pcdm.hasFile, repeatable=True, cls=File)
+    title = DataProperty(dcterms.title)
+    number = DataProperty(fabio.hasSequenceIdentifier)
+
+    def __str__(self):
+        return str(self.title or self.uri)

--- a/plastron-models/src/plastron/models/pcdm.py
+++ b/plastron-models/src/plastron/models/pcdm.py
@@ -20,6 +20,7 @@ class PCDMFile(RDFResource):
     mime_type = DataProperty(ebucore.hasMimeType)
     filename = DataProperty(ebucore.filename)
     size = DataProperty(premis.hasSize, datatype=xsd.long)
+    checksum = ObjectProperty(premis.hasMessageDigest)
 
     def __str__(self):
         return str(self.title or self.uri)

--- a/plastron-models/src/plastron/models/poster.py
+++ b/plastron-models/src/plastron/models/poster.py
@@ -1,10 +1,12 @@
 from rdflib import URIRef
 
 from plastron.handles import HandleBearingResource
+from plastron.models import ContentModeledResource
 from plastron.models.authorities import UMD_PRESENTATION_SETS, UMD_TERMS_OF_USE_STATEMENTS
 from plastron.models.fedora import FedoraResource
 from plastron.models.pcdm import PCDMObject
-from plastron.namespaces import bibo, dcterms, dc, edm, geo, ore, schema, umd, xsd
+from plastron.models.page import Page
+from plastron.namespaces import bibo, dcterms, dc, edm, geo, ore, schema, umd, xsd, pcdm
 from plastron.rdfmapping.decorators import rdf_type
 from plastron.rdfmapping.descriptors import ObjectProperty, DataProperty, Property
 from plastron.validation.rules import is_edtf_formatted
@@ -12,7 +14,12 @@ from plastron.validation.vocabularies import ControlledVocabularyProperty
 
 
 @rdf_type(bibo.Image, umd.Poster)
-class Poster(PCDMObject, HandleBearingResource, FedoraResource):
+class Poster(ContentModeledResource, PCDMObject, HandleBearingResource, FedoraResource):
+    model_name = 'Poster'
+    is_top_level = True
+
+    member_of = ObjectProperty(pcdm.memberOf)
+    has_member = ObjectProperty(pcdm.hasMember, repeatable=True, cls=Page)
     title = DataProperty(dcterms.title, required=True)
     alternative = DataProperty(dcterms.alternative)
     publisher = DataProperty(dc.publisher)

--- a/plastron-models/src/plastron/models/umd.py
+++ b/plastron-models/src/plastron/models/umd.py
@@ -1,9 +1,11 @@
 from plastron.handles import HandleBearingResource
+from plastron.models import ContentModeledResource
 from plastron.models.authorities import Agent, Subject, Place, DCMI_TYPES, UMD_RIGHTS_STATEMENTS, UMD_FORMATS, \
     UMD_ARCHIVAL_COLLECTIONS, UMD_PRESENTATION_SETS, UMD_TERMS_OF_USE_STATEMENTS
 from plastron.models.fedora import FedoraResource
+from plastron.models.page import Page
 from plastron.models.pcdm import PCDMObject
-from plastron.namespaces import dc, dcterms, edm, fabio, pcdm, ore, schema, umdtype, umd
+from plastron.namespaces import dc, dcterms, edm, pcdm, ore, schema, umdtype, umd
 from plastron.rdfmapping.decorators import rdf_type
 from plastron.rdfmapping.descriptors import ObjectProperty, DataProperty
 from plastron.rdfmapping.resources import RDFResource
@@ -24,8 +26,12 @@ class AdminSet(RDFResource):
 
 
 @rdf_type(umd.Item)
-class Item(PCDMObject, HandleBearingResource, FedoraResource):
+class Item(ContentModeledResource, PCDMObject, HandleBearingResource, FedoraResource):
+    model_name = 'Item'
+    is_top_level = True
+
     member_of = ObjectProperty(pcdm.memberOf)
+    has_member = ObjectProperty(pcdm.hasMember, repeatable=True, cls=Page)
     object_type = ControlledVocabularyProperty(dcterms.type, required=True, vocab=DCMI_TYPES)
     identifier = DataProperty(dcterms.identifier, required=True, repeatable=True)
     rights = ControlledVocabularyProperty(dcterms.rights, required=True, vocab=UMD_RIGHTS_STATEMENTS)
@@ -92,12 +98,3 @@ class Item(PCDMObject, HandleBearingResource, FedoraResource):
 
     def __str__(self):
         return str(self.title)
-
-
-@rdf_type(fabio.Page)
-class Page(PCDMObject):
-    title = DataProperty(dcterms.title)
-    number = DataProperty(fabio.hasSequenceIdentifier)
-
-    def __str__(self):
-        return str(self.title or self.uri)


### PR DESCRIPTION
- moved the Page model class into a separate module (plastron.models.pages)
- create a File model class in the plastron.models.pages module
- add ContentModeledResource as a mix-in to Letter, Poster, Issue, Item, Page, and File
- added Page and File content models to the entrypoint definitions for "plastron.content_models"
- added "checksum" property (mapped to premis:hasMessageDigest) to the PCDMFile class

https://umd-dit.atlassian.net/browse/LIBFCREPO-1583