### PR TITLE
LIBFCREPO-1619: Add has_file to Item Class

### DIFF
--- a/plastron-models/src/plastron/models/umd.py
+++ b/plastron-models/src/plastron/models/umd.py
@@ -3,7 +3,7 @@ from plastron.models import ContentModeledResource
 from plastron.models.authorities import Agent, Subject, Place, DCMI_TYPES, UMD_RIGHTS_STATEMENTS, UMD_FORMATS, \
     UMD_ARCHIVAL_COLLECTIONS, UMD_PRESENTATION_SETS, UMD_TERMS_OF_USE_STATEMENTS
 from plastron.models.fedora import FedoraResource
-from plastron.models.page import Page
+from plastron.models.page import File, Page
 from plastron.models.pcdm import PCDMObject
 from plastron.namespaces import dc, dcterms, edm, pcdm, ore, schema, umdtype, umd
 from plastron.rdfmapping.decorators import rdf_type
@@ -34,6 +34,7 @@ class Item(ContentModeledResource, PCDMObject, HandleBearingResource, FedoraReso
     is_top_level = True
 
     member_of = ObjectProperty(pcdm.memberOf)
+    has_file = ObjectProperty(pcdm.hasFile, repeatable=True, cls=File)
     has_member = ObjectProperty(pcdm.hasMember, repeatable=True, cls=Page)
     object_type = ControlledVocabularyProperty(dcterms.type, required=True, vocab=DCMI_TYPES)
     identifier = DataProperty(dcterms.identifier, required=True, repeatable=True)


### PR DESCRIPTION
Fixes an issue where all the keys within it had pcdm prefixed to them

https://umd-dit.atlassian.net/browse/LIBFCREPO-1619