### PR TITLE
LIBFCREPO-1609. Added "rights holder" property to newspaper issue model.

### DIFF
--- a/plastron-models/src/plastron/models/newspaper.py
+++ b/plastron-models/src/plastron/models/newspaper.py
@@ -3,7 +3,7 @@ from lxml.etree import parse, XMLSyntaxError
 from plastron.handles import HandleBearingResource
 from plastron.models import ContentModeledResource
 from plastron.models.annotations import TextblockOnPage
-from plastron.models.authorities import UMD_TERMS_OF_USE_STATEMENTS, UMD_PRESENTATION_SETS, UMD_RIGHTS_STATEMENTS
+from plastron.models.authorities import UMD_TERMS_OF_USE_STATEMENTS, UMD_PRESENTATION_SETS, UMD_RIGHTS_STATEMENTS, Agent
 from plastron.models.fedora import FedoraResource
 from plastron.models.pcdm import PCDMObject, PCDMFile
 from plastron.namespaces import bibo, carriers, dc, dcterms, fabio, ndnp, ore, pcdm, pcdmuse, schema, umd
@@ -30,6 +30,7 @@ class Issue(ContentModeledResource, PCDMObject, HandleBearingResource, FedoraRes
     copyright_notice = DataProperty(schema.copyrightNotice)
     terms_of_use = ControlledVocabularyProperty(dcterms.license, vocab=UMD_TERMS_OF_USE_STATEMENTS)
     rights = ControlledVocabularyProperty(dcterms.rights, required=True, vocab=UMD_RIGHTS_STATEMENTS)
+    rights_holder = ObjectProperty(dcterms.rightsHolder, repeatable=True, embed=True, cls=Agent)
 
     HEADER_MAP = {
         'title': 'Title',


### PR DESCRIPTION
Repeatable, not required, embedded Agent object.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1609