### PR TITLE
LIBFCREPO-1625. Include file usage information in CSV import.

### DIFF
--- a/plastron-jobs/docs/import.md
+++ b/plastron-jobs/docs/import.md
@@ -185,3 +185,29 @@ titles on the member objects.
 * If no relpaths have labels, the default behavior of assigning the labels 
   "Page 1" through "Page N" based on the document order of the relpaths 
   will be used
+
+Each relpath may have a usage tag prepended to it.
+
+* The usage tag is enclosed in angle brackets (e.g., `<ocr>`)
+* The usage tag follows the optional page label but precedes the filename 
+  (e.g., `Page 1:<ocr>0001.xml`)
+* Not all files need a usage tag (e.g., `0002.jpg;<ocr>0002.hocr`)
+* Multiple files may have the same usage tag (e.g.,
+  `<ocr>0004.xml;<ocr>0004.hocr`)
+* Usage tags are matched case insensitively. Unrecognized usage tags are 
+  ignored (e.g., `<OCR>0005.html;<ignore ME>0005.txt`)
+* Usage tags map to a set of RDF types that are added to the file's 
+  metadata during import
+
+Recognized usage tags and their mapping are:
+
+| Tag            | RDF Type                         |
+|----------------|----------------------------------|
+| `preservation` | [pcdmuse:PreservationMasterFile] |
+| `ocr`          | [pcdmuse:ExtractedText]          |
+| `metadata`     | [fabio:MetadataFile]             |
+
+
+[pcdmuse:PreservationMasterFile]: https://pcdm.org/use#PreservationMasterFile
+[pcdmuse:ExtractedText]: https://pcdm.org/use#ExtractedText
+[fabio:MetadataFile]: http://purl.org/spar/fabio/MetadataFile

--- a/plastron-jobs/src/plastron/jobs/importjob/__init__.py
+++ b/plastron-jobs/src/plastron/jobs/importjob/__init__.py
@@ -486,7 +486,7 @@ class ImportRow:
             raise RuntimeError('Must specify --binaries-location if the metadata has a FILES and/or ITEM_FILES column')
 
         results['FILES'] = self.validate_files(self.row.filenames)
-        results['ITEM_FILES'] = self.validate_files(self.row.item_filenames)
+        results['ITEM_FILES'] = self.validate_files(f.name for f in self.row.item_files)
 
         return results
 
@@ -582,9 +582,9 @@ class ImportRow:
 
                 # item-level files
                 if self.row.has_item_files:
-                    for filename in self.row.item_filenames:
-                        source = self.job.get_source(self.job.config.binaries_location, filename)
-                        resource.create_file(source=source)
+                    for file in self.row.item_files:
+                        source = self.job.get_source(self.job.config.binaries_location, file.name)
+                        resource.create_file(source=source, rdf_types=file.rdf_types)
 
                 # publish this resource, if requested
                 if self._publish:

--- a/plastron-jobs/tests/jobs/test_import_job_utils.py
+++ b/plastron-jobs/tests/jobs/test_import_job_utils.py
@@ -53,6 +53,28 @@ def test_build_file_groups_labeled(value, expected_count, expected_labels):
         assert groups[rootname].label == label
 
 
+@pytest.mark.parametrize(
+    ('value', 'expected_count', 'expected_usages'),
+    [
+        ('foo.tif;foo.xml', 1, {'foo': {'foo.tif': None, 'foo.xml': None}}),
+        ('<Preservation>foo.tif;<OCR>foo.xml', 1, {'foo': {'foo.tif': 'Preservation', 'foo.xml': 'OCR'}}),
+        (
+            '<Preservation>foo.tif;<OCR>foo.xml;bar.jpg;bar.xml',
+            2,
+            {'foo': {'foo.tif': 'Preservation', 'foo.xml': 'OCR'}, 'bar': {'bar.jpg': None, 'bar.xml': None}},
+        ),
+        ('Page 1:<Preservation>foo.tif;<OCR>foo.xml', 1, {'foo': {'foo.tif': 'Preservation', 'foo.xml': 'OCR'}}),
+        ('<ocr>0004.xml;<ocr>0004.hocr', 1, {'0004': {'0004.xml': 'ocr', '0004.hocr': 'ocr'}}),
+    ]
+)
+def test_build_file_groups_with_usage(value, expected_count, expected_usages):
+    groups = build_file_groups(value)
+    assert len(groups) == expected_count
+    for rootname, usage_map in expected_usages.items():
+        for name, usage in usage_map.items():
+            assert groups[rootname].file(name).usage == usage
+
+
 def test_build_fields_with_default_datatype():
     fields = build_fields(['Accession Number'], Item)
     assert fields['accession_number'][0].datatype == umdtype.accessionNumber

--- a/plastron-repo/src/plastron/files/__init__.py
+++ b/plastron-repo/src/plastron/files/__init__.py
@@ -1,12 +1,13 @@
 import hashlib
 import io
+import re
 import urllib
 import zipfile
 from dataclasses import dataclass, field
 from http import HTTPStatus
 from mimetypes import guess_type
 from os.path import basename, isfile
-from typing import Mapping, Any, Protocol, Union, Set, List
+from typing import Mapping, Any, Protocol, Union, Set, List, Tuple, Optional, ClassVar, Dict
 from urllib.parse import urlsplit
 
 from paramiko import SFTPClient, SSHClient, AutoAddPolicy, SSHException
@@ -14,7 +15,7 @@ from paramiko.config import SSH_PORT
 from rdflib import URIRef
 from requests import Response, Session
 
-from plastron.namespaces import pcdmuse
+from plastron.namespaces import pcdmuse, fabio
 
 
 def get_ssh_client(sftp_uri: Union[str, urllib.parse.SplitResult], **kwargs) -> SSHClient:
@@ -403,10 +404,27 @@ class ZipFileSource(BinarySource):
 @dataclass
 class FileSpec:
     name: str
+    usage: str = None
     source: BinarySource = None
+
+    USAGE_TAGS: ClassVar[Dict[str, Set[URIRef]]] = {
+        'preservation': {pcdmuse.PreservationMasterFile},
+        'ocr': {pcdmuse.ExtractedText},
+        'metadata': {fabio.MetadataFile},
+    }
+
+    @classmethod
+    def parse(cls, data: str):
+        name, usage = parse_usage_tag(data)
+        return cls(name=name, usage=usage)
 
     def __str__(self):
         return self.name
+
+    @property
+    def rdf_types(self) -> Optional[Set[URIRef]]:
+        if self.usage is not None:
+            return self.USAGE_TAGS.get(self.usage.lower(), None)
 
 
 @dataclass
@@ -422,3 +440,16 @@ class FileGroup:
     @property
     def filenames(self) -> List[str]:
         return [file.name for file in self.files]
+
+    def file(self, name: str) -> FileSpec:
+        for file in self.files:
+            if file.name == name:
+                return file
+        raise RuntimeError(f'{name} is not in file group {self}')
+
+
+def parse_usage_tag(filename: str) -> Tuple[str, Optional[str]]:
+    if m := re.search(r'^<([^>]+)>(.*)', filename):
+        return m[2], m[1]
+    else:
+        return filename, None

--- a/plastron-repo/src/plastron/repo/pcdm.py
+++ b/plastron-repo/src/plastron/repo/pcdm.py
@@ -12,6 +12,7 @@ from plastron.models.ldp import LDPContainer
 from plastron.models.ore import Proxy
 from plastron.models.pcdm import PCDMObject, PCDMFile
 from plastron.models.umd import Page
+from plastron.namespaces import pcdmuse, fabio
 from plastron.rdfmapping.resources import RDFResourceBase
 from plastron.repo import ContainerResource, Repository, BinaryResource, RepositoryResource
 
@@ -71,6 +72,7 @@ class PCDMFileBearingResource(ContainerResource):
             self,
             source: BinarySource,
             slug: Optional[str] = None,
+            rdf_types: Optional[Set] = None,
     ) -> BinaryResource:
         """Create a single file from the given source as a `pcdm:fileOf` this resource.
         If no slug is provided, one is generated using `random_slug()`."""
@@ -104,6 +106,8 @@ class PCDMFileBearingResource(ContainerResource):
         file.file_of.add(parent)
         parent.has_file.add(file)
         file.rdf_type.extend(source.rdf_types)
+        if rdf_types is not None:
+            file.rdf_type.extend(rdf_types)
 
         file_resource.update()
         self.update()
@@ -233,7 +237,7 @@ class PCDMObjectResource(PCDMFileBearingResource, AggregationResource):
         )
         parent.has_member.add(URIRef(page_resource.url))
         for file_spec in file_group.files:
-            page_resource.create_file(source=file_spec.source)
+            page_resource.create_file(source=file_spec.source, rdf_types=file_spec.rdf_types)
         self.update()
         self.member_urls.add(page_resource.url)
         logger.debug(f'Created page {number}: {page_resource.url} "{file_group.label}"')


### PR DESCRIPTION
- page-level and item-level files can have an option "usage tag" in angle brackets
- a usage tag maps to a set of RDF types that are added to that file resource
  * "preservation" -> pcdmuse:PreservationMasterFile
  * "ocr" -> pcdmuse:ExtractedText
  * "metadata" -> fabio:MetadataFile

https://umd-dit.atlassian.net/browse/LIBFCREPO-1625