### PR TITLE
LIBFCREPO-1622. Added "audience" to the Item content model.

### DIFF
--- a/plastron-cli/tests/commands/test_importcommand.py
+++ b/plastron-cli/tests/commands/test_importcommand.py
@@ -116,9 +116,10 @@ def test_container_is_required_unless_resuming(datadir, plastron_context):
                 'Format', 'Archival Collection', 'Presentation Set', 'Date',
                 'Description', 'Alternate Title', 'Creator', 'Creator URI',
                 'Contributor', 'Contributor URI', 'Publisher', 'Publisher URI',
-                'Location', 'Extent', 'Subject', 'Language', 'Rights Holder',
-                'Terms of Use', 'Copyright Notice', 'Collection Information',
-                'Accession Number', 'Handle', 'FILES', 'ITEM_FILES'
+                'Audience', 'Audience URI', 'Location', 'Extent', 'Subject',
+                'Language', 'Rights Holder', 'Terms of Use', 'Copyright Notice',
+                'Collection Information', 'Accession Number', 'Handle', 'FILES',
+                'ITEM_FILES'
             ]
         ),
         (

--- a/plastron-models/src/plastron/models/umd.py
+++ b/plastron-models/src/plastron/models/umd.py
@@ -49,6 +49,7 @@ class Item(ContentModeledResource, PCDMObject, HandleBearingResource, FedoraReso
     creator = ObjectProperty(dcterms.creator, repeatable=True, embed=True, cls=Agent)
     contributor = ObjectProperty(dcterms.contributor, repeatable=True, embed=True, cls=Agent)
     publisher = ObjectProperty(dcterms.publisher, repeatable=True, embed=True, cls=Agent)
+    audience = ObjectProperty(dcterms.audience, repeatable=True, embed=True, cls=Agent)
     location = ObjectProperty(dcterms.spatial, repeatable=True, embed=True, cls=Place)
     extent = DataProperty(dcterms.extent, repeatable=True)
     subject = ObjectProperty(dcterms.subject, repeatable=True, embed=True, cls=Subject)
@@ -81,6 +82,10 @@ class Item(ContentModeledResource, PCDMObject, HandleBearingResource, FedoraReso
         'publisher': {
             'label': 'Publisher',
             'same_as': 'Publisher URI',
+        },
+        'audience': {
+            'label': 'Audience',
+            'same_as': 'Audience URI',
         },
         'location': {
             'label': 'Location',

--- a/plastron-models/tests/test_umd_model.py
+++ b/plastron-models/tests/test_umd_model.py
@@ -1,7 +1,9 @@
 from rdflib import Graph, Literal, URIRef
 
+from plastron.models.authorities import Agent
 from plastron.models.umd import Item
-from plastron.namespaces import dcterms, umdtype
+from plastron.namespaces import dcterms, umdtype, rdfs
+from plastron.rdfmapping.embed import embedded
 
 
 def test_identifier_distinct_from_accession_number():
@@ -35,3 +37,13 @@ def test_item_valid_with_only_required_fields():
     item.rights = 'http://vocab.lib.umd.edu/rightsStatement#InC-EDU'
     item.title = 'Test Item'
     assert item.is_valid
+
+
+def test_audience_property():
+    item = Item(uri=URIRef('http://example.com/foo'), audience=embedded(Agent)(label=Literal('John Doe')))
+
+    audience_triples = list(item.graph.triples((URIRef('http://example.com/foo'), dcterms.audience, None)))
+    assert len(audience_triples) == 1
+    embedded_subject = audience_triples[0][2]
+    label_triples = list(item.graph.triples((embedded_subject, rdfs.label, Literal('John Doe'))))
+    assert len(label_triples) == 1


### PR DESCRIPTION
- object property, embedded, repeatable, not required
- predicate is `dcterms:audience`
- object class is `Agent`

https://umd-dit.atlassian.net/browse/LIBFCREPO-1622