### PR TITLE
LIBFCREPO-1763. Ensure correct serialization of all embedded objects.

### DIFF
--- a/plastron-cli/src/plastron/cli/commands/__init__.py
+++ b/plastron-cli/src/plastron/cli/commands/__init__.py
@@ -16,12 +16,12 @@ class BaseCommand:
             name = 'import'
         return self.context.config.get('COMMANDS', {}).get(name.upper(), {})
 
-    def _run(self, command: Generator):
+    def _run(self, command: Generator[dict[str, Any], None, dict[str, Any]]):
         # delegating generator; each progress step is passed to the calling
         # method, and the return value from the command is stored as the result
         self.result = yield from command
 
-    def run(self, command: Generator):
+    def run(self, command: Generator[Any, None, dict[str, Any]]) -> dict[str, Any]:
         # Run the delegating generator to exhaustion, discarding the intermediate
         # yielded values. Return the final result.
         for _ in self._run(command):

--- a/plastron-cli/src/plastron/cli/commands/importcommand.py
+++ b/plastron-cli/src/plastron/cli/commands/importcommand.py
@@ -166,7 +166,6 @@ def configure_cli(subparsers):
         help=(
             'method for grouping related files into file groups; '
             '"rootname" (default) groups files by shared base name, '
-            '"label" groups files by assigned label, '
             '"none" treats each file as a separate group'
         ),
         choices=['rootname', 'none'],

--- a/plastron-jobs/src/plastron/jobs/importjob/spreadsheet.py
+++ b/plastron-jobs/src/plastron/jobs/importjob/spreadsheet.py
@@ -200,7 +200,6 @@ def build_file_groups(filenames_string: str, grouping_strategy: str = 'rootname'
         for idx, filename in enumerate(filenames_string.split(';'), 1):
             filename, label = parse_label(filename)
             filename, usage = parse_usage_tag(filename)
-            root, ext = splitext(basename(filename))
             # Use the full filename as the key to ensure uniqueness
             group_key = filename
             file_groups[group_key] = FileGroup(

--- a/plastron-models/docs/CSVSerializer.md
+++ b/plastron-models/docs/CSVSerializer.md
@@ -1,6 +1,4 @@
-# Serializers
-
-## CSV Serializer
+# CSV Serializer
 
 The mapping from RDF description objects to tabular (e.g., CSV) data is 
 defined by a *header map*:
@@ -93,3 +91,62 @@ We expect this CSV serialization:
 Title,Identifier,Author Name,Author Website,URI,INDEX
 Good Omens,0060853980|978-0060853983,Neil Gaiman;Terry Pratchett,https://neilgaiman.com;https://terrypratchett.com,http://example.com/item,creator[0]=#gaiman;creator[1]=#pratchett
 ```
+
+## Multiple Values
+
+Multiple values for the same non-embedded field are separated by a pipe 
+character ("|"). Values for different embedded objects of the same field 
+(e.g., multiple authors) are separated by a semicolon (";").
+
+These can be mixed, if there are multiple embedded objects and at least 
+one has multiple values for the same field.
+
+## Multiple Languages
+
+The deserializer supports two formats for specifying a language tag for 
+certain values:
+
+1. [Language-specific columns](#language-specific-columns)
+2. [Value-level language tags](#value-level-language-tags)
+
+The serializer, however, only supports writing value-level language tags, 
+in order to ensure export-to-import round trip capability.
+
+### Language-specific columns
+
+The language code is appended to the column header like this:
+
+```
+Title [de]
+```
+
+Only values with that language tag appear in that column. This can lead to 
+a variable number of columns for each field, depending on the number of 
+distinct language tags for that field's values.
+
+This format is only supported by the `import` command; the `export` 
+command always uses the value-level langauge tags.
+
+### Value-level language tags
+
+The language code is prepended to the actual data value like this:
+
+```
+[@de]Der Prozeß
+```
+
+This format allow mixing of languages in a single column:
+
+```
+[@de]Der Prozeß|[@en]The Trial
+```
+
+And you can combine tagged and untagged values:
+
+```
+The Trial|[@de]Der Prozeß
+```
+
+This format is closer to the RDF data model, where the language is an 
+attribute of the value, and thus provides a more direct representation of 
+the underlying data structure.

--- a/plastron-models/src/plastron/serializers/__init__.py
+++ b/plastron-models/src/plastron/serializers/__init__.py
@@ -1,12 +1,14 @@
-""".. include:: ../../../docs/serializers.md"""
+""".. include:: ../../../docs/CSVSerializer.md"""
 import logging
 
-from rdflib import URIRef
+from rdflib import URIRef, Graph
 
+from plastron.models import ContentModeledResource
 from plastron.models.letter import Letter
 from plastron.models.newspaper import Issue
 from plastron.models.poster import Poster
-from plastron.namespaces import bibo, rdf
+from plastron.models.umd import Item
+from plastron.namespaces import bibo, rdf, umd
 from plastron.serializers.csv import CSVSerializer
 from plastron.serializers.turtle import TurtleSerializer
 
@@ -21,13 +23,19 @@ SERIALIZER_CLASSES = {
 }
 
 MODEL_MAP = {
+    umd.Issue: Issue,
+    umd.Item: Item,
     bibo.Image: Poster,
     bibo.Issue: Issue,
     bibo.Letter: Letter
 }
 
 
-def detect_resource_class(graph, subject, fallback=None):
+def detect_resource_class(
+    graph: Graph,
+    subject: str | URIRef,
+    fallback: type[ContentModeledResource] = None,
+) -> type[ContentModeledResource]:
     types = set(graph.objects(URIRef(subject), rdf.type))
 
     for rdf_type, cls in MODEL_MAP.items():

--- a/plastron-models/src/plastron/serializers/csv.py
+++ b/plastron-models/src/plastron/serializers/csv.py
@@ -1,10 +1,11 @@
 import csv
 import re
 from collections import defaultdict
+from collections.abc import Iterable, Mapping
 from contextlib import contextmanager
 from itertools import zip_longest
 from pathlib import Path
-from typing import Iterable, Mapping, NamedTuple, TextIO, Type, TypeVar
+from typing import TextIO, TypeVar, IO, NamedTuple
 
 from rdflib import Literal, URIRef
 from urlobject import URLObject
@@ -19,7 +20,7 @@ from plastron.rdfmapping.properties import RDFDataProperty, RDFObjectProperty
 from plastron.rdfmapping.resources import RDFResource, RDFResourceBase
 
 
-def not_empty(value):
+def not_empty(value: str) -> bool:
     """Returns true if `value` is not `None` and is not the empty string."""
     return value is not None and value != ''
 
@@ -166,6 +167,26 @@ class ColumnsDict(dict):
         self.index = []
 
 
+def language_tagged_str(literal: Literal) -> str:
+    """If `literal` has a language tag, return a string in the format
+    `"[@lang]value"`. If `literal` has no language tag, just return its
+    value.
+
+    ```pycon
+    >>> language_tagged_str(Literal('Book'))
+    'Book'
+
+    >>> language_tagged_str(Literal('das Buch', lang='de'))
+    '[@de]das Buch'
+
+    ```
+    """
+    if literal.language:
+        return f'[@{literal.language}]{literal.value}'
+    else:
+        return literal.value
+
+
 def flatten(
     description: RDFResourceBase,
     header_map: dict[str, str | dict],
@@ -183,25 +204,30 @@ def flatten(
                 # add this embedded object to the index for this row
                 columns.index.append([f'{attr}[{n}]=#{URLObject(obj.uri).fragment}'])
                 embedded_columns = flatten(obj, header)
-                columns.update(embedded_columns)
+                for k, v in embedded_columns.items():
+                    if k not in columns:
+                        columns[k] = []
+                    # the values list for each separate embedded object must
+                    # be added as a list to the main column (forming a list
+                    # of lists) so the join_values() function knows to use the
+                    # proper ";" separator between parallel objects
+                    columns[k].append(v)
         else:
-            if description is not None:
-                prop = getattr(description, attr)
-                if isinstance(prop, RDFDataProperty):
-                    # handle language tags on literals
-                    languages = list(prop.languages)
-                    if languages:
-                        for language in languages:
-                            columns[ColumnHeader(label=header, language=language)] = [
-                                v for v in prop.values if v.language == language
-                            ]
-                    else:
-                        columns[ColumnHeader(label=header)] = []
-                else:
-                    columns[ColumnHeader(label=header)] = list(prop.values)
-            else:
-                columns[ColumnHeader(label=header)] = []
+            columns[ColumnHeader(label=header)] = flatten_basic_property(description, attr)
+
     return columns
+
+
+def flatten_basic_property(description: RDFResourceBase, attr: str) -> list[str]:
+    if description is None:
+        return []
+
+    prop = getattr(description, attr)
+    if isinstance(prop, RDFDataProperty):
+        # handle language tags on literals
+        return [language_tagged_str(v) for v in prop.values]
+    else:
+        return [str(v) for v in prop.values]
 
 
 def get_column_headers(headers: Iterable[str], base_header: str) -> list[ColumnHeader]:
@@ -264,10 +290,10 @@ def get_embedded_params(row: Mapping[str, str], header_labels: Iterable[str]) ->
 
 
 def unflatten(
-        row_data: Mapping[str, str],
-        resource_class: Type[RDFResourceBase],
-        header_map: Mapping[str, str | dict],
-        index: Mapping[str, Mapping[int, str]] = None,
+    row_data: Mapping[str, str],
+    resource_class: type[RDFResourceBase],
+    header_map: Mapping[str, str | dict],
+    index: Mapping[str, Mapping[int, str]] = None,
 ) -> dict[str, list[Literal | URIRef | EmbeddedObject]]:
     """Transform a mapping of column headers to values (such as would be returned by a
     `csv.DictReader`) into a dictionary of parameters that can be passed to the constructor
@@ -326,7 +352,7 @@ def get_literal(column_header: ColumnHeader, descriptor: DataProperty, input_val
 
 
 @contextmanager
-def ensure_text_mode(file):
+def ensure_text_mode(file: IO):
     if 'b' in file.mode:
         # re-open in text mode
         fh = open(file.fileno(), mode=file.mode.replace('b', ''), closefd=False)
@@ -338,7 +364,7 @@ def ensure_text_mode(file):
 
 
 @contextmanager
-def ensure_binary_mode(file):
+def ensure_binary_mode(file: IO):
     if 'b' not in file.mode:
         # re-open in binary mode
         fh = open(file.fileno(), mode=file.mode + 'b', closefd=False)
@@ -350,14 +376,14 @@ def ensure_binary_mode(file):
 
 
 class Sheet:
-    def __init__(self, model: Type[ContentModeledResource]):
+    def __init__(self, model: type[ContentModeledResource]):
         self.model_class = model
         self.headers = list(flatten_headers(self.header_map).keys()) + CSVSerializer.SYSTEM_HEADERS
         self.extra_headers = defaultdict(set)
         self.rows = []
 
     @property
-    def header_map(self):
+    def header_map(self) -> dict[str, str | dict[str, str]]:
         return self.model_class.HEADER_MAP
 
     def write_csv_file(self, file: TextIO):
@@ -405,11 +431,11 @@ class CSVSerializer:
         self.finish()
 
     def write(
-            self,
-            resource: T,
-            files: Iterable[FileSpec] = None,
-            item_files: Iterable[FileSpec] = None,
-            public_url: str = None,
+        self,
+        resource: T,
+        files: Iterable[FileSpec] = None,
+        item_files: Iterable[FileSpec] = None,
+        public_url: str = None,
     ) -> dict[str, str]:
         """
         Serializes the given resource as a CSV row using the `flatten()` function. The resulting row is

--- a/plastron-models/tests/serializers/test_csv.py
+++ b/plastron-models/tests/serializers/test_csv.py
@@ -1,13 +1,16 @@
 import pytest
-from rdflib import URIRef
+from rdflib import URIRef, Literal
 
 from plastron.models import ContentModeledResource
+from plastron.models.authorities import Place
 from plastron.models.umd import Item
 from plastron.namespaces import umdaccess, dcterms, dcmitype
 from plastron.rdfmapping.decorators import rdf_type
 from plastron.rdfmapping.descriptors import DataProperty
+from plastron.rdfmapping.embed import embedded, EmbeddedObject
 from plastron.rdfmapping.resources import RDFResource
 from plastron.serializers import CSVSerializer
+from plastron.serializers.csv import unflatten
 
 
 @pytest.mark.parametrize(
@@ -47,7 +50,7 @@ def test_write(resource, expected_values):
 def test_serialize_multiple_languages(multilingual_item, header_map):
     serializer = CSVSerializer()
     row = serializer.write(multilingual_item)
-    expected_values = {'Title': 'The Trial', 'Title [de]': 'Der Prozeß'}
+    expected_values = {'Title': 'The Trial|[@de]Der Prozeß'}
     for key, value in expected_values.items():
         assert row[key] == value
 
@@ -68,3 +71,58 @@ def test_serialize_all_columns():
     obj = SimpleModel()
     row = serializer.write(obj)
     assert len(row) == len(SimpleModel.HEADER_MAP) + len(CSVSerializer.SYSTEM_HEADERS)
+
+
+def test_round_trip_serialization():
+    item = Item()
+    item.location.add(embedded(Place)(label=Literal('Baltimore')))
+    item.location.add(embedded(Place)(label=Literal('Washington')))
+    assert len(item.location) == 2
+
+    serializer = CSVSerializer()
+    row = serializer.write(item)
+    assert row['Location'] == 'Baltimore;Washington'
+
+    new_item_params = unflatten(row, Item, Item.HEADER_MAP)
+    locations = new_item_params['location']
+    assert len(locations) == 2
+    assert isinstance(locations[0], EmbeddedObject)
+    assert locations[0].cls is Place
+    assert locations[0].kwargs == {'label': [Literal('Baltimore')]}
+    assert isinstance(locations[1], EmbeddedObject)
+    assert locations[1].cls is Place
+    assert locations[1].kwargs == {'label': [Literal('Washington')]}
+
+
+def test_multilanguage_round_trip_one_object():
+    item = Item()
+    item.location.add(embedded(Place)(label=[Literal('Germany'), Literal('Deutschland', lang='de')]))
+    assert len(item.location) == 1
+    serializer = CSVSerializer()
+    row = serializer.write(item)
+    assert row['Location'] == 'Germany|[@de]Deutschland'
+    new_item_params = unflatten(row, Item, Item.HEADER_MAP)
+    locations = new_item_params['location']
+    assert len(locations) == 1
+    assert isinstance(locations[0], EmbeddedObject)
+    assert locations[0].cls is Place
+    assert locations[0].kwargs == {'label': [Literal('Germany'), Literal('Deutschland', lang='de')]}
+
+
+def test_multilanguage_round_trip_two_objects():
+    item = Item()
+    item.location.add(embedded(Place)(label=Literal('France')))
+    item.location.add(embedded(Place)(label=Literal('Deutschland', lang='de')))
+    assert len(item.location) == 2
+    serializer = CSVSerializer()
+    row = serializer.write(item)
+    assert row['Location'] == 'France;[@de]Deutschland'
+    new_item_params = unflatten(row, Item, Item.HEADER_MAP)
+    locations = new_item_params['location']
+    assert len(locations) == 2
+    assert isinstance(locations[0], EmbeddedObject)
+    assert locations[0].cls is Place
+    assert locations[0].kwargs == {'label': [Literal('France')]}
+    assert isinstance(locations[1], EmbeddedObject)
+    assert locations[1].cls is Place
+    assert locations[1].kwargs == {'label': [Literal('Deutschland', lang='de')]}

--- a/plastron-models/tests/serializers/test_csv_functions.py
+++ b/plastron-models/tests/serializers/test_csv_functions.py
@@ -6,7 +6,20 @@ from plastron.rdfmapping.descriptors import DataProperty, ObjectProperty
 from plastron.rdfmapping.embed import EmbeddedObject
 from plastron.rdfmapping.resources import RDFResource
 from plastron.serializers.csv import join_values, flatten_headers, unflatten, flatten, ensure_text_mode, \
-    ensure_binary_mode, ColumnHeader
+    ensure_binary_mode, ColumnHeader, not_empty
+
+
+@pytest.mark.parametrize(
+    ('value', 'expected'),
+    [
+        (None, False),
+        ('', False),
+        (' ', True),
+        ('foo', True),
+    ]
+)
+def test_not_empty(value, expected):
+    assert not_empty(value) == expected
 
 
 class Subject(RDFResource):
@@ -49,8 +62,7 @@ def test_flatten_headers(header_map):
 
 def test_flatten_multiple_languages(multilingual_item, header_map):
     expected_values = {
-        ColumnHeader(label='Title'): [Literal('The Trial')],
-        ColumnHeader(label='Title', language='de'): [Literal('Der Prozeß', lang='de')],
+        ColumnHeader(label='Title'): ['The Trial', '[@de]Der Prozeß'],
     }
     columns = flatten(multilingual_item, header_map)
     for key, value in expected_values.items():

--- a/plastron-models/tests/serializers/test_detect_resource_class.py
+++ b/plastron-models/tests/serializers/test_detect_resource_class.py
@@ -1,0 +1,40 @@
+import pytest
+from rdflib import Graph, URIRef
+
+from plastron.models.letter import Letter
+from plastron.models.newspaper import Issue
+from plastron.models.poster import Poster
+from plastron.models.umd import Item
+from plastron.namespaces import bibo, rdf, umd
+from plastron.serializers import detect_resource_class
+
+
+@pytest.mark.parametrize(
+    ('rdf_types', 'expected_class'),
+    [
+        ([umd.Item], Item),
+        ([umd.Item, bibo.Letter], Item),
+        ([umd.Item, bibo.Poster], Item),
+        ([umd.Issue, bibo.Issue], Issue),
+        ([bibo.Letter], Letter),
+        ([bibo.Issue], Issue),
+        ([bibo.Image], Poster),
+    ]
+)
+def test_detect_resource_class(rdf_types, expected_class):
+    graph = Graph()
+    for rdf_type in rdf_types:
+        graph.add((URIRef(''), rdf.type, rdf_type))
+
+    assert detect_resource_class(graph, URIRef('')) is expected_class
+
+
+def test_detect_resource_class_fallback():
+    graph = Graph()
+    assert detect_resource_class(graph, URIRef(''), fallback=Item) is Item
+
+
+def test_detect_resource_class_no_fallback():
+    graph = Graph()
+    with pytest.raises(RuntimeError):
+        detect_resource_class(graph, URIRef(''))


### PR DESCRIPTION
- make sure that the embedded object columns are created as a list of lists, so the values are separated by a ";" (meaning different objects) instead of "|" (meaning multiple values on the same object)
- serialize using the tagged value format, since this allows for accurate round-tripping vs the column header tagging, with a slight reduction in human-readability
- added test to round-trip serialize an object
- updated the `MODEL__MAP` for `detect_resource_class`
- added tests for the `detect_resource_class` function
- added additional type hints
- fixed up some documentation and typing for the import command

https://umd-dit.atlassian.net/browse/LIBFCREPO-1763