### PR TITLE
LIBFCREPO-1823: Cast Literal as string instead of returning value

### DIFF
--- a/plastron-models/src/plastron/serializers/csv.py
+++ b/plastron-models/src/plastron/serializers/csv.py
@@ -5,19 +5,19 @@ from collections.abc import Iterable, Mapping
 from contextlib import contextmanager
 from itertools import zip_longest
 from pathlib import Path
-from typing import TextIO, TypeVar, IO, NamedTuple
-
-from rdflib import Literal, URIRef
-from urlobject import URLObject
+from typing import IO, NamedTuple, TextIO, TypeVar
 
 from plastron.files import FileSpec
-from plastron.models import ContentModeledResource
 from plastron.models.fedora import FedoraResource
-from plastron.namespaces import umdaccess
 from plastron.rdfmapping.descriptors import DataProperty, ObjectProperty
 from plastron.rdfmapping.embed import EmbeddedObject
 from plastron.rdfmapping.properties import RDFDataProperty, RDFObjectProperty
 from plastron.rdfmapping.resources import RDFResource, RDFResourceBase
+from rdflib import Literal, URIRef
+from urlobject import URLObject
+
+from plastron.models import ContentModeledResource
+from plastron.namespaces import umdaccess
 
 
 def not_empty(value: str) -> bool:
@@ -182,9 +182,11 @@ def language_tagged_str(literal: Literal) -> str:
     ```
     """
     if literal.language:
-        return f'[@{literal.language}]{literal.value}'
+        # return f'[@{literal.language}]{literal.value}'
+        return f'[@{literal.language}]{str(literal)}'
     else:
-        return literal.value
+        # return literal.value
+        return str(literal)
 
 
 def flatten(

--- a/plastron-models/src/plastron/serializers/csv.py
+++ b/plastron-models/src/plastron/serializers/csv.py
@@ -182,10 +182,8 @@ def language_tagged_str(literal: Literal) -> str:
     ```
     """
     if literal.language:
-        # return f'[@{literal.language}]{literal.value}'
-        return f'[@{literal.language}]{str(literal)}'
+        return f'[@{literal.language}]{literal}'
     else:
-        # return literal.value
         return str(literal)
 
 

--- a/plastron-models/tests/serializers/test_csv_functions.py
+++ b/plastron-models/tests/serializers/test_csv_functions.py
@@ -1,12 +1,22 @@
 import pytest
-from rdflib import Literal, URIRef
-
-from plastron.namespaces import rdfs, owl, dcterms
+from plastron.models.umd import Item
 from plastron.rdfmapping.descriptors import DataProperty, ObjectProperty
 from plastron.rdfmapping.embed import EmbeddedObject
 from plastron.rdfmapping.resources import RDFResource
-from plastron.serializers.csv import join_values, flatten_headers, unflatten, flatten, ensure_text_mode, \
-    ensure_binary_mode, ColumnHeader, not_empty
+from plastron.serializers.csv import (
+    ColumnHeader,
+    ensure_binary_mode,
+    ensure_text_mode,
+    flatten,
+    flatten_basic_property,
+    flatten_headers,
+    join_values,
+    not_empty,
+    unflatten,
+)
+from rdflib import Literal, URIRef
+
+from plastron.namespaces import dcterms, owl, rdfs, umdtype
 
 
 @pytest.mark.parametrize(
@@ -67,6 +77,18 @@ def test_flatten_multiple_languages(multilingual_item, header_map):
     columns = flatten(multilingual_item, header_map)
     for key, value in expected_values.items():
         assert columns[key] == value
+
+def test_flatten_handle_property():
+    """Test that handle properties serialize correctly."""
+    item = Item(handle=Literal('hdl:1903.1/1234', datatype=umdtype.handle))
+    result = flatten_basic_property(item, 'handle')
+    assert result == ['hdl:1903.1/1234']
+
+def test_flatten_accession_number_property():
+    """Test that accession_number properties serialize correctly."""
+    item = Item(accession_number=Literal('2008-51', datatype=umdtype.accessionNumber))
+    result = flatten_basic_property(item, 'accession_number')
+    assert result == ['2008-51']
 
 
 def test_unflatten(header_map):


### PR DESCRIPTION
Since these are custom datatypes, the value method in the Literal class will not work to return the actual value, so we must cast it as a string instead.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1823